### PR TITLE
Add Docker Compose with MySQL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+*.log
+.env
+.env.local
+.env*.local

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,19 @@
-# create local copy of this file and rename to .env.local
-# make sure to add .env.local to .gitignore!!
-MONGO_URI={mongo-uri-here}
+# Database (Docker MySQL)
+DATABASE_URL="mysql://prfc_user:prfc_password@localhost:3306/prfc_portal"
+
+# Docker MySQL Configuration
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=prfc_portal
+MYSQL_USER=prfc_user
+MYSQL_PASSWORD=prfc_password
+
+# SMTP Configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your-email@example.com
+SMTP_PASS=your-password
+FROM_EMAIL=noreply@example.com
+
+# Admin Access
+DATABASE_PASSWORD=your-admin-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 
 volumes:
   mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: prfc-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-prfc_portal}
+      MYSQL_USER: ${MYSQL_USER:-prfc_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-prfc_password}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+  adminer:
+    image: adminer:latest
+    container_name: prfc-adminer
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+
+volumes:
+  mysql_data:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "test": "echo 'Install jest (or another unit test suite) to use this command.'",
-    "prepare": "husky"
+    "prepare": "husky",
+    "docker:up": "docker-compose up -d",
+    "docker:down": "docker-compose down",
+    "docker:logs": "docker-compose logs -f",
+    "docker:reset": "docker-compose down -v && docker-compose up -d"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Sets up a local MySQL database using Docker Compose. Includes Adminer on port 8080 fordatabase management.

Added npm scripts: `docker:up`, `docker:down`, `docker:logs`, `docker:reset`.

Also replaced the old MongoDB placeholder in `.env.local.example` with the MySQL connection string and SMTP config we'll need later.