### PR TITLE
Add sendMessage and sendBlast to contact-group actions

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -161,12 +161,12 @@ export async function sendMessage(input: {
 }): Promise<ActionResult<MessageResult>> {
   try {
     const session = await verifySession();
-    const validated = ComposeMessageSchema.parse(input);
 
-    if (!session.isAdmin && !(await isGroupOwner(validated.groupId, session.ownerid))) {
+    if (!session.isAdmin && !(await isGroupOwner(input.groupId, session.ownerid))) {
       return { success: false, error: "You do not have permission to send messages to this group" };
     }
 
+    const validated = ComposeMessageSchema.parse(input);
     const result = await sendGroupMessage(validated, session.ownerid);
 
     return { success: true, data: result };

--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -7,6 +7,8 @@ import {
   UpdateContactGroupSchema,
   AddMembersSchema,
   UpdateNotificationSchema,
+  ComposeMessageSchema,
+  BlastMessageSchema,
 } from "@/schema/contact-group";
 import {
   createGroup,
@@ -17,8 +19,10 @@ import {
   removeMemberFromGroup,
   updateMemberNotifications,
 } from "@/services/contact-group";
+import { sendGroupMessage, sendBlastMessage } from "@/services/message";
 import { transformError } from "@/utils/errors";
 import type { ActionResult } from "@/lib/action-types";
+import type { MessageResult } from "@/services/message";
 
 export async function createContactGroup(formData: FormData): Promise<ActionResult<{ id: number }>> {
   try {
@@ -142,6 +146,54 @@ export async function updateNotifications(input: {
 
     revalidatePath(`/groups/${validated.groupId}`);
     return { success: true };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function sendMessage(input: {
+  groupId: number;
+  subject: string;
+  body: string;
+  sendEmail?: boolean;
+  sendSms?: boolean;
+}): Promise<ActionResult<MessageResult>> {
+  try {
+    const session = await verifySession();
+    const validated = ComposeMessageSchema.parse(input);
+
+    if (!session.isAdmin && !(await isGroupOwner(validated.groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to send messages to this group" };
+    }
+
+    const result = await sendGroupMessage(validated, session.ownerid);
+
+    return { success: true, data: result };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function sendBlast(input: {
+  subject: string;
+  body: string;
+  sendEmail?: boolean;
+  sendSms?: boolean;
+  confirmationText: "SEND TO ALL";
+}): Promise<ActionResult<MessageResult>> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin) {
+      return { success: false, error: "You do not have permission to send blast messages" };
+    }
+
+    const validated = BlastMessageSchema.parse(input);
+    const result = await sendBlastMessage(validated, session.ownerid);
+
+    return { success: true, data: result };
   } catch (error) {
     const appError = transformError(error);
     return { success: false, error: appError.message };

--- a/test/actions/contact-group.test.ts
+++ b/test/actions/contact-group.test.ts
@@ -364,6 +364,40 @@ describe("sendMessage", () => {
     expect(result.error).toContain("do not have permission");
     expect(mockSendGroupMessage).not.toHaveBeenCalled();
   });
+
+  it("returns validation error for invalid input", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+
+    const result = await sendMessage({
+      groupId: 3,
+      subject: "",
+      body: "Body text",
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(mockSendGroupMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns error when service throws", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+    mockSendGroupMessage.mockRejectedValue(new AppError("MESSAGE_SEND_FAILED", "Email delivery failed"));
+
+    const result = await sendMessage({
+      groupId: 3,
+      subject: "Hello",
+      body: "Body text",
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Email delivery failed");
+  });
 });
 
 describe("sendBlast", () => {
@@ -413,5 +447,37 @@ describe("sendBlast", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("do not have permission");
     expect(mockSendBlastMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns validation error for invalid confirmation text", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 99, isAdmin: true });
+
+    const result = await sendBlast({
+      subject: "Update",
+      body: "Blast body",
+      sendEmail: true,
+      sendSms: false,
+      confirmationText: "WRONG TEXT" as "SEND TO ALL",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(mockSendBlastMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns error when service throws", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 99, isAdmin: true });
+    mockSendBlastMessage.mockRejectedValue(new AppError("MESSAGE_SEND_FAILED", "Blast delivery failed"));
+
+    const result = await sendBlast({
+      subject: "Update",
+      body: "Blast body",
+      sendEmail: true,
+      sendSms: false,
+      confirmationText: "SEND TO ALL",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Blast delivery failed");
   });
 });

--- a/test/actions/contact-group.test.ts
+++ b/test/actions/contact-group.test.ts
@@ -1,0 +1,417 @@
+import { vi, type MockedFunction } from "vitest";
+import { AppError } from "@/utils/errors";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/dal", () => ({
+  verifySession: vi.fn(),
+}));
+
+vi.mock("@/services/contact-group", () => ({
+  createGroup: vi.fn(),
+  updateGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  isGroupOwner: vi.fn(),
+  addMembersToGroup: vi.fn(),
+  removeMemberFromGroup: vi.fn(),
+  updateMemberNotifications: vi.fn(),
+}));
+
+vi.mock("@/services/message", () => ({
+  sendGroupMessage: vi.fn(),
+  sendBlastMessage: vi.fn(),
+}));
+
+import { revalidatePath } from "next/cache";
+import { verifySession } from "@/lib/dal";
+import {
+  createGroup,
+  updateGroup,
+  deleteGroup,
+  isGroupOwner,
+  addMembersToGroup,
+  removeMemberFromGroup,
+  updateMemberNotifications,
+} from "@/services/contact-group";
+import { sendGroupMessage, sendBlastMessage } from "@/services/message";
+import {
+  createContactGroup,
+  updateContactGroup,
+  deleteContactGroup,
+  addMembers,
+  removeMember,
+  updateNotifications,
+  sendMessage,
+  sendBlast,
+} from "@/actions/contact-group";
+
+const mockRevalidatePath = revalidatePath as MockedFunction<typeof revalidatePath>;
+const mockVerifySession = verifySession as MockedFunction<typeof verifySession>;
+const mockCreateGroup = createGroup as MockedFunction<typeof createGroup>;
+const mockUpdateGroup = updateGroup as MockedFunction<typeof updateGroup>;
+const mockDeleteGroup = deleteGroup as MockedFunction<typeof deleteGroup>;
+const mockIsGroupOwner = isGroupOwner as MockedFunction<typeof isGroupOwner>;
+const mockAddMembersToGroup = addMembersToGroup as MockedFunction<typeof addMembersToGroup>;
+const mockRemoveMemberFromGroup = removeMemberFromGroup as MockedFunction<typeof removeMemberFromGroup>;
+const mockUpdateMemberNotifications = updateMemberNotifications as MockedFunction<typeof updateMemberNotifications>;
+const mockSendGroupMessage = sendGroupMessage as MockedFunction<typeof sendGroupMessage>;
+const mockSendBlastMessage = sendBlastMessage as MockedFunction<typeof sendBlastMessage>;
+
+function createFormData(data: Record<string, string>): FormData {
+  const formData = new FormData();
+  Object.entries(data).forEach(([key, value]) => formData.append(key, value));
+  return formData;
+}
+
+describe("createContactGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("verifies session, creates group, and revalidates", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockCreateGroup.mockResolvedValue({
+      id: 55,
+      name: "Neighbors",
+      description: "Local list",
+      ownerid: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const formData = createFormData({ name: "Neighbors", description: "Local list" });
+    const result = await createContactGroup(formData);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.id).toBe(55);
+    expect(mockVerifySession).toHaveBeenCalled();
+    expect(mockCreateGroup).toHaveBeenCalledWith({ name: "Neighbors", description: "Local list" }, 10);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups");
+  });
+
+  it("returns validation error when data is invalid", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+
+    const formData = createFormData({ name: "", description: "Local list" });
+    const result = await createContactGroup(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(mockCreateGroup).not.toHaveBeenCalled();
+  });
+
+  it("returns error when session verification fails", async () => {
+    mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
+
+    const formData = createFormData({ name: "Neighbors", description: "Local list" });
+    const result = await createContactGroup(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Authentication required");
+  });
+});
+
+describe("updateContactGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows owner to update group", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+    mockUpdateGroup.mockResolvedValue({
+      id: 5,
+      name: "Updated",
+      description: "Updated desc",
+      ownerid: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const formData = createFormData({ name: "Updated", description: "Updated desc" });
+    const result = await updateContactGroup(5, formData);
+
+    expect(result.success).toBe(true);
+    expect(mockUpdateGroup).toHaveBeenCalledWith(5, { name: "Updated", description: "Updated desc" });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups/5");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups");
+  });
+
+  it("allows admin to update group without owner check", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 99, isAdmin: true });
+    mockUpdateGroup.mockResolvedValue({
+      id: 5,
+      name: "Admin Updated",
+      description: null,
+      ownerid: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const formData = createFormData({ name: "Admin Updated", description: "" });
+    const result = await updateContactGroup(5, formData);
+
+    expect(result.success).toBe(true);
+    expect(mockIsGroupOwner).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-owner non-admin updates", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const formData = createFormData({ name: "Blocked", description: "Nope" });
+    const result = await updateContactGroup(5, formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockUpdateGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteContactGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows owner to delete group", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+
+    const result = await deleteContactGroup(7);
+
+    expect(result.success).toBe(true);
+    expect(mockDeleteGroup).toHaveBeenCalledWith(7);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups");
+  });
+
+  it("rejects non-owner non-admin deletes", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await deleteContactGroup(7);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockDeleteGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe("addMembers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds members when authorized", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+    mockAddMembersToGroup.mockResolvedValue({ count: 2 });
+
+    const input = {
+      groupId: 3,
+      members: [
+        { memberId: 101, notifyEmail: true, notifySms: false },
+        { memberId: 102, notifyEmail: true, notifySms: true },
+      ],
+    };
+    const result = await addMembers(input);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.count).toBe(2);
+    expect(mockAddMembersToGroup).toHaveBeenCalledWith(3, input.members, 10);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups/3");
+  });
+
+  it("rejects non-owner non-admin adds", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await addMembers({
+      groupId: 3,
+      members: [{ memberId: 101, notifyEmail: true, notifySms: false }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockAddMembersToGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe("removeMember", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes member when authorized", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+
+    const result = await removeMember(3, 101);
+
+    expect(result.success).toBe(true);
+    expect(mockRemoveMemberFromGroup).toHaveBeenCalledWith(3, 101);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups/3");
+  });
+
+  it("rejects non-owner non-admin removes", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await removeMember(3, 101);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockRemoveMemberFromGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates notification preferences when authorized", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+
+    const result = await updateNotifications({
+      groupId: 3,
+      memberId: 101,
+      notifyEmail: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockUpdateMemberNotifications).toHaveBeenCalledWith(3, 101, { notifyEmail: false, notifySms: undefined });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/groups/3");
+  });
+
+  it("returns validation error when no preferences provided", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+
+    const result = await updateNotifications({ groupId: 3, memberId: 101 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("At least one notification preference");
+    expect(mockUpdateMemberNotifications).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const messageResult = { messageId: 22, emailCount: 3, smsCount: 0, failedCount: 0 };
+
+  it("allows owner to send group message", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+    mockSendGroupMessage.mockResolvedValue(messageResult);
+
+    const result = await sendMessage({
+      groupId: 3,
+      subject: "Hello",
+      body: "Body text",
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(messageResult);
+    expect(mockSendGroupMessage).toHaveBeenCalledWith(
+      {
+        groupId: 3,
+        subject: "Hello",
+        body: "Body text",
+        sendEmail: true,
+        sendSms: false,
+      },
+      10,
+    );
+  });
+
+  it("allows admin to send group message", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 99, isAdmin: true });
+    mockSendGroupMessage.mockResolvedValue(messageResult);
+
+    const result = await sendMessage({
+      groupId: 3,
+      subject: "Admin",
+      body: "Admin body",
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockIsGroupOwner).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-owner non-admin sends", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await sendMessage({
+      groupId: 3,
+      subject: "Nope",
+      body: "Body text",
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockSendGroupMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendBlast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const messageResult = { messageId: 33, emailCount: 10, smsCount: 0, failedCount: 0 };
+
+  it("allows admin to send blast message", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 99, isAdmin: true });
+    mockSendBlastMessage.mockResolvedValue(messageResult);
+
+    const result = await sendBlast({
+      subject: "Update",
+      body: "Blast body",
+      sendEmail: true,
+      sendSms: false,
+      confirmationText: "SEND TO ALL",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(messageResult);
+    expect(mockSendBlastMessage).toHaveBeenCalledWith(
+      {
+        subject: "Update",
+        body: "Blast body",
+        sendEmail: true,
+        sendSms: false,
+        confirmationText: "SEND TO ALL",
+      },
+      99,
+    );
+  });
+
+  it("rejects non-admin blast sends", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+
+    const result = await sendBlast({
+      subject: "Update",
+      body: "Blast body",
+      sendEmail: true,
+      sendSms: false,
+      confirmationText: "SEND TO ALL",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockSendBlastMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Developer

Snehil Kakani

Closes #61 

## What changed?

Added missing server actions in contact-group.ts
- sendMessage for group messages (owner/admin allowed)
- sendBlast for blast messages (admin only)

## How to test

{Steps for reviewers to verify your changes work}

1. Run contact-group.test.ts
2. Confirm owner/admin can call sendMessage and non-owner is rejected
3. Confirm only admin can call sendBlast

## Screenshots

## Checklist

- [ ] Code works and is readable
- [ ] Tested locally
- [ ] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] Assigned reviewers
