### PR TITLE
Fix middleware path to match navigation config

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,5 +14,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/referral-database/:path*", "/contact-groups/:path*"],
+  matcher: ["/referral-database/:path*", "/groups/:path*"],
 };


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #42

## What changed?

- Updated middleware matcher from `/contact-groups/:path*` to `/groups/:path*`
- Now matches `navigation.ts` and server actions `revalidatePath()` calls

## How to test

1. Run `npm run build` - should pass
2. Verify middleware protects `/groups` routes (requires auth cookie)

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers