### PR TITLE
fix: address copilot review feedback

### DIFF
--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -1,36 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Ratelimit } from "@upstash/ratelimit";
-import { Redis } from "@upstash/redis";
-import { env } from "@/env";
 import { verifySession } from "@/lib/dal";
+import { membersRateLimiter } from "@/lib/rate-limit";
 import { getMemberById } from "@/lib/api/member-api";
 import { AppError, apiErrorHandler } from "@/utils/errors";
 
-function createMembersRateLimiter() {
-  if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
-    return null;
-  }
-
-  const redis = new Redis({
-    url: env.UPSTASH_REDIS_REST_URL,
-    token: env.UPSTASH_REDIS_REST_TOKEN,
-  });
-
-  return new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(10, "60 s"),
-    prefix: "prfc:members",
-  });
-}
-
-const rateLimiter = createMembersRateLimiter();
-
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    if (rateLimiter) {
+    if (membersRateLimiter) {
       const forwarded = req.headers.get("x-forwarded-for");
       const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
-      const { success, remaining, reset } = await rateLimiter.limit(ip);
+      const { success, remaining, reset } = await membersRateLimiter.limit(ip);
 
       if (!success) {
         return NextResponse.json(
@@ -49,12 +28,12 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     await verifySession();
 
     const { id } = await params;
-    const memberId = parseInt(id, 10);
 
-    if (isNaN(memberId)) {
+    if (!/^\d+$/.test(id)) {
       throw new AppError("VALIDATION_ERROR", "Invalid member ID format");
     }
 
+    const memberId = parseInt(id, 10);
     const member = await getMemberById(memberId);
 
     if (!member) {

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,36 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Ratelimit } from "@upstash/ratelimit";
-import { Redis } from "@upstash/redis";
-import { env } from "@/env";
 import { verifySession } from "@/lib/dal";
+import { membersRateLimiter } from "@/lib/rate-limit";
 import { getAllMembers } from "@/lib/api/member-api";
 import { apiErrorHandler } from "@/utils/errors";
 
-function createMembersRateLimiter() {
-  if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
-    return null;
-  }
-
-  const redis = new Redis({
-    url: env.UPSTASH_REDIS_REST_URL,
-    token: env.UPSTASH_REDIS_REST_TOKEN,
-  });
-
-  return new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(10, "60 s"),
-    prefix: "prfc:members",
-  });
-}
-
-const rateLimiter = createMembersRateLimiter();
-
 export async function GET(req: NextRequest) {
   try {
-    if (rateLimiter) {
+    if (membersRateLimiter) {
       const forwarded = req.headers.get("x-forwarded-for");
       const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
-      const { success, remaining, reset } = await rateLimiter.limit(ip);
+      const { success, remaining, reset } = await membersRateLimiter.limit(ip);
 
       if (!success) {
         return NextResponse.json(

--- a/src/lib/api/member-api.ts
+++ b/src/lib/api/member-api.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { env } from "@/env";
+import { AppError } from "@/utils/errors";
 import type { MockMember } from "@/lib/mock-members";
 
 export interface MemberSummary {
@@ -17,7 +18,7 @@ async function getMockMemberDetails(memberIds: number[]): Promise<MockMember[]> 
 }
 
 async function getRealMemberDetails(_memberIds: number[]): Promise<MockMember[]> {
-  throw new Error("Member Portal API integration not yet implemented");
+  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
 }
 
 async function getMockAllActiveMemberIds(): Promise<number[]> {
@@ -26,7 +27,7 @@ async function getMockAllActiveMemberIds(): Promise<number[]> {
 }
 
 async function getRealAllActiveMemberIds(): Promise<number[]> {
-  throw new Error("Member Portal API integration not yet implemented");
+  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
 }
 
 async function getMockAllMembers(): Promise<MemberSummary[]> {
@@ -35,7 +36,7 @@ async function getMockAllMembers(): Promise<MemberSummary[]> {
 }
 
 async function getRealAllMembers(): Promise<MemberSummary[]> {
-  throw new Error("Member Portal API integration not yet implemented");
+  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
 }
 
 async function getMockMemberById(id: number): Promise<MockMember | null> {
@@ -44,7 +45,7 @@ async function getMockMemberById(id: number): Promise<MockMember | null> {
 }
 
 async function getRealMemberById(_id: number): Promise<MockMember | null> {
-  throw new Error("Member Portal API integration not yet implemented");
+  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
 }
 
 export async function getMemberDetails(memberIds: number[]): Promise<MockMember[]> {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -3,7 +3,13 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { env } from "@/env";
 
-function createRateLimiter() {
+type RateLimitConfig = {
+  prefix: string;
+  limit: number;
+  window: string;
+};
+
+export function createRateLimiter(config: RateLimitConfig) {
   if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
     return null;
   }
@@ -15,9 +21,11 @@ function createRateLimiter() {
 
   return new Ratelimit({
     redis,
-    limiter: Ratelimit.slidingWindow(5, "60 s"),
-    prefix: "prfc:referral",
+    limiter: Ratelimit.slidingWindow(config.limit, config.window as Parameters<typeof Ratelimit.slidingWindow>[1]),
+    prefix: config.prefix,
   });
 }
 
-export const rateLimiter = createRateLimiter();
+export const rateLimiter = createRateLimiter({ prefix: "prfc:referral", limit: 5, window: "60 s" });
+
+export const membersRateLimiter = createRateLimiter({ prefix: "prfc:members", limit: 10, window: "60 s" });


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

- Centralized rate limiter factory in `lib/rate-limit.ts`
- Added regex validation for member ID before parseInt
- Replaced raw Error throws with AppError in member-api stubs

## How to test

1. Run `npm run build` - should pass
2. Run `npm run lint` - should pass
3. Test `GET /api/members/100001abc` returns 400 validation error

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers