### PR TITLE
Add Zod schema layer for referral validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.4.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.1.13"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -8187,7 +8188,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.4.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,1 @@
+export * from "./referral";

--- a/src/schema/referral.ts
+++ b/src/schema/referral.ts
@@ -3,11 +3,11 @@ import { z } from "zod";
 export const ReferralSchema = z.object({
   id: z.number().int().positive(),
   createdAt: z.date(),
-  memberName: z.string().min(1),
-  memberEmail: z.string().email(),
-  prospectName: z.string().min(1),
-  prospectEmail: z.string().email(),
-  referralCode: z.string().min(1),
+  memberName: z.string().min(1).max(255),
+  memberEmail: z.string().email().max(255),
+  prospectName: z.string().min(1).max(255),
+  prospectEmail: z.string().email().max(255),
+  referralCode: z.string().min(1).max(100),
   redeemed: z.boolean(),
 });
 
@@ -19,14 +19,14 @@ export const CreateReferralSchema = ReferralSchema.omit({
 });
 
 export const ProspectSchema = z.object({
-  prospectName: z.string().min(1),
-  prospectEmail: z.string().email(),
+  prospectName: z.string().min(1).max(255),
+  prospectEmail: z.string().email().max(255),
 });
 
 export const ReferralFormSchema = z.object({
-  memberName: z.string().min(1),
-  memberEmail: z.string().email(),
-  referralCode: z.string().min(1),
+  memberName: z.string().min(1).max(255),
+  memberEmail: z.string().email().max(255),
+  referralCode: z.string().min(1).max(100),
   prospects: z.array(ProspectSchema).min(1).max(5),
 });
 
@@ -35,9 +35,9 @@ export const UpdateRedeemedSchema = z.object({
 });
 
 export const ChecksumSchema = z.object({
-  nm: z.string().min(1),
-  em: z.string().email(),
-  ref: z.string().min(1),
+  nm: z.string().min(1).max(255),
+  em: z.string().email().max(255),
+  ref: z.string().min(1).max(100),
   cs: z.string().min(1),
 });
 

--- a/src/schema/referral.ts
+++ b/src/schema/referral.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+export const ReferralSchema = z.object({
+  id: z.number().int().positive(),
+  createdAt: z.date(),
+  memberName: z.string().min(1),
+  memberEmail: z.string().email(),
+  prospectName: z.string().min(1),
+  prospectEmail: z.string().email(),
+  referralCode: z.string().min(1),
+  redeemed: z.boolean(),
+});
+
+export const CreateReferralSchema = ReferralSchema.omit({
+  id: true,
+  createdAt: true,
+}).extend({
+  redeemed: z.boolean().default(false),
+});
+
+export const ProspectSchema = z.object({
+  prospectName: z.string().min(1),
+  prospectEmail: z.string().email(),
+});
+
+export const ReferralFormSchema = z.object({
+  memberName: z.string().min(1),
+  memberEmail: z.string().email(),
+  referralCode: z.string().min(1),
+  prospects: z.array(ProspectSchema).min(1).max(5),
+});
+
+export const UpdateRedeemedSchema = z.object({
+  redeemed: z.boolean(),
+});
+
+export const ChecksumSchema = z.object({
+  nm: z.string().min(1),
+  em: z.string().email(),
+  ref: z.string().min(1),
+  cs: z.string().min(1),
+});
+
+export type Referral = z.infer<typeof ReferralSchema>;
+export type CreateReferral = z.infer<typeof CreateReferralSchema>;
+export type Prospect = z.infer<typeof ProspectSchema>;
+export type ReferralForm = z.infer<typeof ReferralFormSchema>;
+export type UpdateRedeemed = z.infer<typeof UpdateRedeemedSchema>;
+export type ChecksumInput = z.infer<typeof ChecksumSchema>;


### PR DESCRIPTION
Adds Zod schemas for runtime validation. These serve as the single source of truth for types.

**Schemas created:**
- `ReferralSchema` / `CreateReferralSchema`
- `ProspectSchema` / `ReferralFormSchema`
- `UpdateRedeemedSchema` / `ChecksumSchema`

Types are inferred from schemas, so no duplication between validation and type definitions.

Using Zod 4.1.13 (came in with shadcn/ui). API is compatible with future development.
