### PR TITLE
Add auth types and navigation config

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,0 +1,25 @@
+import type { AuthState } from "@/lib/auth-types";
+
+export interface NavItem {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+export const NAV_CONFIG: Record<AuthState, NavItem[]> = {
+  unauthenticated: [
+    { label: "Home", href: "/" },
+    { label: "Sign In", href: "https://pasofoodcooperative.coop/accounts/", external: true },
+  ],
+  member: [
+    { label: "Home", href: "/" },
+    { label: "My Groups", href: "/groups" },
+    { label: "Referral", href: "/referral" },
+  ],
+  admin: [
+    { label: "Home", href: "/" },
+    { label: "Groups", href: "/groups" },
+    { label: "Referral Database", href: "/referral-database" },
+    { label: "Broadcast", href: "/broadcast" },
+  ],
+};

--- a/src/lib/auth-types.ts
+++ b/src/lib/auth-types.ts
@@ -1,0 +1,6 @@
+export type AuthState = "unauthenticated" | "member" | "admin";
+
+export interface SessionData {
+  state: AuthState;
+  ownerid?: number;
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #32

## What changed?

- Created `src/lib/auth-types.ts` with AuthState and SessionData types
- Created `src/config/navigation.ts` with NAV_CONFIG for three auth states
- NavItem interface includes label, href, and external flag

## How to test

1. Run `npm run lint` - should pass
2. Run `npm run build` - should pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers