### PR TITLE
Add Contact Group server actions

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -1,0 +1,156 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { verifySession } from "@/lib/dal";
+import {
+  CreateContactGroupSchema,
+  UpdateContactGroupSchema,
+  AddMembersSchema,
+  UpdateNotificationSchema,
+} from "@/schema/contact-group";
+import {
+  createGroup,
+  updateGroup,
+  deleteGroup,
+  isGroupOwner,
+  addMembersToGroup,
+  removeMemberFromGroup,
+  updateMemberNotifications,
+} from "@/services/contact-group";
+import { transformError } from "@/utils/errors";
+
+export interface ActionResult<T = void> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export async function createContactGroup(formData: FormData): Promise<ActionResult<{ id: number }>> {
+  try {
+    const session = await verifySession();
+
+    const validated = CreateContactGroupSchema.parse({
+      name: formData.get("name"),
+      description: formData.get("description") || null,
+    });
+
+    const group = await createGroup(validated, session.ownerid);
+
+    revalidatePath("/groups");
+    return { success: true, data: { id: group.id } };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function updateContactGroup(groupId: number, formData: FormData): Promise<ActionResult> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to edit this group" };
+    }
+
+    const validated = UpdateContactGroupSchema.parse({
+      name: formData.get("name") || undefined,
+      description: formData.get("description"),
+    });
+
+    await updateGroup(groupId, validated);
+
+    revalidatePath(`/groups/${groupId}`);
+    revalidatePath("/groups");
+    return { success: true };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function deleteContactGroup(groupId: number): Promise<ActionResult> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to delete this group" };
+    }
+
+    await deleteGroup(groupId);
+
+    revalidatePath("/groups");
+    return { success: true };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function addMembers(input: {
+  groupId: number;
+  members: Array<{ memberId: number; notifyEmail?: boolean; notifySms?: boolean }>;
+}): Promise<ActionResult<{ count: number }>> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin && !(await isGroupOwner(input.groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to add members to this group" };
+    }
+
+    const validated = AddMembersSchema.parse(input);
+
+    const result = await addMembersToGroup(validated.groupId, validated.members, session.ownerid);
+
+    revalidatePath(`/groups/${input.groupId}`);
+    return { success: true, data: result };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function removeMember(groupId: number, memberId: number): Promise<ActionResult> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to remove members from this group" };
+    }
+
+    await removeMemberFromGroup(groupId, memberId);
+
+    revalidatePath(`/groups/${groupId}`);
+    return { success: true };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function updateNotifications(input: {
+  groupId: number;
+  memberId: number;
+  notifyEmail?: boolean;
+  notifySms?: boolean;
+}): Promise<ActionResult> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin && !(await isGroupOwner(input.groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to update notification preferences" };
+    }
+
+    const validated = UpdateNotificationSchema.parse(input);
+
+    await updateMemberNotifications(validated.groupId, validated.memberId, {
+      notifyEmail: validated.notifyEmail,
+      notifySms: validated.notifySms,
+    });
+
+    revalidatePath(`/groups/${input.groupId}`);
+    return { success: true };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}

--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -54,7 +54,7 @@ export async function updateContactGroup(groupId: number, formData: FormData): P
 
     const validated = UpdateContactGroupSchema.parse({
       name: formData.get("name") || undefined,
-      description: formData.get("description"),
+      description: formData.get("description") || null,
     });
 
     await updateGroup(groupId, validated);
@@ -92,16 +92,15 @@ export async function addMembers(input: {
 }): Promise<ActionResult<{ count: number }>> {
   try {
     const session = await verifySession();
+    const validated = AddMembersSchema.parse(input);
 
-    if (!session.isAdmin && !(await isGroupOwner(input.groupId, session.ownerid))) {
+    if (!session.isAdmin && !(await isGroupOwner(validated.groupId, session.ownerid))) {
       return { success: false, error: "You do not have permission to add members to this group" };
     }
 
-    const validated = AddMembersSchema.parse(input);
-
     const result = await addMembersToGroup(validated.groupId, validated.members, session.ownerid);
 
-    revalidatePath(`/groups/${input.groupId}`);
+    revalidatePath(`/groups/${validated.groupId}`);
     return { success: true, data: result };
   } catch (error) {
     const appError = transformError(error);
@@ -135,19 +134,18 @@ export async function updateNotifications(input: {
 }): Promise<ActionResult> {
   try {
     const session = await verifySession();
+    const validated = UpdateNotificationSchema.parse(input);
 
-    if (!session.isAdmin && !(await isGroupOwner(input.groupId, session.ownerid))) {
+    if (!session.isAdmin && !(await isGroupOwner(validated.groupId, session.ownerid))) {
       return { success: false, error: "You do not have permission to update notification preferences" };
     }
-
-    const validated = UpdateNotificationSchema.parse(input);
 
     await updateMemberNotifications(validated.groupId, validated.memberId, {
       notifyEmail: validated.notifyEmail,
       notifySms: validated.notifySms,
     });
 
-    revalidatePath(`/groups/${input.groupId}`);
+    revalidatePath(`/groups/${validated.groupId}`);
     return { success: true };
   } catch (error) {
     const appError = transformError(error);


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #31

## What changed?

- Added `src/actions/contact-group.ts` with server actions for Contact Groups
- Group CRUD: `createContactGroup`, `updateContactGroup`, `deleteContactGroup`
- Member management: `addMembers`, `removeMember`, `updateNotifications`
- All actions verify session first (security)
- Ownership checks with admin bypass
- Zod validation with `.parse()`
- `revalidatePath()` after all mutations

**Note:** `sendMessage` and `sendBlast` actions not included - requires `src/services/message.ts` which doesn't exist yet.

## How to test

1. Run `npm run lint` - should pass
2. Run `npm run build` - should pass
3. Run `npm run test` - all 55 tests pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers