### PR TITLE
test: add email suppression service tests

### DIFF
--- a/test/mocks/email-suppressions.ts
+++ b/test/mocks/email-suppressions.ts
@@ -1,0 +1,24 @@
+import type { EmailSuppression } from "@/generated/prisma/client";
+
+export const suppressedLucy: EmailSuppression = {
+  id: 1,
+  email: "lucy@yahoo.com",
+  reason: "hard_bounce",
+  suppressedAt: new Date("2024-01-15"),
+};
+
+export const suppressedMarcie: EmailSuppression = {
+  id: 2,
+  email: "marcie@gmail.com",
+  reason: "complaint",
+  suppressedAt: new Date("2024-01-20"),
+};
+
+export const suppressedSally: EmailSuppression = {
+  id: 3,
+  email: "sally@icloud.com",
+  reason: "unsubscribe",
+  suppressedAt: new Date("2024-01-25"),
+};
+
+export const allSuppressions: EmailSuppression[] = [suppressedLucy, suppressedMarcie, suppressedSally];

--- a/test/services/email-suppression.test.ts
+++ b/test/services/email-suppression.test.ts
@@ -1,0 +1,108 @@
+import { prismaMock } from "../mocks/prisma";
+import { suppressedLucy, suppressedMarcie } from "../mocks/email-suppressions";
+import { isEmailSuppressed, suppressEmail, filterSuppressedEmails } from "@/services/email";
+
+describe("isEmailSuppressed", () => {
+  it("returns true when email exists in suppression list", async () => {
+    prismaMock.emailSuppression.findUnique.mockResolvedValue(suppressedLucy);
+
+    const result = await isEmailSuppressed("lucy@yahoo.com");
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when email not found", async () => {
+    prismaMock.emailSuppression.findUnique.mockResolvedValue(null);
+
+    const result = await isEmailSuppressed("charlie@test.com");
+
+    expect(result).toBe(false);
+  });
+
+  it("normalizes email to lowercase for lookup", async () => {
+    prismaMock.emailSuppression.findUnique.mockResolvedValue(suppressedLucy);
+
+    await isEmailSuppressed("LUCY@YAHOO.COM");
+
+    expect(prismaMock.emailSuppression.findUnique).toHaveBeenCalledWith({
+      where: { email: "lucy@yahoo.com" },
+    });
+  });
+});
+
+describe("suppressEmail", () => {
+  it("creates suppression record with reason", async () => {
+    prismaMock.emailSuppression.upsert.mockResolvedValue(suppressedLucy);
+
+    await suppressEmail("lucy@yahoo.com", "hard_bounce");
+
+    expect(prismaMock.emailSuppression.upsert).toHaveBeenCalledWith({
+      where: { email: "lucy@yahoo.com" },
+      update: { reason: "hard_bounce", suppressedAt: expect.any(Date) },
+      create: { email: "lucy@yahoo.com", reason: "hard_bounce" },
+    });
+  });
+
+  it("normalizes email to lowercase before storage", async () => {
+    prismaMock.emailSuppression.upsert.mockResolvedValue(suppressedLucy);
+
+    await suppressEmail("LUCY@YAHOO.COM", "complaint");
+
+    expect(prismaMock.emailSuppression.upsert).toHaveBeenCalledWith({
+      where: { email: "lucy@yahoo.com" },
+      update: { reason: "complaint", suppressedAt: expect.any(Date) },
+      create: { email: "lucy@yahoo.com", reason: "complaint" },
+    });
+  });
+});
+
+describe("filterSuppressedEmails", () => {
+  it("separates suppressed from valid emails", async () => {
+    prismaMock.emailSuppression.findMany.mockResolvedValue([suppressedLucy, suppressedMarcie]);
+
+    const result = await filterSuppressedEmails([
+      "charlie@test.com",
+      "lucy@yahoo.com",
+      "marcie@gmail.com",
+      "snoopy@test.com",
+    ]);
+
+    expect(result.valid).toEqual(["charlie@test.com", "snoopy@test.com"]);
+    expect(result.suppressed).toEqual(["lucy@yahoo.com", "marcie@gmail.com"]);
+  });
+
+  it("handles case-insensitive matching", async () => {
+    prismaMock.emailSuppression.findMany.mockResolvedValue([suppressedLucy]);
+
+    const result = await filterSuppressedEmails(["LUCY@YAHOO.COM", "charlie@test.com"]);
+
+    expect(result.valid).toEqual(["charlie@test.com"]);
+    expect(result.suppressed).toEqual(["LUCY@YAHOO.COM"]);
+  });
+
+  it("returns empty arrays for empty input", async () => {
+    prismaMock.emailSuppression.findMany.mockResolvedValue([]);
+
+    const result = await filterSuppressedEmails([]);
+
+    expect(result.valid).toEqual([]);
+    expect(result.suppressed).toEqual([]);
+  });
+
+  it("returns all emails as valid when none suppressed", async () => {
+    prismaMock.emailSuppression.findMany.mockResolvedValue([]);
+
+    const result = await filterSuppressedEmails(["charlie@test.com", "snoopy@test.com"]);
+
+    expect(result.valid).toEqual(["charlie@test.com", "snoopy@test.com"]);
+    expect(result.suppressed).toEqual([]);
+  });
+
+  it("throws on database error", async () => {
+    prismaMock.emailSuppression.findMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(filterSuppressedEmails(["test@test.com"])).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #59

## What changed?

Added reference implementation for Sprint 2 service-level tests demonstrating mock fixtures and Prisma mocking patterns.

## How to test

1. Run `npm test -- test/services/email-suppression.test.ts`
2. Verify 10 tests pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers