### PR TITLE
Add Contact Group service layer

### DIFF
--- a/src/services/contact-group.ts
+++ b/src/services/contact-group.ts
@@ -1,0 +1,212 @@
+import "server-only";
+import prisma from "@/lib/db";
+import { AppError, transformError } from "@/utils/errors";
+import type { ContactGroup, ContactGroupMember } from "@/generated/prisma/client";
+
+export interface GroupWithCount extends ContactGroup {
+  memberCount: number;
+}
+
+export interface GroupWithMembers extends ContactGroup {
+  members: ContactGroupMember[];
+  memberCount: number;
+}
+
+export async function getGroupsByOwner(ownerid: number): Promise<GroupWithCount[]> {
+  try {
+    const groups = await prisma.contactGroup.findMany({
+      where: { ownerid },
+      include: {
+        _count: { select: { members: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return groups.map((g) => ({
+      ...g,
+      memberCount: g._count.members,
+    }));
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getAllGroups(): Promise<GroupWithCount[]> {
+  try {
+    const groups = await prisma.contactGroup.findMany({
+      include: {
+        _count: { select: { members: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return groups.map((g) => ({
+      ...g,
+      memberCount: g._count.members,
+    }));
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getGroupById(id: number): Promise<GroupWithMembers> {
+  try {
+    const group = await prisma.contactGroup.findUnique({
+      where: { id },
+      include: {
+        members: true,
+        _count: { select: { members: true } },
+      },
+    });
+
+    if (!group) {
+      throw new AppError("NOT_FOUND", `Group with id ${id} not found`);
+    }
+
+    return {
+      ...group,
+      memberCount: group._count.members,
+    };
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function isGroupOwner(groupId: number, ownerid: number): Promise<boolean> {
+  try {
+    const group = await prisma.contactGroup.findFirst({
+      where: { id: groupId, ownerid },
+      select: { id: true },
+    });
+    return group !== null;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function createGroup(
+  data: { name: string; description?: string | null },
+  ownerid: number,
+): Promise<ContactGroup> {
+  try {
+    return await prisma.contactGroup.create({
+      data: {
+        name: data.name,
+        description: data.description,
+        ownerid,
+      },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function updateGroup(
+  id: number,
+  data: { name?: string; description?: string | null },
+): Promise<ContactGroup> {
+  try {
+    return await prisma.contactGroup.update({
+      where: { id },
+      data,
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function deleteGroup(id: number): Promise<void> {
+  try {
+    await prisma.contactGroup.delete({
+      where: { id },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function addMemberToGroup(
+  groupId: number,
+  memberId: number,
+  addedBy: number,
+  preferences: { notifyEmail?: boolean; notifySms?: boolean } = {},
+): Promise<ContactGroupMember> {
+  try {
+    return await prisma.contactGroupMember.create({
+      data: {
+        groupId,
+        memberId,
+        addedBy,
+        notifyEmail: preferences.notifyEmail ?? true,
+        notifySms: preferences.notifySms ?? false,
+      },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function addMembersToGroup(
+  groupId: number,
+  members: Array<{ memberId: number; notifyEmail?: boolean; notifySms?: boolean }>,
+  addedBy: number,
+): Promise<{ count: number }> {
+  try {
+    return await prisma.contactGroupMember.createMany({
+      data: members.map((m) => ({
+        groupId,
+        memberId: m.memberId,
+        addedBy,
+        notifyEmail: m.notifyEmail ?? true,
+        notifySms: m.notifySms ?? false,
+      })),
+      skipDuplicates: true,
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function removeMemberFromGroup(groupId: number, memberId: number): Promise<void> {
+  try {
+    await prisma.contactGroupMember.delete({
+      where: {
+        groupId_memberId: { groupId, memberId },
+      },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function updateMemberNotifications(
+  groupId: number,
+  memberId: number,
+  preferences: { notifyEmail?: boolean; notifySms?: boolean },
+): Promise<ContactGroupMember> {
+  try {
+    return await prisma.contactGroupMember.update({
+      where: {
+        groupId_memberId: { groupId, memberId },
+      },
+      data: preferences,
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getGroupRecipients(groupId: number, channel: "email" | "sms"): Promise<number[]> {
+  try {
+    const members = await prisma.contactGroupMember.findMany({
+      where: {
+        groupId,
+        ...(channel === "email" ? { notifyEmail: true } : { notifySms: true }),
+      },
+      select: { memberId: true },
+    });
+    return members.map((m) => m.memberId);
+  } catch (error) {
+    throw transformError(error);
+  }
+}

--- a/src/services/contact-group.ts
+++ b/src/services/contact-group.ts
@@ -2,6 +2,9 @@ import "server-only";
 import prisma from "@/lib/db";
 import { AppError, transformError } from "@/utils/errors";
 import type { ContactGroup, ContactGroupMember } from "@/generated/prisma/client";
+import type { CreateContactGroup, UpdateContactGroup, GroupMember, UpdateNotification } from "@/schema/contact-group";
+
+type NotificationPreferences = Pick<UpdateNotification, "notifyEmail" | "notifySms">;
 
 export interface GroupWithCount extends ContactGroup {
   memberCount: number;
@@ -84,10 +87,7 @@ export async function isGroupOwner(groupId: number, ownerid: number): Promise<bo
   }
 }
 
-export async function createGroup(
-  data: { name: string; description?: string | null },
-  ownerid: number,
-): Promise<ContactGroup> {
+export async function createGroup(data: CreateContactGroup, ownerid: number): Promise<ContactGroup> {
   try {
     return await prisma.contactGroup.create({
       data: {
@@ -101,10 +101,7 @@ export async function createGroup(
   }
 }
 
-export async function updateGroup(
-  id: number,
-  data: { name?: string; description?: string | null },
-): Promise<ContactGroup> {
+export async function updateGroup(id: number, data: UpdateContactGroup): Promise<ContactGroup> {
   try {
     return await prisma.contactGroup.update({
       where: { id },
@@ -129,7 +126,7 @@ export async function addMemberToGroup(
   groupId: number,
   memberId: number,
   addedBy: number,
-  preferences: { notifyEmail?: boolean; notifySms?: boolean } = {},
+  preferences: NotificationPreferences = {},
 ): Promise<ContactGroupMember> {
   try {
     return await prisma.contactGroupMember.create({
@@ -148,7 +145,7 @@ export async function addMemberToGroup(
 
 export async function addMembersToGroup(
   groupId: number,
-  members: Array<{ memberId: number; notifyEmail?: boolean; notifySms?: boolean }>,
+  members: GroupMember[],
   addedBy: number,
 ): Promise<{ count: number }> {
   try {
@@ -157,8 +154,8 @@ export async function addMembersToGroup(
         groupId,
         memberId: m.memberId,
         addedBy,
-        notifyEmail: m.notifyEmail ?? true,
-        notifySms: m.notifySms ?? false,
+        notifyEmail: m.notifyEmail,
+        notifySms: m.notifySms,
       })),
       skipDuplicates: true,
     });
@@ -182,7 +179,7 @@ export async function removeMemberFromGroup(groupId: number, memberId: number): 
 export async function updateMemberNotifications(
   groupId: number,
   memberId: number,
-  preferences: { notifyEmail?: boolean; notifySms?: boolean },
+  preferences: NotificationPreferences,
 ): Promise<ContactGroupMember> {
   try {
     return await prisma.contactGroupMember.update({


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #30

## What changed?

- Added `src/services/contact-group.ts` with CRUD operations for groups and member management
- Exported types: `GroupWithCount`, `GroupWithMembers`
- CRUD functions: `getGroupsByOwner`, `getAllGroups`, `getGroupById`, `createGroup`, `updateGroup`, `deleteGroup`
- Member functions: `addMemberToGroup`, `addMembersToGroup`, `removeMemberFromGroup`, `updateMemberNotifications`, `getGroupRecipients`
- All functions use `transformError()` pattern matching existing codebase

## How to test

1. Run `npm run lint` - should pass
2. Run `npm run build` - should pass
3. Run `npm run test` - all 55 tests pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers