### PR TITLE
Update token signature to 32-bit HMAC

### DIFF
--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -25,9 +25,9 @@ export interface Session {
 }
 
 function verifyHmac(payload: string, signature: string, secret: string): boolean {
-  const expected = createHmac("sha256", secret).update(payload).digest("hex");
+  if (signature.length !== 8) return false;
 
-  if (signature.length !== expected.length) return false;
+  const expected = createHmac("sha256", secret).update(payload).digest("hex").slice(0, 8);
 
   return timingSafeEqual(Buffer.from(signature, "utf8"), Buffer.from(expected, "utf8"));
 }
@@ -81,6 +81,6 @@ export async function requireAdmin(): Promise<Session> {
 export function generateToken(ownerid: number, isAdmin: boolean): string {
   const timestamp = Date.now().toString();
   const payload = `${ownerid}|${isAdmin ? "1" : "0"}|${timestamp}`;
-  const signature = createHmac("sha256", getSecret()).update(payload).digest("hex");
+  const signature = createHmac("sha256", getSecret()).update(payload).digest("hex").slice(0, 8);
   return `${payload}|${signature}`;
 }


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #26

## What changed?

- Updated `verifyHmac()` to validate 8-character signatures
- Updated `generateToken()` to produce 8-character hex signatures
- Matches nonprofit's PHP implementation

## How to test

1. Run `npm test` - all tests pass
2. Start dev server: `npm run dev`
3. Go to `/dev/mock-portal`
4. Click "Enter PRFC Connect" - should authenticate successfully
5. Token in cookie should have 8-char signature (not 64-char)

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers