### PR TITLE
feat: add logout, getSession, and auth flow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The PRFC Connect team consists of 18 Cal Poly students. Over the course of about
 - [Anney Haong](https://www.linkedin.com/in/anneyhaong/) - Designer
 - [Kyle Lin](https://www.linkedin.com/in/kyle-lin-584235295/) - Software Developer
 - [Snehil Kakani](https://www.linkedin.com/in/snehilkakani/) - Software Developer
-- [First Last](https://www.linkedin.com/in/your-profile/) - Software Developer
 - [Ethan Ma](https://www.linkedin.com/in/ethan-ma-389568319/) - Software Developer
 - [Saurish Suman](https://www.linkedin.com/in/saurish-suman/) - Software Developer
 - [Karson Chen](https://www.linkedin.com/in/karson-chen-3b989a27a) - Software Developer

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { AUTH_COOKIE } from "@/lib/dal";
+
+export async function logout() {
+  const cookieStore = await cookies();
+  cookieStore.delete(AUTH_COOKIE);
+  redirect("/");
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AUTH_COOKIE } from "@/lib/dal";
+
+export async function POST(req: NextRequest) {
+  const response = NextResponse.redirect(new URL("/", req.url));
+  response.cookies.delete(AUTH_COOKIE);
+  return response;
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -70,6 +70,17 @@ export const verifySession = cache(async (): Promise<Session> => {
   return session;
 });
 
+export const getSession = cache(async (): Promise<Session | null> => {
+  const cookieStore = await cookies();
+  const authCookie = cookieStore.get(AUTH_COOKIE);
+
+  if (!authCookie?.value) {
+    return null;
+  }
+
+  return validateToken(authCookie.value, getSecret());
+});
+
 export async function requireAdmin(): Promise<Session> {
   const session = await verifySession();
   if (!session.isAdmin) {

--- a/test/actions/referral.test.ts
+++ b/test/actions/referral.test.ts
@@ -1,21 +1,11 @@
-import { vi, type MockedFunction } from "vitest";
-import { prismaMock } from "../mocks/prisma";
+import "../mocks/next-cache";
+import "../mocks/dal";
 import "../mocks/email";
+import { prismaMock, mockRequireAdmin } from "../mocks";
 import { referralCharlie, formWithTwoProspects } from "../mocks/referrals";
 import { AppError } from "@/utils/errors";
 
-vi.mock("next/cache", () => ({
-  revalidatePath: vi.fn(),
-}));
-
-vi.mock("@/lib/dal", () => ({
-  requireAdmin: vi.fn(),
-}));
-
 import { submitReferrals, toggleRedeemed } from "@/actions/referral";
-import { requireAdmin } from "@/lib/dal";
-
-const mockRequireAdmin = requireAdmin as MockedFunction<typeof requireAdmin>;
 
 function createFormData(data: Record<string, string>): FormData {
   const formData = new FormData();

--- a/test/api/referral-route.test.ts
+++ b/test/api/referral-route.test.ts
@@ -1,8 +1,8 @@
-import { vi, type MockedFunction } from "vitest";
 import "../mocks/email";
 import "../mocks/rate-limit";
 import "../mocks/idempotency";
 import "../mocks/csrf";
+import "../mocks/dal";
 import {
   prismaMock,
   createMockRequest,
@@ -13,17 +13,10 @@ import {
   rateLimiterMock,
   mockGetIdempotentResponse,
   mockValidateOrigin,
+  mockRequireAdmin,
 } from "../mocks";
 import { GET, POST } from "@/app/api/referral/route";
 import { AppError } from "@/utils/errors";
-
-vi.mock("@/lib/dal", () => ({
-  requireAdmin: vi.fn(),
-}));
-
-import { requireAdmin } from "@/lib/dal";
-
-const mockRequireAdmin = requireAdmin as MockedFunction<typeof requireAdmin>;
 
 describe("GET /api/referral", () => {
   beforeEach(() => {

--- a/test/auth/auth-flow.test.ts
+++ b/test/auth/auth-flow.test.ts
@@ -1,0 +1,249 @@
+import { vi, type MockedFunction } from "vitest";
+import { createHmac } from "crypto";
+
+const { mockCookieStore } = vi.hoisted(() => ({
+  mockCookieStore: {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue(mockCookieStore),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+// Make React cache() a passthrough so tests get fresh results
+vi.mock("react", async () => {
+  const actual = await vi.importActual("react");
+  return { ...actual, cache: (fn: unknown) => fn };
+});
+
+import { redirect } from "next/navigation";
+import { validateToken, generateToken, getSecret, verifySession, getSession, AUTH_COOKIE } from "@/lib/dal";
+import { POST as callbackPOST } from "@/app/api/auth/callback/route";
+import { POST as logoutPOST } from "@/app/api/auth/logout/route";
+import { logout } from "@/actions/auth";
+import { NextRequest } from "next/server";
+
+const mockRedirect = redirect as MockedFunction<typeof redirect>;
+
+const SECRET = getSecret();
+
+function createToken(ownerid: number, isAdmin: boolean, timestamp: number): string {
+  const payload = `${ownerid}|${isAdmin ? "1" : "0"}|${timestamp}`;
+  const signature = createHmac("sha256", SECRET).update(payload).digest("hex").slice(0, 8);
+  return `${payload}|${signature}`;
+}
+
+describe("validateToken", () => {
+  it("returns session for valid admin token", () => {
+    const token = createToken(100001, true, Date.now());
+    const session = validateToken(token, SECRET);
+
+    expect(session).toEqual({ ownerid: 100001, isAdmin: true });
+  });
+
+  it("returns session for valid member token", () => {
+    const token = createToken(100050, false, Date.now());
+    const session = validateToken(token, SECRET);
+
+    expect(session).toEqual({ ownerid: 100050, isAdmin: false });
+  });
+
+  it("rejects tampered ownerid", () => {
+    const token = createToken(100001, true, Date.now());
+    const parts = token.split("|");
+    parts[0] = "999999";
+    const tampered = parts.join("|");
+
+    expect(validateToken(tampered, SECRET)).toBeNull();
+  });
+
+  it("rejects tampered isAdmin flag", () => {
+    const token = createToken(100001, false, Date.now());
+    const parts = token.split("|");
+    parts[1] = "1";
+    const tampered = parts.join("|");
+
+    expect(validateToken(tampered, SECRET)).toBeNull();
+  });
+
+  it("rejects expired token", () => {
+    const expiredTimestamp = Date.now() - 3_600_001;
+    const token = createToken(100001, true, expiredTimestamp);
+
+    expect(validateToken(token, SECRET)).toBeNull();
+  });
+
+  it("rejects token with wrong secret", () => {
+    const token = createToken(100001, true, Date.now());
+
+    expect(validateToken(token, "wrong-secret-that-is-long-enough")).toBeNull();
+  });
+
+  it("rejects malformed token with missing parts", () => {
+    expect(validateToken("only|two", SECRET)).toBeNull();
+  });
+
+  it("rejects token with empty fields", () => {
+    expect(validateToken("||1234|abcd1234", SECRET)).toBeNull();
+  });
+});
+
+describe("POST /api/auth/callback", () => {
+  it("sets auth cookie for valid token", async () => {
+    const token = generateToken(100001, true);
+    const formData = new FormData();
+    formData.set("token", token);
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await callbackPOST(request);
+    const cookie = response.cookies.get(AUTH_COOKIE);
+
+    expect(response.status).toBe(307);
+    expect(cookie).toBeDefined();
+    expect(cookie!.value).toBe(token);
+    expect(cookie!.httpOnly).toBe(true);
+    expect(cookie!.sameSite).toBe("lax");
+    expect(cookie!.path).toBe("/");
+  });
+
+  it("redirects without cookie for invalid token", async () => {
+    const formData = new FormData();
+    formData.set("token", "invalid|token|data|badhash!");
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await callbackPOST(request);
+    const cookie = response.cookies.get(AUTH_COOKIE);
+
+    expect(response.status).toBe(307);
+    expect(cookie).toBeUndefined();
+  });
+
+  it("redirects without cookie when token is missing", async () => {
+    const formData = new FormData();
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await callbackPOST(request);
+    const cookie = response.cookies.get(AUTH_COOKIE);
+
+    expect(response.status).toBe(307);
+    expect(cookie).toBeUndefined();
+  });
+});
+
+describe("POST /api/auth/logout", () => {
+  it("clears session cookie", async () => {
+    const request = new NextRequest("http://localhost:3000/api/auth/logout", {
+      method: "POST",
+    });
+
+    const response = await logoutPOST(request);
+    const setCookies = response.headers.getSetCookie();
+
+    expect(response.status).toBe(307);
+    expect(setCookies.some((c) => c.includes(AUTH_COOKIE) && c.includes("Expires=Thu, 01 Jan 1970"))).toBe(true);
+  });
+});
+
+describe("logout server action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes cookie and redirects", async () => {
+    await logout().catch(() => {});
+
+    expect(mockCookieStore.delete).toHaveBeenCalledWith(AUTH_COOKIE);
+    expect(mockRedirect).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("verifySession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns session for valid cookie", async () => {
+    const token = generateToken(100001, true);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: token });
+
+    const session = await verifySession();
+
+    expect(session).toEqual({ ownerid: 100001, isAdmin: true });
+  });
+
+  it("throws UNAUTHORIZED for missing cookie", async () => {
+    mockCookieStore.get.mockReturnValue(undefined);
+
+    await expect(verifySession()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("throws UNAUTHORIZED for expired token", async () => {
+    const expiredToken = createToken(100001, true, Date.now() - 3_600_001);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: expiredToken });
+
+    await expect(verifySession()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+});
+
+describe("getSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns session for valid cookie", async () => {
+    const token = generateToken(100001, false);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: token });
+
+    const session = await getSession();
+
+    expect(session).toEqual({ ownerid: 100001, isAdmin: false });
+  });
+
+  it("returns null for missing cookie", async () => {
+    mockCookieStore.get.mockReturnValue(undefined);
+
+    const session = await getSession();
+
+    expect(session).toBeNull();
+  });
+
+  it("returns null for invalid token", async () => {
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: "garbage" });
+
+    const session = await getSession();
+
+    expect(session).toBeNull();
+  });
+
+  it("returns null for expired token", async () => {
+    const expiredToken = createToken(100001, true, Date.now() - 3_600_001);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: expiredToken });
+
+    const session = await getSession();
+
+    expect(session).toBeNull();
+  });
+});

--- a/test/mocks/dal.ts
+++ b/test/mocks/dal.ts
@@ -1,0 +1,16 @@
+import { vi } from "vitest";
+
+const mockVerifySession = vi.fn();
+const mockRequireAdmin = vi.fn();
+
+vi.mock("@/lib/dal", () => ({
+  verifySession: mockVerifySession,
+  requireAdmin: mockRequireAdmin,
+}));
+
+beforeEach(() => {
+  mockVerifySession.mockReset();
+  mockRequireAdmin.mockReset();
+});
+
+export { mockVerifySession, mockRequireAdmin };

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -5,3 +5,5 @@ export { emailTransportMock } from "./email";
 export { rateLimiterMock } from "./rate-limit";
 export { mockGetIdempotentResponse, mockSetIdempotentResponse } from "./idempotency";
 export { mockValidateOrigin } from "./csrf";
+export { mockVerifySession, mockRequireAdmin } from "./dal";
+export { mockRevalidatePath } from "./next-cache";

--- a/test/mocks/next-cache.ts
+++ b/test/mocks/next-cache.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+
+const mockRevalidatePath = vi.fn();
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+beforeEach(() => {
+  mockRevalidatePath.mockClear();
+});
+
+export { mockRevalidatePath };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -18,6 +18,7 @@ export default defineConfig({
       ["test/actions/**", "node"],
       ["test/api/**", "node"],
       ["test/utils/errors.test.ts", "node"],
+      ["test/auth/**", "node"],
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #67

## What changed?

Added logout route, logout server action, getSession utility, 20-test auth flow suite, and extracted dal/next-cache mocks into shared mock files.

## How to test

1. Run `npm run test` and verify all 128 tests pass
2. Run `npm run build` and verify it compiles
3. Check `test/auth/auth-flow.test.ts` covers all acceptance criteria from #67

## Screenshots

N/A

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers