### PR TITLE
Create API routes for referral system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: "mysql://ci:ci@localhost:3306/ci"
 
       - name: Run tests
         run: npm test

--- a/src/app/api/checksum/route.ts
+++ b/src/app/api/checksum/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ChecksumSchema } from "@/schema/referral";
+import { calculateChecksum } from "@/utils/checksum";
+import { AppError, apiErrorHandler } from "@/utils/errors";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { nm, em, ref, cs } = ChecksumSchema.parse(body);
+
+    const cleanedName = nm.replace(/\s+/g, "");
+    const generatedChecksum = calculateChecksum(`${em}${cleanedName}${ref}`);
+
+    if (generatedChecksum !== cs) {
+      throw new AppError("VALIDATION_ERROR", "Checksum mismatch");
+    }
+
+    return NextResponse.json({ message: "Checksum validated successfully." }, { status: 200 });
+  } catch (error) {
+    return apiErrorHandler(error);
+  }
+}

--- a/src/app/api/referral/[id]/route.ts
+++ b/src/app/api/referral/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { toggleReferralRedeemed } from "@/services/referral-store";
+import { AppError, apiErrorHandler } from "@/utils/errors";
+
+export async function PUT(req: NextRequest, context: { params: Promise<{ id?: string }> }) {
+  try {
+    const resolvedParams = await context.params;
+    if (!resolvedParams?.id) {
+      throw new AppError("VALIDATION_ERROR", "Invalid referral ID");
+    }
+
+    const referralId = parseInt(resolvedParams.id, 10);
+    if (isNaN(referralId)) {
+      throw new AppError("VALIDATION_ERROR", "Invalid referral ID");
+    }
+
+    const updatedReferral = await toggleReferralRedeemed(referralId);
+
+    return NextResponse.json({ message: "Referral updated successfully!", referral: updatedReferral }, { status: 200 });
+  } catch (error) {
+    return apiErrorHandler(error);
+  }
+}

--- a/src/app/api/referral/route.ts
+++ b/src/app/api/referral/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ReferralFormSchema } from "@/schema/referral";
+import { createManyReferrals, getAllReferrals } from "@/services/referral-store";
+import { sendReferralEmails } from "@/services/email-service";
+import { apiErrorHandler } from "@/utils/errors";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { memberName, memberEmail, referralCode, prospects } = ReferralFormSchema.parse(body);
+
+    await sendReferralEmails({ prospects, referralCode, memberName });
+
+    const referrals = prospects.map((prospect) => ({
+      memberName,
+      memberEmail,
+      prospectName: prospect.prospectName,
+      prospectEmail: prospect.prospectEmail,
+      referralCode,
+      redeemed: false,
+    }));
+
+    const newReferrals = await createManyReferrals(referrals);
+
+    return NextResponse.json({ message: "Referrals created successfully!", referrals: newReferrals }, { status: 201 });
+  } catch (error) {
+    return apiErrorHandler(error);
+  }
+}
+
+export async function GET() {
+  try {
+    const referrals = await getAllReferrals();
+    return NextResponse.json(referrals, { status: 200 });
+  } catch (error) {
+    return apiErrorHandler(error);
+  }
+}


### PR DESCRIPTION
Adds API routes for the referral system.

`POST /api/referral` validates the form submission with Zod, sends emails to prospects, then creates referral records in the database. `GET /api/referral` returns all referrals for the admin dashboard.

`PUT /api/referral/[id]` toggles the redeemed status for a referral.

`POST /api/checksum` validates the URL parameters that authenticate form submissions. This prevents users from forging referral links.

Second commit switches CI to use a placeholder DATABASE_URL during build. Next.js imports all route handlers at build time for static analysis, which triggered the DATABASE_URL check even though no actual database connection happens until runtime.

This should follow exactly what the original repository intends.

