### PR TITLE
Add referral data grid with TanStack Table

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,13 @@ export default [
       ...pluginReactHooks.configs.recommended.rules,
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
     },
   },
   eslintConfigPrettier,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,11 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jspdf": "^3.0.4",
+        "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.555.0",
         "next": "^15.5.6",
         "nodemailer": "^7.0.11",
@@ -26,6 +29,7 @@
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2",
         "zod": "^4.1.13"
       },
       "devDependencies": {
@@ -1000,6 +1004,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3825,6 +3838,39 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3884,6 +3930,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
@@ -3903,6 +3962,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.0",
@@ -4850,6 +4916,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
@@ -5067,6 +5143,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5253,6 +5349,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5266,6 +5374,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -5481,6 +5599,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -6311,6 +6439,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -6338,6 +6477,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -6859,6 +7004,20 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
@@ -6960,6 +7119,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -7524,6 +7689,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
+      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+      "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8447,6 +8638,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8499,6 +8696,13 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8879,6 +9083,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/rc9": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -9033,6 +9247,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp-to-ast": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
@@ -9170,6 +9391,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -9552,6 +9783,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -9865,6 +10106,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -10004,6 +10255,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -10438,6 +10699,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/valibot": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
@@ -10451,6 +10722,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-toast": "^1.2.15",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3014,6 +3015,40 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-toast": "^1.2.15",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jspdf": "^3.0.4",
+    "jspdf-autotable": "^5.0.2",
     "lucide-react": "^0.555.0",
     "next": "^15.5.6",
     "nodemailer": "^7.0.11",
@@ -40,6 +43,7 @@
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.2",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,7 +10,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/src/components/referral/referral-data-grid.tsx
+++ b/src/components/referral/referral-data-grid.tsx
@@ -1,0 +1,820 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  flexRender,
+  type ColumnDef,
+  type SortingState,
+  type ColumnFiltersState,
+  type VisibilityState,
+} from "@tanstack/react-table";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { cn } from "@/lib/utils";
+import { SlidersHorizontal } from "lucide-react";
+import jsPDF from "jspdf";
+import autoTable from "jspdf-autotable";
+import type { Referral } from "@/schema/referral";
+
+type Density = "compact" | "standard" | "comfortable";
+
+const densityClasses: Record<Density, string> = {
+  compact: "h-8 py-1 text-sm",
+  standard: "h-12 py-2",
+  comfortable: "h-16 py-4",
+};
+
+const columnDisplayLabels: Record<string, string> = {
+  select: "Checkbox selection",
+  createdAt: "Date",
+  memberName: "Member Name",
+  memberEmail: "Member Email",
+  prospectName: "Prospect Name",
+  prospectEmail: "Prospect Email",
+  referralCode: "Code",
+  redeemed: "Redeemed",
+};
+
+const filterableColumns = [
+  { id: "createdAt", label: "Date" },
+  { id: "memberName", label: "Member Name" },
+  { id: "memberEmail", label: "Member Email" },
+  { id: "prospectName", label: "Prospect Name" },
+  { id: "prospectEmail", label: "Prospect Email" },
+  { id: "referralCode", label: "Code" },
+];
+
+const filterOperators = [
+  { value: "contains", label: "contains" },
+  { value: "doesNotContain", label: "does not contain" },
+  { value: "equals", label: "equals" },
+  { value: "doesNotEqual", label: "does not equal" },
+  { value: "startsWith", label: "starts with" },
+  { value: "endsWith", label: "ends with" },
+  { value: "isEmpty", label: "is empty" },
+  { value: "isNotEmpty", label: "is not empty" },
+  { value: "isAnyOf", label: "is any of" },
+];
+
+const MOBILE_HIDDEN_COLUMNS = ["createdAt", "memberEmail", "prospectEmail", "referralCode"];
+const STORAGE_KEY = "referral-table-columns";
+
+const getDefaultVisibility = (isMobile: boolean): VisibilityState => {
+  const visibility: VisibilityState = {};
+  MOBILE_HIDDEN_COLUMNS.forEach((col) => {
+    visibility[col] = !isMobile;
+  });
+  return visibility;
+};
+
+interface ReferralDataGridProps {
+  initialIsMobile: boolean;
+}
+
+export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
+  const [referrals, setReferrals] = useState<Referral[]>([]);
+  const [sorting, setSorting] = useState<SortingState>([{ id: "createdAt", desc: true }]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() =>
+    getDefaultVisibility(initialIsMobile),
+  );
+  const [rowSelection, setRowSelection] = useState({});
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [density, setDensity] = useState<Density>("standard");
+
+  const [showFilterPanel, setShowFilterPanel] = useState(false);
+  const [filterColumn, setFilterColumn] = useState("createdAt");
+  const [filterOperator, setFilterOperator] = useState("contains");
+  const [filterValue, setFilterValue] = useState("");
+  const [columnSearch, setColumnSearch] = useState("");
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setColumnVisibility(JSON.parse(stored));
+        return;
+      } catch {
+        // Invalid JSON, use viewport detection below
+      }
+    }
+
+    const actualIsMobile = window.innerWidth < 768;
+    if (actualIsMobile !== initialIsMobile) {
+      setColumnVisibility(getDefaultVisibility(actualIsMobile));
+    }
+  }, [initialIsMobile]);
+
+  const handleColumnVisibilityChange = useCallback(
+    (updater: VisibilityState | ((prev: VisibilityState) => VisibilityState)) => {
+      setColumnVisibility((prev) => {
+        const newState = typeof updater === "function" ? updater(prev) : updater;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+        return newState;
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const fetchReferrals = async () => {
+      try {
+        const response = await fetch("/api/referral");
+        if (!response.ok) throw new Error("Failed to fetch referrals");
+        const data = await response.json();
+        setReferrals(data);
+      } catch (error) {
+        console.error("Error fetching referrals:", error);
+      }
+    };
+    fetchReferrals();
+  }, []);
+
+  const handleToggleRedeemed = useCallback(async (id: number, currentValue: boolean) => {
+    setReferrals((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: !currentValue } : ref)));
+
+    try {
+      const response = await fetch(`/api/referral/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!response.ok) throw new Error("Failed to update referral");
+    } catch (error) {
+      console.error("Error updating referral:", error);
+      setReferrals((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: currentValue } : ref)));
+    }
+  }, []);
+
+  const formatDate = useCallback((date: string | Date) => {
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: true,
+    }).format(new Date(date));
+  }, []);
+
+  const columns: ColumnDef<Referral>[] = useMemo(
+    () => [
+      {
+        id: "select",
+        header: ({ table }) => (
+          <Checkbox
+            checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+            aria-label="Select all rows"
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            aria-label="Select row"
+          />
+        ),
+        enableSorting: false,
+        enableHiding: false,
+      },
+      {
+        accessorKey: "createdAt",
+        header: "Date",
+        cell: ({ row }) => formatDate(row.getValue("createdAt")),
+      },
+      {
+        accessorKey: "memberName",
+        header: "Member Name",
+        enableHiding: false,
+      },
+      {
+        accessorKey: "memberEmail",
+        header: "Member Email",
+      },
+      {
+        accessorKey: "prospectName",
+        header: "Prospect Name",
+        enableHiding: false,
+      },
+      {
+        accessorKey: "prospectEmail",
+        header: "Prospect Email",
+      },
+      {
+        accessorKey: "referralCode",
+        header: "Code",
+      },
+      {
+        accessorKey: "redeemed",
+        header: () => <div className="text-center">Redeemed</div>,
+        enableHiding: false,
+        cell: ({ row }) => (
+          <div className="flex justify-center">
+            <Switch
+              checked={row.getValue("redeemed")}
+              onCheckedChange={() => handleToggleRedeemed(row.original.id, row.getValue("redeemed"))}
+              aria-label="Toggle redeemed status"
+            />
+          </div>
+        ),
+      },
+    ],
+    [formatDate, handleToggleRedeemed],
+  );
+
+  const table = useReactTable({
+    data: referrals,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: handleColumnVisibilityChange,
+    onRowSelectionChange: setRowSelection,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: "includesString",
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+      globalFilter,
+    },
+  });
+
+  const handleClearFilter = useCallback(() => {
+    setFilterValue("");
+    setColumnFilters([]);
+    setShowFilterPanel(false);
+  }, []);
+
+  const handleShowHideAll = useCallback(
+    (show: boolean) => {
+      table.getAllColumns().forEach((column) => {
+        if (column.getCanHide()) {
+          column.toggleVisibility(show);
+        }
+      });
+    },
+    [table],
+  );
+
+  const handleReset = useCallback(() => {
+    handleShowHideAll(true);
+    setColumnSearch("");
+  }, [handleShowHideAll]);
+
+  const handleResetToDefaults = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    const isMobile = window.innerWidth < 768;
+    setColumnVisibility(getDefaultVisibility(isMobile));
+  }, []);
+
+  const allColumnsVisible = table
+    .getAllColumns()
+    .filter((c) => c.getCanHide())
+    .every((c) => c.getIsVisible());
+
+  const hiddenColumnCount = table.getAllColumns().filter((c) => c.getCanHide() && !c.getIsVisible()).length;
+
+  const isFiltered = columnFilters.length > 0;
+
+  const exportToPDF = useCallback(() => {
+    const doc = new jsPDF();
+    const tableColumns = ["Date", "Member Name", "Member Email", "Prospect Name", "Prospect Email", "Code", "Redeemed"];
+    const tableRows = table
+      .getFilteredRowModel()
+      .rows.map((row) => [
+        formatDate(row.original.createdAt),
+        row.original.memberName,
+        row.original.memberEmail,
+        row.original.prospectName,
+        row.original.prospectEmail,
+        row.original.referralCode,
+        row.original.redeemed ? "Yes" : "No",
+      ]);
+
+    doc.setFontSize(16);
+    doc.text("Paso Food Co-op Referral Database", doc.internal.pageSize.getWidth() / 2, 15, { align: "center" });
+
+    autoTable(doc, {
+      head: [tableColumns],
+      body: tableRows,
+      startY: 25,
+      styles: { fontSize: 10 },
+      headStyles: { fillColor: [131, 16, 2] },
+      alternateRowStyles: { fillColor: [237, 221, 204] },
+      margin: { left: 10, right: 10 },
+    });
+
+    doc.autoPrint();
+    window.open(doc.output("bloburl"), "_blank");
+  }, [table, formatDate]);
+
+  const filteredColumns = table
+    .getAllColumns()
+    .filter((column) => column.id !== "select")
+    .filter((column) => {
+      const label = columnDisplayLabels[column.id] || column.id;
+      return label.toLowerCase().includes(columnSearch.toLowerCase());
+    });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 p-2 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className="flex flex-1 items-center bg-white px-2 py-1"
+            style={{
+              border: "2px solid #831002",
+              borderRadius: "28px",
+            }}
+          >
+            <svg className="w-5 h-5 text-gray-500 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+            <Input
+              type="text"
+              placeholder="Search…"
+              value={globalFilter}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              className="border-none shadow-none focus-visible:ring-0 w-40 p-0 h-auto text-sm"
+              aria-label="Search referrals"
+            />
+          </div>
+
+          <Drawer open={mobileDrawerOpen} onOpenChange={setMobileDrawerOpen}>
+            <DrawerTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="relative flex md:hidden min-h-[44px] min-w-[44px] shrink-0"
+                aria-label="Open filters and options"
+              >
+                <SlidersHorizontal className="h-5 w-5" />
+                {(isFiltered || hiddenColumnCount > 0) && (
+                  <span className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-[#1976d2]" />
+                )}
+              </Button>
+            </DrawerTrigger>
+            <DrawerContent className="max-h-[85vh]">
+              <DrawerHeader>
+                <DrawerTitle>Filters & Display Options</DrawerTitle>
+              </DrawerHeader>
+              <div className="space-y-6 px-4 pb-4 overflow-y-auto">
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium" style={{ color: "#1976d2" }}>
+                      Visible Columns
+                      {hiddenColumnCount > 0 && (
+                        <span className="ml-2 text-sm text-muted-foreground">({hiddenColumnCount} hidden)</span>
+                      )}
+                    </h3>
+                    <button onClick={handleResetToDefaults} className="text-sm text-[#1976d2] hover:underline">
+                      Reset to defaults
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    {table
+                      .getAllColumns()
+                      .filter((column) => column.id !== "select" && column.getCanHide())
+                      .map((column) => (
+                        <label key={column.id} className="flex items-center gap-2 min-h-[44px] cursor-pointer">
+                          <Checkbox
+                            checked={column.getIsVisible()}
+                            onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                          />
+                          <span>{columnDisplayLabels[column.id] || column.id}</span>
+                        </label>
+                      ))}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="font-medium" style={{ color: "#1976d2" }}>
+                    Filters
+                  </h3>
+                  <div className="space-y-2">
+                    <Select value={filterColumn} onValueChange={setFilterColumn}>
+                      <SelectTrigger className="w-full min-h-[44px]">
+                        <SelectValue placeholder="Column" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {filterableColumns.map((col) => (
+                          <SelectItem key={col.id} value={col.id}>
+                            {col.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select value={filterOperator} onValueChange={setFilterOperator}>
+                      <SelectTrigger className="w-full min-h-[44px]">
+                        <SelectValue placeholder="Operator" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {filterOperators.map((op) => (
+                          <SelectItem key={op.value} value={op.value}>
+                            {op.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Input
+                      type="text"
+                      placeholder="Filter value"
+                      value={filterValue}
+                      onChange={(e) => {
+                        setFilterValue(e.target.value);
+                        if (e.target.value.trim()) {
+                          setColumnFilters([{ id: filterColumn, value: e.target.value }]);
+                        } else {
+                          setColumnFilters([]);
+                        }
+                      }}
+                      className="w-full min-h-[44px]"
+                    />
+                    {isFiltered && (
+                      <Button variant="outline" onClick={handleClearFilter} className="w-full min-h-[44px]">
+                        Clear Filter
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="font-medium" style={{ color: "#1976d2" }}>
+                    Table Density
+                  </h3>
+                  <div className="flex flex-col gap-2">
+                    {(["compact", "standard", "comfortable"] as Density[]).map((d) => (
+                      <label
+                        key={d}
+                        className={cn(
+                          "flex items-center gap-3 min-h-[44px] px-3 rounded-lg cursor-pointer",
+                          density === d ? "bg-gray-100" : "hover:bg-gray-50",
+                        )}
+                      >
+                        <input
+                          type="radio"
+                          name="density"
+                          checked={density === d}
+                          onChange={() => setDensity(d)}
+                          className="h-4 w-4"
+                        />
+                        <span className="capitalize">{d}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <DrawerFooter>
+                <DrawerClose asChild>
+                  <Button variant="outline" className="w-full min-h-[44px]">
+                    Done
+                  </Button>
+                </DrawerClose>
+              </DrawerFooter>
+            </DrawerContent>
+          </Drawer>
+        </div>
+
+        <div className="hidden md:flex items-center gap-4">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center gap-1 text-sm hover:opacity-80" style={{ color: "#1976d2" }}>
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M4 4h4v4H4V4zm6 0h4v4h-4V4zm6 0h4v4h-4V4zM4 10h4v4H4v-4zm6 0h4v4h-4v-4zm6 0h4v4h-4v-4zM4 16h4v4H4v-4zm6 0h4v4h-4v-4zm6 0h4v4h-4v-4z" />
+                </svg>
+                <span className="font-medium">COLUMNS</span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+              <div className="p-2">
+                <div className="flex items-center border rounded px-2 py-1">
+                  <svg className="w-4 h-4 text-gray-400 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                    />
+                  </svg>
+                  <input
+                    type="text"
+                    placeholder="Search"
+                    value={columnSearch}
+                    onChange={(e) => setColumnSearch(e.target.value)}
+                    className="border-none outline-none text-sm w-full"
+                  />
+                </div>
+              </div>
+              {filteredColumns.map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                >
+                  {columnDisplayLabels[column.id] || column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+              <DropdownMenuSeparator />
+              <div className="flex items-center justify-between px-2 py-1.5">
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <Checkbox checked={allColumnsVisible} onCheckedChange={(checked) => handleShowHideAll(!!checked)} />
+                  Show/Hide All
+                </label>
+                <button onClick={handleReset} className="text-xs text-gray-400 hover:text-gray-600 uppercase">
+                  Reset
+                </button>
+              </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <button
+            onClick={() => setShowFilterPanel(!showFilterPanel)}
+            className="flex items-center gap-1 text-sm hover:opacity-80"
+            style={{ color: "#1976d2" }}
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z" />
+            </svg>
+            <span className="font-medium">FILTERS</span>
+          </button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center gap-1 text-sm hover:opacity-80" style={{ color: "#1976d2" }}>
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M4 8h16V6H4v2zm0 5h16v-2H4v2zm0 5h16v-2H4v2z" />
+                </svg>
+                <span className="font-medium">DENSITY</span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <button
+                onClick={() => setDensity("compact")}
+                className={cn(
+                  "flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-gray-100",
+                  density === "compact" && "bg-gray-50",
+                )}
+              >
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M4 8h16V6H4v2zm0 4h16v-2H4v2zm0 4h16v-2H4v2zm0 4h16v-2H4v2z" />
+                </svg>
+                Compact
+              </button>
+              <button
+                onClick={() => setDensity("standard")}
+                className={cn(
+                  "flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-gray-100",
+                  density === "standard" && "bg-gray-50",
+                )}
+              >
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M4 8h16V6H4v2zm0 5h16v-2H4v2zm0 5h16v-2H4v2z" />
+                </svg>
+                Standard
+              </button>
+              <button
+                onClick={() => setDensity("comfortable")}
+                className={cn(
+                  "flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-gray-100",
+                  density === "comfortable" && "bg-gray-50",
+                )}
+              >
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M4 9h16V7H4v2zm0 6h16v-2H4v2z" />
+                </svg>
+                Comfortable
+              </button>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        <Button
+          onClick={exportToPDF}
+          className="w-full md:w-auto text-white border-none rounded cursor-pointer"
+          style={{
+            backgroundColor: "#831002",
+            padding: "8px 16px",
+          }}
+        >
+          Export to PDF
+        </Button>
+      </div>
+
+      <div
+        role="region"
+        aria-label="Referral data table"
+        tabIndex={0}
+        className="overflow-x-auto focus:outline-2 focus:outline-blue-500"
+        style={{
+          border: "2px solid #968676",
+          borderRadius: "12px",
+        }}
+      >
+        {showFilterPanel && (
+          <div className="flex items-center gap-3 px-4 py-2 bg-white border-b border-gray-200">
+            <button onClick={handleClearFilter} className="text-gray-500 hover:text-gray-700" aria-label="Clear filter">
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+              </svg>
+            </button>
+
+            <span className="text-sm text-gray-600">Columns</span>
+            <Select value={filterColumn} onValueChange={setFilterColumn}>
+              <SelectTrigger className="w-36 h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterableColumns.map((col) => (
+                  <SelectItem key={col.id} value={col.id}>
+                    {col.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <span className="text-sm text-gray-600">Operator</span>
+            <Select value={filterOperator} onValueChange={setFilterOperator}>
+              <SelectTrigger className="w-36 h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterOperators.map((op) => (
+                  <SelectItem key={op.value} value={op.value}>
+                    {op.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <span className="text-sm" style={{ color: "#1976d2" }}>
+              Value
+            </span>
+            <Input
+              type="text"
+              placeholder="Filter value"
+              value={filterValue}
+              onChange={(e) => {
+                setFilterValue(e.target.value);
+                if (e.target.value.trim()) {
+                  setColumnFilters([{ id: filterColumn, value: e.target.value }]);
+                } else {
+                  setColumnFilters([]);
+                }
+              }}
+              className="w-36 h-8 text-sm"
+            />
+          </div>
+        )}
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow
+                key={headerGroup.id}
+                style={{
+                  borderTop: "2px solid #968676",
+                  backgroundColor: "#EDDDCC",
+                }}
+              >
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    className={cn(
+                      "font-bold",
+                      header.column.getCanSort() && "cursor-pointer underline select-none",
+                      header.column.columnDef.meta?.className,
+                    )}
+                    style={{ color: "#831002" }}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                    {{
+                      asc: " ↑",
+                      desc: " ↓",
+                    }[header.column.getIsSorted() as string] ?? null}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row, index) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  className={cn(densityClasses[density])}
+                  style={{
+                    backgroundColor: index % 2 === 0 ? "#ffffff" : "#D9D9D9",
+                    transition: "none",
+                  }}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className={cell.column.columnDef.meta?.className}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No rows
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <span className="text-sm text-gray-600">Rows per page:</span>
+        <Select
+          value={`${table.getState().pagination.pageSize}`}
+          onValueChange={(value) => table.setPageSize(Number(value))}
+        >
+          <SelectTrigger className="w-16 h-8" aria-label="Rows per page">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {[5, 10, 20, 100].map((size) => (
+              <SelectItem key={size} value={`${size}`}>
+                {size}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <span className="text-sm text-gray-600 mx-2">
+          {table.getFilteredRowModel().rows.length === 0
+            ? "0–0 of 0"
+            : `${table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1}–${Math.min(
+                (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
+                table.getFilteredRowModel().rows.length,
+              )} of ${table.getFilteredRowModel().rows.length}`}
+        </span>
+
+        <button
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+          className="p-1 disabled:opacity-30"
+          style={{ color: "rgba(0, 0, 0, 0.54)" }}
+          aria-label="Previous page"
+        >
+          <svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
+          </svg>
+        </button>
+        <button
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+          className="p-1 disabled:opacity-30"
+          style={{ color: "rgba(0, 0, 0, 0.54)" }}
+          aria-label="Next page"
+        >
+          <svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ReferralDataGrid;

--- a/src/components/referral/referral-data-grid.tsx
+++ b/src/components/referral/referral-data-grid.tsx
@@ -40,6 +40,9 @@ import { SlidersHorizontal } from "lucide-react";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import type { Referral } from "@/schema/referral";
+import { operatorFilter, filterOperators, type FilterOperator, type ColumnFilterValue } from "@/lib/table-filters";
+import { useToast } from "@/hooks/use-toast";
+import { useReferrals } from "@/hooks/use-referrals";
 
 type Density = "compact" | "standard" | "comfortable";
 
@@ -69,18 +72,6 @@ const filterableColumns = [
   { id: "referralCode", label: "Code" },
 ];
 
-const filterOperators = [
-  { value: "contains", label: "contains" },
-  { value: "doesNotContain", label: "does not contain" },
-  { value: "equals", label: "equals" },
-  { value: "doesNotEqual", label: "does not equal" },
-  { value: "startsWith", label: "starts with" },
-  { value: "endsWith", label: "ends with" },
-  { value: "isEmpty", label: "is empty" },
-  { value: "isNotEmpty", label: "is not empty" },
-  { value: "isAnyOf", label: "is any of" },
-];
-
 const MOBILE_HIDDEN_COLUMNS = ["createdAt", "memberEmail", "prospectEmail", "referralCode"];
 const STORAGE_KEY = "referral-table-columns";
 
@@ -97,7 +88,7 @@ interface ReferralDataGridProps {
 }
 
 export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
-  const [referrals, setReferrals] = useState<Referral[]>([]);
+  const { data: referrals, error, toggleRedeemed } = useReferrals();
   const [sorting, setSorting] = useState<SortingState>([{ id: "createdAt", desc: true }]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() =>
@@ -109,20 +100,21 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
 
   const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [filterColumn, setFilterColumn] = useState("createdAt");
-  const [filterOperator, setFilterOperator] = useState("contains");
+  const [filterOperator, setFilterOperator] = useState<FilterOperator>("contains");
   const [filterValue, setFilterValue] = useState("");
   const [columnSearch, setColumnSearch] = useState("");
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const { toast } = useToast();
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      try {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
         setColumnVisibility(JSON.parse(stored));
         return;
-      } catch {
-        // Invalid JSON, use viewport detection below
       }
+    } catch (error) {
+      console.warn("Failed to load column preferences:", error);
     }
 
     const actualIsMobile = window.innerWidth < 768;
@@ -135,7 +127,11 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
     (updater: VisibilityState | ((prev: VisibilityState) => VisibilityState)) => {
       setColumnVisibility((prev) => {
         const newState = typeof updater === "function" ? updater(prev) : updater;
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+        } catch (error) {
+          console.warn("Failed to save column preferences:", error);
+        }
         return newState;
       });
     },
@@ -143,34 +139,10 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
   );
 
   useEffect(() => {
-    const fetchReferrals = async () => {
-      try {
-        const response = await fetch("/api/referral");
-        if (!response.ok) throw new Error("Failed to fetch referrals");
-        const data = await response.json();
-        setReferrals(data);
-      } catch (error) {
-        console.error("Error fetching referrals:", error);
-      }
-    };
-    fetchReferrals();
-  }, []);
-
-  const handleToggleRedeemed = useCallback(async (id: number, currentValue: boolean) => {
-    setReferrals((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: !currentValue } : ref)));
-
-    try {
-      const response = await fetch(`/api/referral/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      if (!response.ok) throw new Error("Failed to update referral");
-    } catch (error) {
-      console.error("Error updating referral:", error);
-      setReferrals((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: currentValue } : ref)));
+    if (error) {
+      toast({ title: "Failed to load referrals", variant: "destructive" });
     }
-  }, []);
+  }, [error, toast]);
 
   const formatDate = useCallback((date: string | Date) => {
     return new Intl.DateTimeFormat("en-US", {
@@ -208,28 +180,34 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
         accessorKey: "createdAt",
         header: "Date",
         cell: ({ row }) => formatDate(row.getValue("createdAt")),
+        filterFn: operatorFilter,
       },
       {
         accessorKey: "memberName",
         header: "Member Name",
         enableHiding: false,
+        filterFn: operatorFilter,
       },
       {
         accessorKey: "memberEmail",
         header: "Member Email",
+        filterFn: operatorFilter,
       },
       {
         accessorKey: "prospectName",
         header: "Prospect Name",
         enableHiding: false,
+        filterFn: operatorFilter,
       },
       {
         accessorKey: "prospectEmail",
         header: "Prospect Email",
+        filterFn: operatorFilter,
       },
       {
         accessorKey: "referralCode",
         header: "Code",
+        filterFn: operatorFilter,
       },
       {
         accessorKey: "redeemed",
@@ -239,14 +217,14 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
           <div className="flex justify-center">
             <Switch
               checked={row.getValue("redeemed")}
-              onCheckedChange={() => handleToggleRedeemed(row.original.id, row.getValue("redeemed"))}
+              onCheckedChange={() => toggleRedeemed(row.original.id, row.getValue("redeemed"))}
               aria-label="Toggle redeemed status"
             />
           </div>
         ),
       },
     ],
-    [formatDate, handleToggleRedeemed],
+    [formatDate, toggleRedeemed],
   );
 
   const table = useReactTable({
@@ -294,7 +272,11 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
   }, [handleShowHideAll]);
 
   const handleResetToDefaults = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.warn("Failed to clear column preferences:", error);
+    }
     const isMobile = window.innerWidth < 768;
     setColumnVisibility(getDefaultVisibility(isMobile));
   }, []);
@@ -387,7 +369,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
               >
                 <SlidersHorizontal className="h-5 w-5" />
                 {(isFiltered || hiddenColumnCount > 0) && (
-                  <span className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-[#1976d2]" />
+                  <span className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-prfc-blue" />
                 )}
               </Button>
             </DrawerTrigger>
@@ -398,13 +380,13 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
               <div className="space-y-6 px-4 pb-4 overflow-y-auto">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <h3 className="font-medium" style={{ color: "#1976d2" }}>
+                    <h3 className="font-medium text-prfc-blue">
                       Visible Columns
                       {hiddenColumnCount > 0 && (
                         <span className="ml-2 text-sm text-muted-foreground">({hiddenColumnCount} hidden)</span>
                       )}
                     </h3>
-                    <button onClick={handleResetToDefaults} className="text-sm text-[#1976d2] hover:underline">
+                    <button onClick={handleResetToDefaults} className="text-sm text-prfc-blue hover:underline">
                       Reset to defaults
                     </button>
                   </div>
@@ -425,9 +407,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
                 </div>
 
                 <div className="space-y-3">
-                  <h3 className="font-medium" style={{ color: "#1976d2" }}>
-                    Filters
-                  </h3>
+                  <h3 className="font-medium text-prfc-blue">Filters</h3>
                   <div className="space-y-2">
                     <Select value={filterColumn} onValueChange={setFilterColumn}>
                       <SelectTrigger className="w-full min-h-[44px]">
@@ -441,7 +421,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
                         ))}
                       </SelectContent>
                     </Select>
-                    <Select value={filterOperator} onValueChange={setFilterOperator}>
+                    <Select value={filterOperator} onValueChange={(v) => setFilterOperator(v as FilterOperator)}>
                       <SelectTrigger className="w-full min-h-[44px]">
                         <SelectValue placeholder="Operator" />
                       </SelectTrigger>
@@ -460,7 +440,12 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
                       onChange={(e) => {
                         setFilterValue(e.target.value);
                         if (e.target.value.trim()) {
-                          setColumnFilters([{ id: filterColumn, value: e.target.value }]);
+                          setColumnFilters([
+                            {
+                              id: filterColumn,
+                              value: { text: e.target.value, operator: filterOperator } as ColumnFilterValue,
+                            },
+                          ]);
                         } else {
                           setColumnFilters([]);
                         }
@@ -476,9 +461,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
                 </div>
 
                 <div className="space-y-3">
-                  <h3 className="font-medium" style={{ color: "#1976d2" }}>
-                    Table Density
-                  </h3>
+                  <h3 className="font-medium text-prfc-blue">Table Density</h3>
                   <div className="flex flex-col gap-2">
                     {(["compact", "standard", "comfortable"] as Density[]).map((d) => (
                       <label
@@ -515,7 +498,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
         <div className="hidden md:flex items-center gap-4">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className="flex items-center gap-1 text-sm hover:opacity-80" style={{ color: "#1976d2" }}>
+              <button className="flex items-center gap-1 text-sm text-prfc-blue hover:opacity-80">
                 <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M4 4h4v4H4V4zm6 0h4v4h-4V4zm6 0h4v4h-4V4zM4 10h4v4H4v-4zm6 0h4v4h-4v-4zm6 0h4v4h-4v-4zM4 16h4v4H4v-4zm6 0h4v4h-4v-4zm6 0h4v4h-4v-4z" />
                 </svg>
@@ -566,8 +549,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
 
           <button
             onClick={() => setShowFilterPanel(!showFilterPanel)}
-            className="flex items-center gap-1 text-sm hover:opacity-80"
-            style={{ color: "#1976d2" }}
+            className="flex items-center gap-1 text-sm text-prfc-blue hover:opacity-80"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
               <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z" />
@@ -577,7 +559,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className="flex items-center gap-1 text-sm hover:opacity-80" style={{ color: "#1976d2" }}>
+              <button className="flex items-center gap-1 text-sm text-prfc-blue hover:opacity-80">
                 <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M4 8h16V6H4v2zm0 5h16v-2H4v2zm0 5h16v-2H4v2z" />
                 </svg>
@@ -670,7 +652,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
             </Select>
 
             <span className="text-sm text-gray-600">Operator</span>
-            <Select value={filterOperator} onValueChange={setFilterOperator}>
+            <Select value={filterOperator} onValueChange={(v) => setFilterOperator(v as FilterOperator)}>
               <SelectTrigger className="w-36 h-8 text-sm">
                 <SelectValue />
               </SelectTrigger>
@@ -683,9 +665,7 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
               </SelectContent>
             </Select>
 
-            <span className="text-sm" style={{ color: "#1976d2" }}>
-              Value
-            </span>
+            <span className="text-sm text-prfc-blue">Value</span>
             <Input
               type="text"
               placeholder="Filter value"
@@ -693,7 +673,12 @@ export function ReferralDataGrid({ initialIsMobile }: ReferralDataGridProps) {
               onChange={(e) => {
                 setFilterValue(e.target.value);
                 if (e.target.value.trim()) {
-                  setColumnFilters([{ id: filterColumn, value: e.target.value }]);
+                  setColumnFilters([
+                    {
+                      id: filterColumn,
+                      value: { text: e.target.value, operator: filterOperator } as ColumnFilterValue,
+                    },
+                  ]);
                 } else {
                   setColumnFilters([]);
                 }

--- a/src/components/referral/referral-form.tsx
+++ b/src/components/referral/referral-form.tsx
@@ -153,30 +153,26 @@ export function ReferralForm() {
               <button
                 type="button"
                 onClick={() => deleteProspect(index)}
-                className="flex bg-transparent border-none text-lg text-red-500 cursor-pointer mb-3 self-end hover:text-red-700"
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center bg-transparent border-none text-red-500 cursor-pointer self-end hover:text-red-700"
                 aria-label="Delete prospect"
               >
                 <Image src="/assets/trash.png" alt="Delete" width={18} height={18} />
               </button>
-              <div className="flex flex-col md:flex-row w-full gap-2">
-                <div className="flex max-[480px]:flex-col gap-2 w-full flex-wrap md:flex-1">
-                  <Input
-                    type="text"
-                    value={prospect.fullName}
-                    onChange={(e) => handleProspectChange(index, "fullName", e.target.value)}
-                    placeholder="Enter Referee Full Name"
-                    className="flex-1 min-w-0 px-[18px] py-3 rounded-lg border-2 border-prfc-brown bg-white"
-                  />
-                </div>
-                <div className="flex justify-center items-center gap-4 w-full md:flex-1">
-                  <Input
-                    type="email"
-                    value={prospect.email}
-                    onChange={(e) => handleProspectChange(index, "email", e.target.value)}
-                    placeholder="Enter Referee Email Address"
-                    className="w-full px-[18px] py-3 rounded-lg border-2 border-prfc-brown bg-white"
-                  />
-                </div>
+              <div className="flex flex-col md:flex-row md:items-center w-full gap-2">
+                <Input
+                  type="text"
+                  value={prospect.fullName}
+                  onChange={(e) => handleProspectChange(index, "fullName", e.target.value)}
+                  placeholder="Enter Referee Full Name"
+                  className="flex-1 min-w-0 px-[18px] py-3 rounded-lg border-2 border-prfc-brown bg-white"
+                />
+                <Input
+                  type="email"
+                  value={prospect.email}
+                  onChange={(e) => handleProspectChange(index, "email", e.target.value)}
+                  placeholder="Enter Referee Email Address"
+                  className="flex-1 min-w-0 px-[18px] py-3 rounded-lg border-2 border-prfc-brown bg-white"
+                />
               </div>
             </div>
           ))}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+const Drawer = ({ shouldScaleBackground = true, ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />
+);
+Drawer.displayName = "Drawer";
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay ref={ref} className={cn("fixed inset-0 z-50 bg-black/80", className)} {...props} />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)} {...props} />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#1976d2] data-[state=unchecked]:bg-input",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-prfc-blue data-[state=unchecked]:bg-input",
       className,
     )}
     {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#1976d2] data-[state=unchecked]:bg-input",
       className,
     )}
     {...props}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive: "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return <ToastPrimitives.Root ref={ref} className={cn(toastVariants({ variant }), className)} {...props} />;
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold [&+div]:text-xs", className)} {...props} />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description ref={ref} className={cn("text-sm opacity-90", className)} {...props} />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+};

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useToast } from "@/hooks/use-toast";
+import { Toast, ToastClose, ToastDescription, ToastProvider, ToastTitle, ToastViewport } from "@/components/ui/toast";
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && <ToastDescription>{description}</ToastDescription>}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
-export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(false);
+export function useIsMobile(initialValue: boolean = false): boolean {
+  const [isMobile, setIsMobile] = useState(initialValue);
 
   useEffect(() => {
     const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+
+    const onChange = () => setIsMobile(mq.matches);
+    onChange();
+
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/src/hooks/use-referrals.ts
+++ b/src/hooks/use-referrals.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { Referral } from "@/schema/referral";
+import { z } from "zod";
+
+const ApiReferralSchema = z.object({
+  id: z.number(),
+  createdAt: z.coerce.date(),
+  memberName: z.string(),
+  memberEmail: z.string(),
+  prospectName: z.string(),
+  prospectEmail: z.string(),
+  referralCode: z.string(),
+  redeemed: z.boolean(),
+});
+
+interface UseReferralsReturn {
+  data: Referral[];
+  error: Error | null;
+  loading: boolean;
+  refetch: () => Promise<void>;
+  toggleRedeemed: (id: number, currentValue: boolean) => Promise<void>;
+}
+
+export function useReferrals(): UseReferralsReturn {
+  const [data, setData] = useState<Referral[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchReferrals = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/referral");
+      if (!response.ok) {
+        throw new Error(`Failed to fetch: ${response.status}`);
+      }
+      const json = await response.json();
+      const validated = z.array(ApiReferralSchema).parse(json);
+      setData(validated);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error("Unknown error");
+      setError(error);
+      console.error("[useReferrals] Fetch error:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchReferrals();
+  }, [fetchReferrals]);
+
+  const toggleRedeemed = useCallback(async (id: number, currentValue: boolean) => {
+    setData((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: !currentValue } : ref)));
+
+    try {
+      const response = await fetch(`/api/referral/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to update: ${response.status}`);
+      }
+    } catch (err) {
+      setData((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: currentValue } : ref)));
+      console.error("[useReferrals] Toggle error:", err);
+    }
+  }, []);
+
+  return {
+    data,
+    error,
+    loading,
+    refetch: fetchReferrals,
+    toggleRedeemed,
+  };
+}

--- a/src/hooks/use-referrals.ts
+++ b/src/hooks/use-referrals.ts
@@ -34,7 +34,7 @@ export function useReferrals(): UseReferralsReturn {
     try {
       const response = await fetch("/api/referral");
       if (!response.ok) {
-        throw new Error(`Failed to fetch: ${response.status}`);
+        throw new Error(`Failed to fetch referrals: ${response.status}`);
       }
       const json = await response.json();
       const validated = z.array(ApiReferralSchema).parse(json);
@@ -62,7 +62,7 @@ export function useReferrals(): UseReferralsReturn {
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to update: ${response.status}`);
+        throw new Error(`Failed to update referral ${id}: ${response.status}`);
       }
     } catch (err) {
       setData((prev) => prev.map((ref) => (ref.id === id ? { ...ref, redeemed: currentValue } : ref)));

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
+
+const TOAST_LIMIT = 1;
+const TOAST_REMOVE_DELAY = 1000000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+
+type Action =
+  | { type: "ADD_TOAST"; toast: ToasterToast }
+  | { type: "UPDATE_TOAST"; toast: Partial<ToasterToast> }
+  | { type: "DISMISS_TOAST"; toastId?: string }
+  | { type: "REMOVE_TOAST"; toastId?: string };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({ type: "REMOVE_TOAST", toastId: toastId });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return { ...state, toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT) };
+
+    case "UPDATE_TOAST":
+      return { ...state, toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)) };
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action;
+
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) => (t.id === toastId || toastId === undefined ? { ...t, open: false } : t)),
+      };
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return { ...state, toasts: [] };
+      }
+      return { ...state, toasts: state.toasts.filter((t) => t.id !== action.toastId) };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, "id">;
+
+function toast({ ...props }: Toast) {
+  const id = genId();
+
+  const update = (props: ToasterToast) => dispatch({ type: "UPDATE_TOAST", toast: { ...props, id } });
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss();
+      },
+    },
+  });
+
+  return { id: id, dismiss, update };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return { ...state, toast, dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }) };
+}
+
+export { useToast, toast };

--- a/src/lib/table-filters.ts
+++ b/src/lib/table-filters.ts
@@ -1,0 +1,46 @@
+export type FilterOperator =
+  | "contains"
+  | "doesNotContain"
+  | "equals"
+  | "doesNotEqual"
+  | "startsWith"
+  | "endsWith"
+  | "isEmpty"
+  | "isNotEmpty";
+
+export interface ColumnFilterValue {
+  text: string;
+  operator: FilterOperator;
+}
+
+const ops: Record<FilterOperator, (cellVal: string, filterVal: string) => boolean> = {
+  contains: (c, f) => c.includes(f),
+  doesNotContain: (c, f) => !c.includes(f),
+  equals: (c, f) => c === f,
+  doesNotEqual: (c, f) => c !== f,
+  startsWith: (c, f) => c.startsWith(f),
+  endsWith: (c, f) => c.endsWith(f),
+  isEmpty: (c) => c === "",
+  isNotEmpty: (c) => c !== "",
+};
+
+export function operatorFilter(
+  row: { getValue: (columnId: string) => unknown },
+  columnId: string,
+  filterValue: ColumnFilterValue,
+): boolean {
+  const cell = String(row.getValue(columnId) ?? "").toLowerCase();
+  const text = filterValue.text.toLowerCase();
+  return ops[filterValue.operator](cell, text);
+}
+
+export const filterOperators: { value: FilterOperator; label: string }[] = [
+  { value: "contains", label: "contains" },
+  { value: "doesNotContain", label: "does not contain" },
+  { value: "equals", label: "equals" },
+  { value: "doesNotEqual", label: "does not equal" },
+  { value: "startsWith", label: "starts with" },
+  { value: "endsWith", label: "ends with" },
+  { value: "isEmpty", label: "is empty" },
+  { value: "isNotEmpty", label: "is not empty" },
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ module.exports = {
         "prfc-cream": "#EDDDCC",
         "prfc-dark-brown": "#3e1c00",
         "prfc-border": "#968676",
+        "prfc-blue": "#1976d2",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {

--- a/types/tanstack-table.d.ts
+++ b/types/tanstack-table.d.ts
@@ -1,0 +1,8 @@
+import "@tanstack/react-table";
+import { RowData } from "@tanstack/react-table";
+
+declare module "@tanstack/react-table" {
+  interface ColumnMeta<_TData extends RowData, _TValue> {
+    className?: string;
+  }
+}


### PR DESCRIPTION
## Summary

Replaces MUI DataGrid with TanStack Table and shadcn primitives. This gives us full feature parity with the original while dropping the MUI dependency.

The data grid handles sorting, filtering, pagination, density controls, column visibility, and PDF export. I added a mobile drawer for smaller screens since the toolbar buttons don't fit well on phones.

**New files:**
- `referral-data-grid.tsx` - The main component, about 800 lines
- `use-referrals.ts` - Fetches data, validates with Zod, handles optimistic updates for the redeemed toggle
- `use-toast.ts` - Toast notification system for error feedback
- `table-filters.ts` - Custom filter operators (contains, equals, startsWith, etc.)
- `drawer.tsx` - shadcn drawer for mobile controls
- `use-mobile.ts` - Viewport detection hook with SSR hydration fix
- `types/tanstack-table.d.ts` - Adds `className` to column meta for responsive hiding

**Code review fixes:**
- Replaced hardcoded `#1976d2` with `prfc-blue` theme color throughout
- Added try-catch blocks for all localStorage operations
- Fixed SSR hydration mismatch in `use-mobile.ts` with `initialValue` parameter
- Implemented custom filter operators that actually work (previous version had non-functional operator UI)
- Added toast notifications when fetch or toggle operations fail
- Refactored data grid to use `useReferrals` hook instead of duplicate fetch logic
- Added Zod validation for API responses

**How mobile works:** The server detects device type via `userAgent()` and passes `initialIsMobile` to the component. This prevents hydration mismatches. On mobile, only Member Name, Prospect Name, and Redeemed show by default. Users can toggle columns in the drawer, and their preferences persist to localStorage. There's a "Reset to defaults" link that clears storage and restores viewport-appropriate columns.

## Tests

- [x] Desktop: verify toolbar controls (columns dropdown, filters panel, density selector, PDF export)
- [x] Desktop: click column headers to sort, confirm arrow indicators appear
- [x] Desktop: toggle a redeemed switch, verify it updates immediately and hits the API
- [x] Mobile (< 768px): tap the sliders icon, confirm drawer opens with column checkboxes and filter controls
- [x] Mobile: verify only 3 columns show by default (Member Name, Prospect Name, Redeemed)
- [x] Mobile: tap "Reset to defaults" and confirm it restores mobile column defaults
- [x] Resize browser: refresh page, confirm column visibility persists from localStorage
- [x] Filter: select a column and operator, enter a value, confirm filtering works
- [x] Error handling: disconnect network, try to toggle redeemed, confirm toast appears

## Referral Form Desktop Viewport
<img width="1271" height="1328" alt="Screenshot 2025-12-02 at 7 40 54 PM" src="https://github.com/user-attachments/assets/ecb2d0b4-8f11-4d60-8db1-688beab55a34" />

## Referral Form Mobile Viewport
<img width="561" height="1328" alt="Screenshot 2025-12-02 at 7 41 08 PM" src="https://github.com/user-attachments/assets/3d87b9e8-6839-438d-8901-aca009807dd4" />

## Referral Table Desktop Columns
<img width="1271" height="1328" alt="Screenshot 2025-12-02 at 7 41 48 PM" src="https://github.com/user-attachments/assets/06bc1fed-47f1-4f52-aeda-a3c8455b8f8d" />

## Referral Table Desktop Filters
<img width="1272" height="1327" alt="Screenshot 2025-12-02 at 7 41 59 PM" src="https://github.com/user-attachments/assets/32268189-9223-4df2-907c-fdd4fd726cd0" />

## Referral Table Desktop Density
<img width="1271" height="1328" alt="Screenshot 2025-12-02 at 7 42 10 PM" src="https://github.com/user-attachments/assets/c68c434c-4218-438c-871e-64e62151c3f6" />

## Referral Table Mobile Unchecked Columns
<img width="630" height="1329" alt="Screenshot 2025-12-02 at 7 57 11 PM" src="https://github.com/user-attachments/assets/5bcc75e7-14cb-4dab-85bc-0932cb1366e5" />

## Referral Table Mobile Checked Columns
<img width="630" height="1327" alt="Screenshot 2025-12-02 at 7 57 23 PM" src="https://github.com/user-attachments/assets/7f0a6b21-1fc9-4ad3-ab8c-75cde27d90e1" />