### PR TITLE
test: add unit tests for contact group service

### DIFF
--- a/test/mocks/contact-groups.ts
+++ b/test/mocks/contact-groups.ts
@@ -1,0 +1,54 @@
+import type { ContactGroup, ContactGroupMember } from "@/generated/prisma/client";
+
+export const groupAlpha: ContactGroup = {
+  id: 1,
+  createdAt: new Date("2024-06-01T10:00:00Z"),
+  updatedAt: new Date("2024-06-01T10:00:00Z"),
+  name: "Alpha Group",
+  description: "First test group",
+  ownerid: 100,
+};
+
+export const groupBravo: ContactGroup = {
+  id: 2,
+  createdAt: new Date("2024-06-02T12:00:00Z"),
+  updatedAt: new Date("2024-06-02T12:00:00Z"),
+  name: "Bravo Group",
+  description: "Second test group",
+  ownerid: 100,
+};
+
+export const groupCharlie: ContactGroup = {
+  id: 3,
+  createdAt: new Date("2024-06-03T08:00:00Z"),
+  updatedAt: new Date("2024-06-03T08:00:00Z"),
+  name: "Charlie Group",
+  description: null,
+  ownerid: 200,
+};
+
+export const allGroups: ContactGroup[] = [groupAlpha, groupBravo, groupCharlie];
+
+export const memberAlice: ContactGroupMember = {
+  id: 1,
+  groupId: 1,
+  memberId: 10,
+  notifyEmail: true,
+  notifySms: false,
+  addedAt: new Date("2024-06-05T09:00:00Z"),
+  addedBy: 100,
+  unsubscribedAt: null,
+  unsubscribeMethod: null,
+};
+
+export const memberBob: ContactGroupMember = {
+  id: 2,
+  groupId: 1,
+  memberId: 20,
+  notifyEmail: false,
+  notifySms: true,
+  addedAt: new Date("2024-06-05T10:00:00Z"),
+  addedBy: 100,
+  unsubscribedAt: null,
+  unsubscribeMethod: null,
+};

--- a/test/services/contact-group.test.ts
+++ b/test/services/contact-group.test.ts
@@ -1,195 +1,240 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { prismaMock } from "../mocks/prisma";
+import { groupAlpha, groupBravo, memberAlice } from "../mocks/contact-groups";
+import {
+  getGroupsByOwner,
+  getAllGroups,
+  getGroupById,
+  isGroupOwner,
+  createGroup,
+  updateGroup,
+  deleteGroup,
+  addMemberToGroup,
+  addMembersToGroup,
+  removeMemberFromGroup,
+  updateMemberNotifications,
+  getGroupRecipients,
+} from "@/services/contact-group";
 
-import { describe, it, expect } from 'vitest';
-import { prismaMock } from '../mocks/prisma';
-import { AppError } from '@/utils/errors';
-import * as ContactGroupService from '../../src/services/contact-group';
+describe("getGroupsByOwner", () => {
+  it("returns groups with member count", async () => {
+    const mockGroups = [
+      { ...groupAlpha, _count: { members: 5 } },
+      { ...groupBravo, _count: { members: 3 } },
+    ];
+    prismaMock.contactGroup.findMany.mockResolvedValue(mockGroups as never);
 
-describe('Contact Group Service', () => {
+    const result = await getGroupsByOwner(100);
 
-  describe('getGroupsByOwner()', () => {
-    it('returns groups with member count', async () => {
-      const mockGroups = [
-        { id: 1, name: 'Group 1', ownerid: 100, _count: { members: 5 } }
-      ];
-      prismaMock.contactGroup.findMany.mockResolvedValue(mockGroups as any);
-
-      const result = await ContactGroupService.getGroupsByOwner(100);
-
-      expect(prismaMock.contactGroup.findMany).toHaveBeenCalledWith({
-        where: { ownerid: 100 },
-        include: { _count: { select: { members: true } } },
-        orderBy: { createdAt: "desc" },
-      });
-      expect(result[0].memberCount).toBe(5);
+    expect(prismaMock.contactGroup.findMany).toHaveBeenCalledWith({
+      where: { ownerid: 100 },
+      include: { _count: { select: { members: true } } },
+      orderBy: { createdAt: "desc" },
     });
+    expect(result).toHaveLength(2);
+    expect(result[0].memberCount).toBe(5);
+    expect(result[1].memberCount).toBe(3);
+  });
 
-    it('transforms Prisma errors correctly', async () => {
-      prismaMock.contactGroup.findMany.mockRejectedValue(new Error('Database down'));
-      await expect(ContactGroupService.getGroupsByOwner(100)).rejects.toThrow();
+  it("throws INTERNAL_ERROR on database failure", async () => {
+    prismaMock.contactGroup.findMany.mockRejectedValue(new Error("Database down"));
+
+    await expect(getGroupsByOwner(100)).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+  });
+});
+
+describe("getAllGroups", () => {
+  it("returns all groups with member counts", async () => {
+    const mockGroups = [
+      { ...groupAlpha, _count: { members: 2 } },
+      { ...groupBravo, _count: { members: 0 } },
+    ];
+    prismaMock.contactGroup.findMany.mockResolvedValue(mockGroups as never);
+
+    const result = await getAllGroups();
+
+    expect(prismaMock.contactGroup.findMany).toHaveBeenCalledWith({
+      include: { _count: { select: { members: true } } },
+      orderBy: { createdAt: "desc" },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].memberCount).toBe(2);
+    expect(result[1].memberCount).toBe(0);
+  });
+});
+
+describe("getGroupById", () => {
+  it("returns group with members and count", async () => {
+    const mockGroup = { ...groupAlpha, members: [memberAlice], _count: { members: 1 } };
+    prismaMock.contactGroup.findUnique.mockResolvedValue(mockGroup as never);
+
+    const result = await getGroupById(1);
+
+    expect(result.id).toBe(1);
+    expect(result.members).toHaveLength(1);
+    expect(result.memberCount).toBe(1);
+  });
+
+  it("throws NOT_FOUND when group does not exist", async () => {
+    prismaMock.contactGroup.findUnique.mockResolvedValue(null);
+
+    await expect(getGroupById(999)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});
+
+describe("isGroupOwner", () => {
+  it("returns true if group exists for owner", async () => {
+    prismaMock.contactGroup.findFirst.mockResolvedValue(groupAlpha as never);
+
+    const result = await isGroupOwner(1, 100);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false if group does not exist for owner", async () => {
+    prismaMock.contactGroup.findFirst.mockResolvedValue(null);
+
+    const result = await isGroupOwner(1, 999);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("createGroup", () => {
+  it("assigns owner during creation", async () => {
+    const input = { name: "New Group", description: "Test" };
+    prismaMock.contactGroup.create.mockResolvedValue({ ...groupAlpha, ...input } as never);
+
+    const result = await createGroup(input, 100);
+
+    expect(prismaMock.contactGroup.create).toHaveBeenCalledWith({
+      data: { name: "New Group", description: "Test", ownerid: 100 },
+    });
+    expect(result.ownerid).toBe(100);
+  });
+});
+
+describe("updateGroup", () => {
+  it("applies partial update", async () => {
+    const updateData = { name: "Updated Name" };
+    prismaMock.contactGroup.update.mockResolvedValue({ ...groupAlpha, ...updateData } as never);
+
+    await updateGroup(1, updateData);
+
+    expect(prismaMock.contactGroup.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: updateData,
+    });
+  });
+});
+
+describe("deleteGroup", () => {
+  it("deletes existing group", async () => {
+    prismaMock.contactGroup.delete.mockResolvedValue(groupAlpha as never);
+
+    await deleteGroup(1);
+
+    expect(prismaMock.contactGroup.delete).toHaveBeenCalledWith({
+      where: { id: 1 },
+    });
+  });
+});
+
+describe("addMemberToGroup", () => {
+  it("adds member with explicit preferences", async () => {
+    prismaMock.contactGroupMember.create.mockResolvedValue(memberAlice as never);
+
+    await addMemberToGroup(1, 10, 100, { notifyEmail: true, notifySms: false });
+
+    expect(prismaMock.contactGroupMember.create).toHaveBeenCalledWith({
+      data: { groupId: 1, memberId: 10, addedBy: 100, notifyEmail: true, notifySms: false },
     });
   });
 
-  describe('getAllGroups()', () => {
-    it('admin view, returns all groups', async () => {
-      const mockGroups = [{ id: 1, _count: { members: 2 } }];
-      prismaMock.contactGroup.findMany.mockResolvedValue(mockGroups as any);
+  it("defaults to email enabled and sms disabled when no preferences given", async () => {
+    prismaMock.contactGroupMember.create.mockResolvedValue(memberAlice as never);
 
-      const result = await ContactGroupService.getAllGroups();
+    await addMemberToGroup(1, 10, 100);
 
-      expect(prismaMock.contactGroup.findMany).toHaveBeenCalledWith(expect.not.objectContaining({ where: expect.anything() }));
-      expect(result[0].memberCount).toBe(2);
+    expect(prismaMock.contactGroupMember.create).toHaveBeenCalledWith({
+      data: { groupId: 1, memberId: 10, addedBy: 100, notifyEmail: true, notifySms: false },
     });
   });
+});
 
-  describe('getGroupById()', () => {
-    it('found case: returns group with members and count', async () => {
-      const mockGroup = { id: 1, members: [], _count: { members: 0 } };
-      prismaMock.contactGroup.findUnique.mockResolvedValue(mockGroup as any);
+describe("addMembersToGroup", () => {
+  it("bulk adds members and skips duplicates", async () => {
+    prismaMock.contactGroupMember.createMany.mockResolvedValue({ count: 2 });
 
-      const result = await ContactGroupService.getGroupById(1);
+    const members = [
+      { memberId: 10, notifyEmail: true, notifySms: false },
+      { memberId: 20, notifyEmail: false, notifySms: true },
+    ];
 
-      expect(result.id).toBe(1);
-      expect(result.memberCount).toBe(0);
+    const result = await addMembersToGroup(1, members, 100);
+
+    expect(prismaMock.contactGroupMember.createMany).toHaveBeenCalledWith({
+      data: [
+        { groupId: 1, memberId: 10, addedBy: 100, notifyEmail: true, notifySms: false },
+        { groupId: 1, memberId: 20, addedBy: 100, notifyEmail: false, notifySms: true },
+      ],
+      skipDuplicates: true,
     });
+    expect(result.count).toBe(2);
+  });
+});
 
-    it('not found case: throws NOT_FOUND AppError', async () => {
-      prismaMock.contactGroup.findUnique.mockResolvedValue(null);
+describe("removeMemberFromGroup", () => {
+  it("removes member by composite key", async () => {
+    prismaMock.contactGroupMember.delete.mockResolvedValue(memberAlice as never);
 
-      await expect(ContactGroupService.getGroupById(999)).rejects.toThrowError(AppError);
-      await expect(ContactGroupService.getGroupById(999)).rejects.toThrow('Group with id 999 not found');
+    await removeMemberFromGroup(1, 10);
+
+    expect(prismaMock.contactGroupMember.delete).toHaveBeenCalledWith({
+      where: { groupId_memberId: { groupId: 1, memberId: 10 } },
     });
   });
+});
 
-  describe('isGroupOwner()', () => {
-    it('returns true if group exists for owner', async () => {
-      prismaMock.contactGroup.findFirst.mockResolvedValue({ id: 1 } as any);
-      const result = await ContactGroupService.isGroupOwner(1, 100);
-      expect(result).toBe(true);
-    });
+describe("updateMemberNotifications", () => {
+  it("updates notification preferences", async () => {
+    const prefs = { notifyEmail: false, notifySms: true };
+    prismaMock.contactGroupMember.update.mockResolvedValue({ ...memberAlice, ...prefs } as never);
 
-    it('returns false if group does not exist for owner', async () => {
-      prismaMock.contactGroup.findFirst.mockResolvedValue(null);
-      const result = await ContactGroupService.isGroupOwner(1, 100);
-      expect(result).toBe(false);
-    });
-  });
+    await updateMemberNotifications(1, 10, prefs);
 
-  describe('createGroup()', () => {
-    it('validates owner assignment during creation', async () => {
-      const mockData = { name: 'New Group', description: 'Test' };
-      prismaMock.contactGroup.create.mockResolvedValue({ id: 1, ...mockData, ownerid: 100 } as any);
-
-      const result = await ContactGroupService.createGroup(mockData, 100);
-
-      expect(prismaMock.contactGroup.create).toHaveBeenCalledWith({
-        data: { name: 'New Group', description: 'Test', ownerid: 100 },
-      });
-      expect(result.ownerid).toBe(100);
+    expect(prismaMock.contactGroupMember.update).toHaveBeenCalledWith({
+      where: { groupId_memberId: { groupId: 1, memberId: 10 } },
+      data: prefs,
     });
   });
+});
 
-  describe('updateGroup()', () => {
-    it('partial updates work', async () => {
-      const updateData = { name: 'Updated Name' };
-      prismaMock.contactGroup.update.mockResolvedValue({ id: 1, name: 'Updated Name' } as any);
+describe("getGroupRecipients", () => {
+  it("filters by email channel", async () => {
+    prismaMock.contactGroupMember.findMany.mockResolvedValue([{ memberId: 10 }, { memberId: 20 }] as never);
 
-      await ContactGroupService.updateGroup(1, updateData);
+    const result = await getGroupRecipients(1, "email");
 
-      expect(prismaMock.contactGroup.update).toHaveBeenCalledWith({
-        where: { id: 1 },
-        data: updateData,
-      });
+    expect(prismaMock.contactGroupMember.findMany).toHaveBeenCalledWith({
+      where: { groupId: 1, notifyEmail: true },
+      select: { memberId: true },
     });
+    expect(result).toEqual([10, 20]);
   });
 
-  describe('deleteGroup()', () => {
-    it('calls delete on the group (cascade delete handled by DB)', async () => {
-      prismaMock.contactGroup.delete.mockResolvedValue({ id: 1 } as any);
-      await ContactGroupService.deleteGroup(1);
-      expect(prismaMock.contactGroup.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  it("filters by sms channel", async () => {
+    prismaMock.contactGroupMember.findMany.mockResolvedValue([{ memberId: 20 }] as never);
+
+    const result = await getGroupRecipients(1, "sms");
+
+    expect(prismaMock.contactGroupMember.findMany).toHaveBeenCalledWith({
+      where: { groupId: 1, notifySms: true },
+      select: { memberId: true },
     });
+    expect(result).toEqual([20]);
   });
-
-  describe('addMemberToGroup()', () => {
-    it('adds a single member with notification preferences', async () => {
-      prismaMock.contactGroupMember.create.mockResolvedValue({ groupId: 1, memberId: 2 } as any);
-      
-      await ContactGroupService.addMemberToGroup(1, 2, 100, { notifyEmail: true, notifySms: false });
-
-      expect(prismaMock.contactGroupMember.create).toHaveBeenCalledWith({
-        data: { groupId: 1, memberId: 2, addedBy: 100, notifyEmail: true, notifySms: false },
-      });
-    });
-  });
-
-  describe('addMembersToGroup()', () => {
-    it('bulk adds members and skips duplicates', async () => {
-      prismaMock.contactGroupMember.createMany.mockResolvedValue({ count: 2 });
-      
-      const members = [
-        { memberId: 2, notifyEmail: true, notifySms: false },
-        { memberId: 3, notifyEmail: false, notifySms: true }
-      ];
-
-      const result = await ContactGroupService.addMembersToGroup(1, members, 100);
-
-      expect(prismaMock.contactGroupMember.createMany).toHaveBeenCalledWith({
-        data: expect.any(Array),
-        skipDuplicates: true, // Specifically tests the acceptance criteria
-      });
-      expect(result.count).toBe(2);
-    });
-  });
-
-  describe('removeMemberFromGroup()', () => {
-    it('removes a specific member', async () => {
-      prismaMock.contactGroupMember.delete.mockResolvedValue({} as any);
-      await ContactGroupService.removeMemberFromGroup(1, 2);
-      expect(prismaMock.contactGroupMember.delete).toHaveBeenCalledWith({
-        where: { groupId_memberId: { groupId: 1, memberId: 2 } },
-      });
-    });
-  });
-
-  describe('updateMemberNotifications()', () => {
-    it('toggles email/SMS preferences', async () => {
-      const prefs = { notifyEmail: false, notifySms: true };
-      prismaMock.contactGroupMember.update.mockResolvedValue({} as any);
-      
-      await ContactGroupService.updateMemberNotifications(1, 2, prefs);
-
-      expect(prismaMock.contactGroupMember.update).toHaveBeenCalledWith({
-        where: { groupId_memberId: { groupId: 1, memberId: 2 } },
-        data: prefs,
-      });
-    });
-  });
-
-  describe('getGroupRecipients()', () => {
-    it('filters by email channel', async () => {
-      prismaMock.contactGroupMember.findMany.mockResolvedValue([{ memberId: 5 }, { memberId: 6 }] as any);
-      
-      const result = await ContactGroupService.getGroupRecipients(1, 'email');
-
-      expect(prismaMock.contactGroupMember.findMany).toHaveBeenCalledWith({
-        where: { groupId: 1, notifyEmail: true },
-        select: { memberId: true },
-      });
-      expect(result).toEqual([5, 6]);
-    });
-
-    it('filters by sms channel', async () => {
-      prismaMock.contactGroupMember.findMany.mockResolvedValue([{ memberId: 9 }] as any);
-      
-      const result = await ContactGroupService.getGroupRecipients(1, 'sms');
-
-      expect(prismaMock.contactGroupMember.findMany).toHaveBeenCalledWith({
-        where: { groupId: 1, notifySms: true },
-        select: { memberId: true },
-      });
-      expect(result).toEqual([9]);
-    });
-  });
-
 });

--- a/test/services/contact-group.test.ts
+++ b/test/services/contact-group.test.ts
@@ -1,0 +1,195 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect } from 'vitest';
+import { prismaMock } from '../mocks/prisma';
+import { AppError } from '@/utils/errors';
+import * as ContactGroupService from '../../src/services/contact-group';
+
+describe('Contact Group Service', () => {
+
+  describe('getGroupsByOwner()', () => {
+    it('returns groups with member count', async () => {
+      const mockGroups = [
+        { id: 1, name: 'Group 1', ownerid: 100, _count: { members: 5 } }
+      ];
+      prismaMock.contactGroup.findMany.mockResolvedValue(mockGroups as any);
+
+      const result = await ContactGroupService.getGroupsByOwner(100);
+
+      expect(prismaMock.contactGroup.findMany).toHaveBeenCalledWith({
+        where: { ownerid: 100 },
+        include: { _count: { select: { members: true } } },
+        orderBy: { createdAt: "desc" },
+      });
+      expect(result[0].memberCount).toBe(5);
+    });
+
+    it('transforms Prisma errors correctly', async () => {
+      prismaMock.contactGroup.findMany.mockRejectedValue(new Error('Database down'));
+      await expect(ContactGroupService.getGroupsByOwner(100)).rejects.toThrow();
+    });
+  });
+
+  describe('getAllGroups()', () => {
+    it('admin view, returns all groups', async () => {
+      const mockGroups = [{ id: 1, _count: { members: 2 } }];
+      prismaMock.contactGroup.findMany.mockResolvedValue(mockGroups as any);
+
+      const result = await ContactGroupService.getAllGroups();
+
+      expect(prismaMock.contactGroup.findMany).toHaveBeenCalledWith(expect.not.objectContaining({ where: expect.anything() }));
+      expect(result[0].memberCount).toBe(2);
+    });
+  });
+
+  describe('getGroupById()', () => {
+    it('found case: returns group with members and count', async () => {
+      const mockGroup = { id: 1, members: [], _count: { members: 0 } };
+      prismaMock.contactGroup.findUnique.mockResolvedValue(mockGroup as any);
+
+      const result = await ContactGroupService.getGroupById(1);
+
+      expect(result.id).toBe(1);
+      expect(result.memberCount).toBe(0);
+    });
+
+    it('not found case: throws NOT_FOUND AppError', async () => {
+      prismaMock.contactGroup.findUnique.mockResolvedValue(null);
+
+      await expect(ContactGroupService.getGroupById(999)).rejects.toThrowError(AppError);
+      await expect(ContactGroupService.getGroupById(999)).rejects.toThrow('Group with id 999 not found');
+    });
+  });
+
+  describe('isGroupOwner()', () => {
+    it('returns true if group exists for owner', async () => {
+      prismaMock.contactGroup.findFirst.mockResolvedValue({ id: 1 } as any);
+      const result = await ContactGroupService.isGroupOwner(1, 100);
+      expect(result).toBe(true);
+    });
+
+    it('returns false if group does not exist for owner', async () => {
+      prismaMock.contactGroup.findFirst.mockResolvedValue(null);
+      const result = await ContactGroupService.isGroupOwner(1, 100);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createGroup()', () => {
+    it('validates owner assignment during creation', async () => {
+      const mockData = { name: 'New Group', description: 'Test' };
+      prismaMock.contactGroup.create.mockResolvedValue({ id: 1, ...mockData, ownerid: 100 } as any);
+
+      const result = await ContactGroupService.createGroup(mockData, 100);
+
+      expect(prismaMock.contactGroup.create).toHaveBeenCalledWith({
+        data: { name: 'New Group', description: 'Test', ownerid: 100 },
+      });
+      expect(result.ownerid).toBe(100);
+    });
+  });
+
+  describe('updateGroup()', () => {
+    it('partial updates work', async () => {
+      const updateData = { name: 'Updated Name' };
+      prismaMock.contactGroup.update.mockResolvedValue({ id: 1, name: 'Updated Name' } as any);
+
+      await ContactGroupService.updateGroup(1, updateData);
+
+      expect(prismaMock.contactGroup.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: updateData,
+      });
+    });
+  });
+
+  describe('deleteGroup()', () => {
+    it('calls delete on the group (cascade delete handled by DB)', async () => {
+      prismaMock.contactGroup.delete.mockResolvedValue({ id: 1 } as any);
+      await ContactGroupService.deleteGroup(1);
+      expect(prismaMock.contactGroup.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
+  });
+
+  describe('addMemberToGroup()', () => {
+    it('adds a single member with notification preferences', async () => {
+      prismaMock.contactGroupMember.create.mockResolvedValue({ groupId: 1, memberId: 2 } as any);
+      
+      await ContactGroupService.addMemberToGroup(1, 2, 100, { notifyEmail: true, notifySms: false });
+
+      expect(prismaMock.contactGroupMember.create).toHaveBeenCalledWith({
+        data: { groupId: 1, memberId: 2, addedBy: 100, notifyEmail: true, notifySms: false },
+      });
+    });
+  });
+
+  describe('addMembersToGroup()', () => {
+    it('bulk adds members and skips duplicates', async () => {
+      prismaMock.contactGroupMember.createMany.mockResolvedValue({ count: 2 });
+      
+      const members = [
+        { memberId: 2, notifyEmail: true, notifySms: false },
+        { memberId: 3, notifyEmail: false, notifySms: true }
+      ];
+
+      const result = await ContactGroupService.addMembersToGroup(1, members, 100);
+
+      expect(prismaMock.contactGroupMember.createMany).toHaveBeenCalledWith({
+        data: expect.any(Array),
+        skipDuplicates: true, // Specifically tests the acceptance criteria
+      });
+      expect(result.count).toBe(2);
+    });
+  });
+
+  describe('removeMemberFromGroup()', () => {
+    it('removes a specific member', async () => {
+      prismaMock.contactGroupMember.delete.mockResolvedValue({} as any);
+      await ContactGroupService.removeMemberFromGroup(1, 2);
+      expect(prismaMock.contactGroupMember.delete).toHaveBeenCalledWith({
+        where: { groupId_memberId: { groupId: 1, memberId: 2 } },
+      });
+    });
+  });
+
+  describe('updateMemberNotifications()', () => {
+    it('toggles email/SMS preferences', async () => {
+      const prefs = { notifyEmail: false, notifySms: true };
+      prismaMock.contactGroupMember.update.mockResolvedValue({} as any);
+      
+      await ContactGroupService.updateMemberNotifications(1, 2, prefs);
+
+      expect(prismaMock.contactGroupMember.update).toHaveBeenCalledWith({
+        where: { groupId_memberId: { groupId: 1, memberId: 2 } },
+        data: prefs,
+      });
+    });
+  });
+
+  describe('getGroupRecipients()', () => {
+    it('filters by email channel', async () => {
+      prismaMock.contactGroupMember.findMany.mockResolvedValue([{ memberId: 5 }, { memberId: 6 }] as any);
+      
+      const result = await ContactGroupService.getGroupRecipients(1, 'email');
+
+      expect(prismaMock.contactGroupMember.findMany).toHaveBeenCalledWith({
+        where: { groupId: 1, notifyEmail: true },
+        select: { memberId: true },
+      });
+      expect(result).toEqual([5, 6]);
+    });
+
+    it('filters by sms channel', async () => {
+      prismaMock.contactGroupMember.findMany.mockResolvedValue([{ memberId: 9 }] as any);
+      
+      const result = await ContactGroupService.getGroupRecipients(1, 'sms');
+
+      expect(prismaMock.contactGroupMember.findMany).toHaveBeenCalledWith({
+        where: { groupId: 1, notifySms: true },
+        select: { memberId: true },
+      });
+      expect(result).toEqual([9]);
+    });
+  });
+
+});


### PR DESCRIPTION
## Developer

Karson Chen

Closes #60

## What changed?

I implemented a comprehensive unit testing suite for the ContactGroupService. This ensures the backend logic for PRFC contact groups is robust and handles data correctly.

Key implementations:

Coverage: Added tests for all 11 service functions, including getGroupsByOwner, createGroup, and getGroupRecipients.

Mocking: Utilized prismaMock to simulate database interactions, keeping tests isolated and fast.

Edge Cases: Included tests for "Not Found" errors and verified that bulk member additions correctly skip duplicates.

Data Mapping: Confirmed that nested database counts are correctly flattened into memberCount for the frontend

## How to test

Open your terminal in the project root.

Run npx prisma generate to ensure local types are up to date.

Run npm test -- contact-group.

Verify all 16 tests in test/services/contact-group.test.ts pass.

## Screenshots

{Optional: Add screenshots or screen recording}

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers
