### PR TITLE
feat: add member API routes

### DIFF
--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { env } from "@/env";
+import { verifySession } from "@/lib/dal";
+import { getMemberById } from "@/lib/api/member-api";
+import { AppError, apiErrorHandler } from "@/utils/errors";
+
+function createMembersRateLimiter() {
+  if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
+    return null;
+  }
+
+  const redis = new Redis({
+    url: env.UPSTASH_REDIS_REST_URL,
+    token: env.UPSTASH_REDIS_REST_TOKEN,
+  });
+
+  return new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(10, "60 s"),
+    prefix: "prfc:members",
+  });
+}
+
+const rateLimiter = createMembersRateLimiter();
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    if (rateLimiter) {
+      const forwarded = req.headers.get("x-forwarded-for");
+      const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
+      const { success, remaining, reset } = await rateLimiter.limit(ip);
+
+      if (!success) {
+        return NextResponse.json(
+          { error: { code: "RATE_LIMITED", message: "Too many requests" } },
+          {
+            status: 429,
+            headers: {
+              "X-RateLimit-Remaining": remaining.toString(),
+              "X-RateLimit-Reset": reset.toString(),
+            },
+          },
+        );
+      }
+    }
+
+    await verifySession();
+
+    const { id } = await params;
+    const memberId = parseInt(id, 10);
+
+    if (isNaN(memberId)) {
+      throw new AppError("VALIDATION_ERROR", "Invalid member ID format");
+    }
+
+    const member = await getMemberById(memberId);
+
+    if (!member) {
+      throw new AppError("NOT_FOUND", "Member not found");
+    }
+
+    return NextResponse.json(member, {
+      status: 200,
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    });
+  } catch (error) {
+    return apiErrorHandler(error);
+  }
+}

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { env } from "@/env";
+import { verifySession } from "@/lib/dal";
+import { getAllMembers } from "@/lib/api/member-api";
+import { apiErrorHandler } from "@/utils/errors";
+
+function createMembersRateLimiter() {
+  if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
+    return null;
+  }
+
+  const redis = new Redis({
+    url: env.UPSTASH_REDIS_REST_URL,
+    token: env.UPSTASH_REDIS_REST_TOKEN,
+  });
+
+  return new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(10, "60 s"),
+    prefix: "prfc:members",
+  });
+}
+
+const rateLimiter = createMembersRateLimiter();
+
+export async function GET(req: NextRequest) {
+  try {
+    if (rateLimiter) {
+      const forwarded = req.headers.get("x-forwarded-for");
+      const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
+      const { success, remaining, reset } = await rateLimiter.limit(ip);
+
+      if (!success) {
+        return NextResponse.json(
+          { error: { code: "RATE_LIMITED", message: "Too many requests" } },
+          {
+            status: 429,
+            headers: {
+              "X-RateLimit-Remaining": remaining.toString(),
+              "X-RateLimit-Reset": reset.toString(),
+            },
+          },
+        );
+      }
+    }
+
+    await verifySession();
+
+    const members = await getAllMembers();
+
+    return NextResponse.json(members, {
+      status: 200,
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    });
+  } catch (error) {
+    return apiErrorHandler(error);
+  }
+}

--- a/src/lib/api/member-api.ts
+++ b/src/lib/api/member-api.ts
@@ -2,6 +2,11 @@ import "server-only";
 import { env } from "@/env";
 import type { MockMember } from "@/lib/mock-members";
 
+export interface MemberSummary {
+  ownerid: number;
+  ownername: string;
+}
+
 async function getMockMemberDetails(memberIds: number[]): Promise<MockMember[]> {
   return memberIds.map((id) => ({
     ownerid: id,
@@ -12,7 +17,7 @@ async function getMockMemberDetails(memberIds: number[]): Promise<MockMember[]> 
 }
 
 async function getRealMemberDetails(_memberIds: number[]): Promise<MockMember[]> {
-  throw new Error("Real Member Portal API integration not yet implemented");
+  throw new Error("Member Portal API integration not yet implemented");
 }
 
 async function getMockAllActiveMemberIds(): Promise<number[]> {
@@ -21,7 +26,25 @@ async function getMockAllActiveMemberIds(): Promise<number[]> {
 }
 
 async function getRealAllActiveMemberIds(): Promise<number[]> {
-  throw new Error("Real Member Portal API integration not yet implemented");
+  throw new Error("Member Portal API integration not yet implemented");
+}
+
+async function getMockAllMembers(): Promise<MemberSummary[]> {
+  const { mockMembers } = await import("@/lib/mock-members");
+  return mockMembers.map(({ ownerid, ownername }) => ({ ownerid, ownername }));
+}
+
+async function getRealAllMembers(): Promise<MemberSummary[]> {
+  throw new Error("Member Portal API integration not yet implemented");
+}
+
+async function getMockMemberById(id: number): Promise<MockMember | null> {
+  const { findMemberById } = await import("@/lib/mock-members");
+  return findMemberById(id) ?? null;
+}
+
+async function getRealMemberById(_id: number): Promise<MockMember | null> {
+  throw new Error("Member Portal API integration not yet implemented");
 }
 
 export async function getMemberDetails(memberIds: number[]): Promise<MockMember[]> {
@@ -36,4 +59,18 @@ export async function getAllActiveMemberIds(): Promise<number[]> {
     return getMockAllActiveMemberIds();
   }
   return getRealAllActiveMemberIds();
+}
+
+export async function getAllMembers(): Promise<MemberSummary[]> {
+  if (env.USE_MOCK_MEMBER_API) {
+    return getMockAllMembers();
+  }
+  return getRealAllMembers();
+}
+
+export async function getMemberById(id: number): Promise<MockMember | null> {
+  if (env.USE_MOCK_MEMBER_API) {
+    return getMockMemberById(id);
+  }
+  return getRealMemberById(id);
 }


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #46

## What changed?

- Added `GET /api/members` route returning member list
- Added `GET /api/members/[id]` route returning single member
- Extended `lib/api/member-api.ts` with `getAllMembers()` and `getMemberById()`
- Rate limiting (10 req/min) before auth
- Cache-Control headers for private data

## How to test

1. Run `npm run build` - should pass
2. Run `npm run lint` - should pass
3. Start dev server, authenticate via mock portal
4. Test `GET /api/members` returns member list
5. Test `GET /api/members/100001` returns single member

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers