### PR TITLE
68 test email service group delivery tests

### DIFF
--- a/src/services/email-suppression.ts
+++ b/src/services/email-suppression.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import prisma from "@/lib/db";
+import type { EmailSuppressionReason } from "@/generated/prisma/client";
+import { transformError } from "@/utils/errors";
+
+export async function isEmailSuppressed(email: string): Promise<boolean> {
+  try {
+    const suppression = await prisma.emailSuppression.findUnique({
+      where: { email: email.toLowerCase() },
+    });
+    return suppression !== null;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function suppressEmail(email: string, reason: EmailSuppressionReason): Promise<void> {
+  try {
+    await prisma.emailSuppression.upsert({
+      where: { email: email.toLowerCase() },
+      update: { reason, suppressedAt: new Date() },
+      create: { email: email.toLowerCase(), reason },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function filterSuppressedEmails(emails: string[]): Promise<{ valid: string[]; suppressed: string[] }> {
+  try {
+    const suppressions = await prisma.emailSuppression.findMany({
+      where: { email: { in: emails.map((e) => e.toLowerCase()) } },
+      select: { email: true },
+    });
+
+    const suppressedSet = new Set(suppressions.map((s) => s.email));
+
+    return {
+      valid: emails.filter((e) => !suppressedSet.has(e.toLowerCase())),
+      suppressed: emails.filter((e) => suppressedSet.has(e.toLowerCase())),
+    };
+  } catch (error) {
+    throw transformError(error);
+  }
+}

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -1,10 +1,8 @@
 import "server-only";
 import nodemailer from "nodemailer";
 import path from "path";
-import prisma from "@/lib/db";
 import type { Prospect } from "@/schema/referral";
-import type { EmailSuppressionReason } from "@/generated/prisma/client";
-import { AppError, transformError } from "@/utils/errors";
+import { AppError } from "@/utils/errors";
 import { env } from "@/env";
 import { generateUnsubscribeToken } from "@/lib/unsubscribe-tokens";
 
@@ -96,47 +94,6 @@ function generateEmailHtml(prospectName: string, memberName: string, referralCod
       </div>
     </div>
   </div>`;
-}
-
-export async function isEmailSuppressed(email: string): Promise<boolean> {
-  try {
-    const suppression = await prisma.emailSuppression.findUnique({
-      where: { email: email.toLowerCase() },
-    });
-    return suppression !== null;
-  } catch (error) {
-    throw transformError(error);
-  }
-}
-
-export async function suppressEmail(email: string, reason: EmailSuppressionReason): Promise<void> {
-  try {
-    await prisma.emailSuppression.upsert({
-      where: { email: email.toLowerCase() },
-      update: { reason, suppressedAt: new Date() },
-      create: { email: email.toLowerCase(), reason },
-    });
-  } catch (error) {
-    throw transformError(error);
-  }
-}
-
-export async function filterSuppressedEmails(emails: string[]): Promise<{ valid: string[]; suppressed: string[] }> {
-  try {
-    const suppressions = await prisma.emailSuppression.findMany({
-      where: { email: { in: emails.map((e) => e.toLowerCase()) } },
-      select: { email: true },
-    });
-
-    const suppressedSet = new Set(suppressions.map((s) => s.email));
-
-    return {
-      valid: emails.filter((e) => !suppressedSet.has(e.toLowerCase())),
-      suppressed: emails.filter((e) => suppressedSet.has(e.toLowerCase())),
-    };
-  } catch (error) {
-    throw transformError(error);
-  }
 }
 
 const BATCH_SIZE = 10;

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -5,6 +5,7 @@ import type { Prospect } from "@/schema/referral";
 import { AppError } from "@/utils/errors";
 import { env } from "@/env";
 import { generateUnsubscribeToken } from "@/lib/unsubscribe-tokens";
+import { filterSuppressedEmails } from "./email-suppression";
 
 const transport = nodemailer.createTransport({
   host: env.SMTP_HOST,

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -100,8 +100,14 @@ function generateEmailHtml(prospectName: string, memberName: string, referralCod
 const BATCH_SIZE = 10;
 const BATCH_DELAY_MS = 1000;
 
+export interface Recipient {
+  email: string;
+  memberId: number;
+  name: string;
+}
+
 interface GroupEmailParams {
-  recipients: Array<{ email: string; memberId: number; name: string }>;
+  recipients: Array<Recipient>;
   subject: string;
   body: string;
   senderName: string;

--- a/test/mocks/email-group.ts
+++ b/test/mocks/email-group.ts
@@ -1,0 +1,31 @@
+import type { Recipient } from "@/services/email";
+
+export const BobbyRecipient: Recipient = {
+  email: "bobbylicious1@yahoo.com",
+  memberId: 1,
+  name: "Bobby Smith",
+};
+
+export const LucyRecipient: Recipient = {
+  email: "lucy.vanpelt@gmail.com",
+  memberId: 2,
+  name: "Lucy Van Pelt",
+};
+
+export const MarcieRecipient: Recipient = {
+  email: "marcie.johnson@gmail.com",
+  memberId: 3,
+  name: "Marcie Johnson",
+};
+
+export const CharlieRecipient: Recipient = {
+  email: "charlie.brown@test.com",
+  memberId: 4,
+  name: "Charlie Brown",
+};
+
+export const SnoopyRecipient: Recipient = {
+  email: "snoopy@peanuts.com",
+  memberId: 5,
+  name: "Snoopy",
+};

--- a/test/mocks/email-group.ts
+++ b/test/mocks/email-group.ts
@@ -29,3 +29,45 @@ export const SnoopyRecipient: Recipient = {
   memberId: 5,
   name: "Snoopy",
 };
+
+export const LinusRecipient: Recipient = {
+  email: "linus.vanpelt@gmail.com",
+  memberId: 6,
+  name: "Linus Van Pelt",
+};
+
+export const PeppermintPattyRecipient: Recipient = {
+  email: "peppermint.patty@test.com",
+  memberId: 7,
+  name: "Peppermint Patty",
+};
+
+export const SchroederRecipient: Recipient = {
+  email: "schroeder.music@gmail.com",
+  memberId: 8,
+  name: "Schroeder",
+};
+
+export const SallyRecipient: Recipient = {
+  email: "sally.brown@yahoo.com",
+  memberId: 9,
+  name: "Sally Brown",
+};
+
+export const WoodstockRecipient: Recipient = {
+  email: "woodstock@peanuts.com",
+  memberId: 10,
+  name: "Woodstock",
+};
+
+export const FranklinRecipient: Recipient = {
+  email: "franklin.armstrong@gmail.com",
+  memberId: 11,
+  name: "Franklin Armstrong",
+};
+
+export const PigpenRecipient: Recipient = {
+  email: "pigpen.dusty@test.com",
+  memberId: 12,
+  name: "Pig-Pen",
+};

--- a/test/mocks/email-group.ts
+++ b/test/mocks/email-group.ts
@@ -1,73 +1,88 @@
 import type { Recipient } from "@/services/email";
 
-export const BobbyRecipient: Recipient = {
+export const recipientBobby: Recipient = {
   email: "bobbylicious1@yahoo.com",
   memberId: 1,
   name: "Bobby Smith",
 };
 
-export const LucyRecipient: Recipient = {
+export const recipientLucy: Recipient = {
   email: "lucy.vanpelt@gmail.com",
   memberId: 2,
   name: "Lucy Van Pelt",
 };
 
-export const MarcieRecipient: Recipient = {
+export const recipientMarcie: Recipient = {
   email: "marcie.johnson@gmail.com",
   memberId: 3,
   name: "Marcie Johnson",
 };
 
-export const CharlieRecipient: Recipient = {
+export const recipientCharlie: Recipient = {
   email: "charlie.brown@test.com",
   memberId: 4,
   name: "Charlie Brown",
 };
 
-export const SnoopyRecipient: Recipient = {
+export const recipientSnoopy: Recipient = {
   email: "snoopy@peanuts.com",
   memberId: 5,
   name: "Snoopy",
 };
 
-export const LinusRecipient: Recipient = {
+export const recipientLinus: Recipient = {
   email: "linus.vanpelt@gmail.com",
   memberId: 6,
   name: "Linus Van Pelt",
 };
 
-export const PeppermintPattyRecipient: Recipient = {
+export const recipientPeppermintPatty: Recipient = {
   email: "peppermint.patty@test.com",
   memberId: 7,
   name: "Peppermint Patty",
 };
 
-export const SchroederRecipient: Recipient = {
+export const recipientSchroeder: Recipient = {
   email: "schroeder.music@gmail.com",
   memberId: 8,
   name: "Schroeder",
 };
 
-export const SallyRecipient: Recipient = {
+export const recipientSally: Recipient = {
   email: "sally.brown@yahoo.com",
   memberId: 9,
   name: "Sally Brown",
 };
 
-export const WoodstockRecipient: Recipient = {
+export const recipientWoodstock: Recipient = {
   email: "woodstock@peanuts.com",
   memberId: 10,
   name: "Woodstock",
 };
 
-export const FranklinRecipient: Recipient = {
+export const recipientFranklin: Recipient = {
   email: "franklin.armstrong@gmail.com",
   memberId: 11,
   name: "Franklin Armstrong",
 };
 
-export const PigpenRecipient: Recipient = {
+export const recipientPigpen: Recipient = {
   email: "pigpen.dusty@test.com",
   memberId: 12,
   name: "Pig-Pen",
 };
+
+export const allRecipients: Recipient[] = [
+  recipientBobby,
+  recipientLucy,
+  recipientMarcie,
+  recipientCharlie,
+  recipientSnoopy,
+  recipientLinus,
+  recipientPeppermintPatty,
+  recipientSchroeder,
+  recipientSally,
+  recipientWoodstock,
+  recipientFranklin,
+  recipientPigpen,
+];

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -35,13 +35,13 @@ describe("sendGroupEmails", () => {
     const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
     const test_emails = test_recipients.map((r) => r.email);
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: [BobbyRecipient.email, MarcieRecipient.email],
-      suppressed: [LucyRecipient.email],
+      valid: [BobbyRecipient.email, LucyRecipient.email, MarcieRecipient.email],
+      suppressed: [],
     });
 
     sendMailMock.mockResolvedValue(undefined);
 
-    const { sent, failed, suppressed } = await sendGroupEmails({
+    await sendGroupEmails({
       recipients: test_recipients,
       subject: "",
       body: "",
@@ -52,14 +52,33 @@ describe("sendGroupEmails", () => {
 
     expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
     expect(sendMailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ to: BobbyRecipient.email }));
-    expect(sendMailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ to: MarcieRecipient.email }));
-    expect(sent).toBe(2);
-    expect(failed).toBe(0);
-    expect(suppressed).toBe(1);
+    expect(sendMailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ to: LucyRecipient.email }));
+    expect(sendMailMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ to: MarcieRecipient.email }));
+    expect(sendMailMock).toHaveBeenCalledTimes(3);
   });
 
   it("filters out suppressed emails before sending", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    const test_emails = test_recipients.map((r) => r.email);
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: [BobbyRecipient.email],
+      suppressed: [LucyRecipient.email, MarcieRecipient.email],
+    });
+
+    sendMailMock.mockResolvedValue(undefined);
+
+    await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
+    expect(sendMailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ to: BobbyRecipient.email }));
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
   });
 
   it("generates unique unsubscribe token per recipient", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -1,12 +1,30 @@
 import { vi } from "vitest";
 
+const sendMailMock = vi.hoisted(() => vi.fn());
+const filterSuppressedEmailsMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/services/email-suppression", async () => ({
-  filterSuppressedEmails: vi.fn(),
+  filterSuppressedEmails: filterSuppressedEmailsMock,
+}));
+vi.mock("nodemailer", async () => ({
+  default: {
+    createTransport: vi.fn(() => ({
+      sendMail: sendMailMock,
+      close: vi.fn(),
+    })),
+  },
 }));
 
 import { sendGroupEmails } from "@/services/email";
 import { filterSuppressedEmails } from "@/services/email-suppression";
-import { LucyRecipient, MarcieRecipient } from "../mocks/email-group";
+import {
+  BobbyRecipient,
+  CharlieRecipient,
+  LucyRecipient,
+  MarcieRecipient,
+  SnoopyRecipient,
+} from "../mocks/email-group";
+import "nodemailer";
 
 describe("sendGroupEmails", () => {
   beforeEach(() => {
@@ -38,7 +56,35 @@ describe("sendGroupEmails", () => {
   });
 
   it("returns correct send/fail counts", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient, CharlieRecipient, SnoopyRecipient];
+    const test_emails = test_recipients.map((r) => r.email);
+
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: test_emails,
+      suppressed: [],
+    });
+
+    sendMailMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("SMTP down"))
+      .mockResolvedValueOnce(undefined);
+
+    const { sent, failed, suppressed } = await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
+    expect(sendMailMock).toHaveBeenCalledTimes(5);
+    expect(sent).toBe(4);
+    expect(failed).toBe(1);
+    expect(suppressed).toBe(0);
   });
 
   it("handles SMTP errors gracefully (no throw)", async () => {
@@ -46,7 +92,7 @@ describe("sendGroupEmails", () => {
   });
 
   it("returns {sent: 0, failed: 0} with empty recipient list", async () => {
-    vi.mocked(filterSuppressedEmails).mockResolvedValue({
+    filterSuppressedEmailsMock.mockResolvedValue({
       valid: [],
       suppressed: [],
     });
@@ -67,7 +113,7 @@ describe("sendGroupEmails", () => {
   });
 
   it("returns {sent: 0, failed: 0, suppressed: n} with n suppressed returns", async () => {
-    vi.mocked(filterSuppressedEmails).mockResolvedValue({
+    filterSuppressedEmailsMock.mockResolvedValue({
       valid: [],
       suppressed: [LucyRecipient.email, MarcieRecipient.email],
     });
@@ -81,7 +127,7 @@ describe("sendGroupEmails", () => {
       groupId: 123,
     });
 
-    expect(filterSuppressedEmails).toHaveBeenCalledWith([LucyRecipient.email, MarcieRecipient.email]);
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith([LucyRecipient.email, MarcieRecipient.email]);
     expect(sent).toBe(0);
     expect(failed).toBe(0);
     expect(suppressed).toBe(2);

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -1,13 +1,11 @@
 import { vi } from "vitest";
-// import { sendGroupEmails } from "@/services/email";
 
-vi.mock("@/services/email-suppression", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/services/email-suppression")>();
-  return {
-    ...actual,
-    filterSuppressedEmails: vi.fn(),
-  };
-});
+vi.mock("@/services/email-suppression", async () => ({
+  filterSuppressedEmails: vi.fn(),
+}));
+
+import { sendGroupEmails } from "@/services/email";
+import { filterSuppressedEmails } from "@/services/email-suppression";
 
 describe("sendGroupEmails", () => {
   beforeEach(() => {
@@ -47,7 +45,6 @@ describe("sendGroupEmails", () => {
   });
 
   it("returns {sent: 0, failed: 0} with empty recipient list", async () => {
-    /*
     vi.mocked(filterSuppressedEmails).mockResolvedValue({
       valid: [],
       suppressed: [],
@@ -66,7 +63,6 @@ describe("sendGroupEmails", () => {
     expect(sent).toBe(0);
     expect(failed).toBe(0);
     expect(suppressed).toBe(0);
-    */
   });
 
   it("returns {sent: 0, failed: 0, suppressed: n} with n suppressed returns", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -19,9 +19,16 @@ import { sendGroupEmails } from "@/services/email";
 import {
   BobbyRecipient,
   CharlieRecipient,
+  FranklinRecipient,
+  LinusRecipient,
   LucyRecipient,
   MarcieRecipient,
+  PeppermintPattyRecipient,
+  PigpenRecipient,
+  SallyRecipient,
+  SchroederRecipient,
   SnoopyRecipient,
+  WoodstockRecipient,
 } from "../mocks/email-group";
 import "nodemailer";
 import * as tokenModule from "@/lib/unsubscribe-tokens";
@@ -175,7 +182,58 @@ describe("sendGroupEmails", () => {
   });
 
   it("batches emails (10 per batch)", async () => {
-    /* Test */
+    vi.useFakeTimers();
+    const test_recipients = [
+      BobbyRecipient,
+      LucyRecipient,
+      MarcieRecipient,
+      CharlieRecipient,
+      SnoopyRecipient,
+      LinusRecipient,
+      PeppermintPattyRecipient,
+      SchroederRecipient,
+      SallyRecipient,
+      WoodstockRecipient,
+      FranklinRecipient,
+      PigpenRecipient,
+    ];
+    const test_emails = test_recipients.map((r) => r.email);
+    const BATCH_DELAY_MS = 1000;
+
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: test_emails,
+      suppressed: [],
+    });
+
+    sendMailMock.mockImplementation(async () => undefined);
+
+    const promise = sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    await Promise.resolve();
+
+    expect(sendMailMock).toHaveBeenCalledTimes(10);
+
+    await vi.advanceTimersByTimeAsync(BATCH_DELAY_MS - 1);
+    await Promise.resolve();
+    expect(sendMailMock).toHaveBeenCalledTimes(10);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    expect(sendMailMock).toHaveBeenCalledTimes(12);
+
+    const { sent, failed, suppressed } = await promise;
+    expect(sent).toBe(12);
+    expect(failed).toBe(0);
+    expect(suppressed).toBe(0);
+
+    vi.useRealTimers();
   });
 
   it("returns correct send/fail counts", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -116,9 +116,10 @@ describe("sendGroupEmails", () => {
   });
 
   it("includes List-Unsubscribe header (RFC 8058)", async () => {
-    const test_recipients = [BobbyRecipient];
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    const test_emails = test_recipients.map((r) => r.email);
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: [BobbyRecipient.email],
+      valid: test_emails,
       suppressed: [],
     });
 
@@ -133,17 +134,44 @@ describe("sendGroupEmails", () => {
       groupId: 123,
     });
 
-    expect(sendMailMock).toBeCalledWith(
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "List-Unsubscribe": expect.any(Object),
+    test_emails.forEach((email) => {
+      expect(sendMailMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: email,
+          headers: expect.objectContaining({
+            "List-Unsubscribe": expect.any(Object),
+          }),
         }),
-      }),
-    );
+      );
+    });
   });
 
   it("appends CAN-SPAM footer with physical address", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    const test_emails = test_recipients.map((r) => r.email);
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: test_emails,
+      suppressed: [],
+    });
+
+    sendMailMock.mockResolvedValue(undefined);
+
+    await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(sendMailMock).toHaveBeenCalledTimes(3);
+    for (const [fields] of sendMailMock.mock.calls) {
+      const html = String(fields.html ?? "");
+      expect(html).toContain("Paso Robles Food Cooperative, Inc.");
+      expect(html).toContain("P.O. Box 922, Paso Robles, CA 93447");
+      expect(html).toMatch(/<a href="[^"]*\/api\/unsubscribe\?token=[^"]*"[^>]*>Unsubscribe from this group<\/a>/);
+    }
   });
 
   it("batches emails (10 per batch)", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -32,7 +32,30 @@ describe("sendGroupEmails", () => {
   });
 
   it("sends to all valid recipients", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    const test_emails = test_recipients.map((r) => r.email);
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: [BobbyRecipient.email, MarcieRecipient.email],
+      suppressed: [LucyRecipient.email],
+    });
+
+    sendMailMock.mockResolvedValue(undefined);
+
+    const { sent, failed, suppressed } = await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
+    expect(sendMailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ to: BobbyRecipient.email }));
+    expect(sendMailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ to: MarcieRecipient.email }));
+    expect(sent).toBe(2);
+    expect(failed).toBe(0);
+    expect(suppressed).toBe(1);
   });
 
   it("filters out suppressed emails before sending", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/services/email-suppression", async () => ({
 
 import { sendGroupEmails } from "@/services/email";
 import { filterSuppressedEmails } from "@/services/email-suppression";
+import { LucyRecipient, MarcieRecipient } from "../mocks/email-group";
 
 describe("sendGroupEmails", () => {
   beforeEach(() => {
@@ -66,6 +67,23 @@ describe("sendGroupEmails", () => {
   });
 
   it("returns {sent: 0, failed: 0, suppressed: n} with n suppressed returns", async () => {
-    /* Test */
+    vi.mocked(filterSuppressedEmails).mockResolvedValue({
+      valid: [],
+      suppressed: [LucyRecipient.email, MarcieRecipient.email],
+    });
+
+    const { sent, failed, suppressed } = await sendGroupEmails({
+      recipients: [LucyRecipient, MarcieRecipient],
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(filterSuppressedEmails).toHaveBeenCalledWith([LucyRecipient.email, MarcieRecipient.email]);
+    expect(sent).toBe(0);
+    expect(failed).toBe(0);
+    expect(suppressed).toBe(2);
   });
 });

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -1,4 +1,19 @@
+import { vi } from "vitest";
+// import { sendGroupEmails } from "@/services/email";
+
+vi.mock("@/services/email-suppression", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/email-suppression")>();
+  return {
+    ...actual,
+    filterSuppressedEmails: vi.fn(),
+  };
+});
+
 describe("sendGroupEmails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("sends to all valid recipients", async () => {
     /* Test */
   });
@@ -32,7 +47,26 @@ describe("sendGroupEmails", () => {
   });
 
   it("returns {sent: 0, failed: 0} with empty recipient list", async () => {
-    /* Test */
+    /*
+    vi.mocked(filterSuppressedEmails).mockResolvedValue({
+      valid: [],
+      suppressed: [],
+    });
+
+    const { sent, failed, suppressed } = await sendGroupEmails({
+      recipients: [],
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(filterSuppressedEmails).toHaveBeenCalledWith([]);
+    expect(sent).toBe(0);
+    expect(failed).toBe(0);
+    expect(suppressed).toBe(0);
+    */
   });
 
   it("returns {sent: 0, failed: 0, suppressed: n} with n suppressed returns", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -1,0 +1,41 @@
+describe("sendGroupEmails", () => {
+  it("sends to all valid recipients", async () => {
+    /* Test */
+  });
+
+  it("filters out suppressed emails before sending", async () => {
+    /* Test */
+  });
+
+  it("generates unique unsubscribe token per recipient", async () => {
+    /* Test */
+  });
+
+  it("includes List-Unsubscribe header (RFC 8058)", async () => {
+    /* Test */
+  });
+
+  it("appends CAN-SPAM footer with physical address", async () => {
+    /* Test */
+  });
+
+  it("batches emails (10 per batch)", async () => {
+    /* Test */
+  });
+
+  it("returns correct send/fail counts", async () => {
+    /* Test */
+  });
+
+  it("handles SMTP errors gracefully (no throw)", async () => {
+    /* Test */
+  });
+
+  it("returns {sent: 0, failed: 0} with empty recipient list", async () => {
+    /* Test */
+  });
+
+  it("returns {sent: 0, failed: 0, suppressed: n} with n suppressed returns", async () => {
+    /* Test */
+  });
+});

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -84,6 +84,7 @@ describe("sendGroupEmails", () => {
   });
 
   it("generates unique unsubscribe token per recipient", async () => {
+    /* This test should be in its own file for unsubscribe-tokens.ts */
     const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
     filterSuppressedEmailsMock.mockResolvedValue({
       valid: [BobbyRecipient.email, LucyRecipient.email, MarcieRecipient.email],
@@ -102,7 +103,7 @@ describe("sendGroupEmails", () => {
     });
 
     const tokens = sendMailMock.mock.calls.map(([fields]) => {
-      const raw = fields.headers?.["List-Unsubscribe"]?.value as string; // `<url>`
+      const raw = fields.headers?.["List-Unsubscribe"]?.value as string;
       const urlStr = raw.slice(1, -1);
       return new URL(urlStr).searchParams.get("token");
     });
@@ -115,7 +116,30 @@ describe("sendGroupEmails", () => {
   });
 
   it("includes List-Unsubscribe header (RFC 8058)", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient];
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: [BobbyRecipient.email],
+      suppressed: [],
+    });
+
+    sendMailMock.mockResolvedValue(undefined);
+
+    await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(sendMailMock).toBeCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "List-Unsubscribe": expect.any(Object),
+        }),
+      }),
+    );
   });
 
   it("appends CAN-SPAM footer with physical address", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -2,7 +2,6 @@ import { vi } from "vitest";
 
 const sendMailMock = vi.hoisted(() => vi.fn());
 const filterSuppressedEmailsMock = vi.hoisted(() => vi.fn());
-const generateUnsubscribeTokenMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/email-suppression", async () => ({
   filterSuppressedEmails: filterSuppressedEmailsMock,
@@ -15,9 +14,6 @@ vi.mock("nodemailer", async () => ({
     })),
   },
 }));
-vi.mock("@/lib/unsubscribe-tokens", () => ({
-  generateUnsubscribeToken: generateUnsubscribeTokenMock,
-}));
 
 import { sendGroupEmails } from "@/services/email";
 import {
@@ -28,6 +24,9 @@ import {
   SnoopyRecipient,
 } from "../mocks/email-group";
 import "nodemailer";
+import * as tokenModule from "@/lib/unsubscribe-tokens";
+
+const tokenSpy = vi.spyOn(tokenModule, "generateUnsubscribeToken");
 
 describe("sendGroupEmails", () => {
   beforeEach(() => {
@@ -54,9 +53,9 @@ describe("sendGroupEmails", () => {
     });
 
     expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
-    expect(sendMailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ to: BobbyRecipient.email }));
-    expect(sendMailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ to: LucyRecipient.email }));
-    expect(sendMailMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ to: MarcieRecipient.email }));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: BobbyRecipient.email }));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: LucyRecipient.email }));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: MarcieRecipient.email }));
     expect(sendMailMock).toHaveBeenCalledTimes(3);
   });
 
@@ -80,12 +79,39 @@ describe("sendGroupEmails", () => {
     });
 
     expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
-    expect(sendMailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ to: BobbyRecipient.email }));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: BobbyRecipient.email }));
     expect(sendMailMock).toHaveBeenCalledTimes(1);
   });
 
   it("generates unique unsubscribe token per recipient", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: [BobbyRecipient.email, LucyRecipient.email, MarcieRecipient.email],
+      suppressed: [],
+    });
+
+    sendMailMock.mockResolvedValue(undefined);
+
+    await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    const tokens = sendMailMock.mock.calls.map(([fields]) => {
+      const raw = fields.headers?.["List-Unsubscribe"]?.value as string; // `<url>`
+      const urlStr = raw.slice(1, -1);
+      return new URL(urlStr).searchParams.get("token");
+    });
+    tokens.forEach((token) => expect(token).toBeTruthy());
+    expect(new Set(tokens).size).toBe(tokens.length);
+    expect(tokenSpy).toHaveBeenCalledTimes(3);
+    expect(tokenSpy).toHaveBeenCalledWith(BobbyRecipient.memberId, 123);
+    expect(tokenSpy).toHaveBeenCalledWith(LucyRecipient.memberId, 123);
+    expect(tokenSpy).toHaveBeenCalledWith(MarcieRecipient.memberId, 123);
   });
 
   it("includes List-Unsubscribe header (RFC 8058)", async () => {

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -17,23 +17,24 @@ vi.mock("nodemailer", async () => ({
 
 import { sendGroupEmails } from "@/services/email";
 import {
-  BobbyRecipient,
-  CharlieRecipient,
-  FranklinRecipient,
-  LinusRecipient,
-  LucyRecipient,
-  MarcieRecipient,
-  PeppermintPattyRecipient,
-  PigpenRecipient,
-  SallyRecipient,
-  SchroederRecipient,
-  SnoopyRecipient,
-  WoodstockRecipient,
+  recipientBobby,
+  recipientLucy,
+  recipientMarcie,
+  recipientCharlie,
+  recipientSnoopy,
+  allRecipients,
 } from "../mocks/email-group";
-import "nodemailer";
 import * as tokenModule from "@/lib/unsubscribe-tokens";
 
 const tokenSpy = vi.spyOn(tokenModule, "generateUnsubscribeToken");
+
+const defaultParams = {
+  subject: "Test Subject",
+  body: "<p>Test Body</p>",
+  senderName: "Test Sender",
+  replyTo: "reply@test.com",
+  groupId: 123,
+};
 
 describe("sendGroupEmails", () => {
   beforeEach(() => {
@@ -41,73 +42,46 @@ describe("sendGroupEmails", () => {
   });
 
   it("sends to all valid recipients", async () => {
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
-    const test_emails = test_recipients.map((r) => r.email);
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: [BobbyRecipient.email, LucyRecipient.email, MarcieRecipient.email],
+      valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-
     sendMailMock.mockResolvedValue(undefined);
 
-    await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    await sendGroupEmails({ ...defaultParams, recipients });
 
-    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
-    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: BobbyRecipient.email }));
-    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: LucyRecipient.email }));
-    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: MarcieRecipient.email }));
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(recipients.map((r) => r.email));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: recipientBobby.email }));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: recipientLucy.email }));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: recipientMarcie.email }));
     expect(sendMailMock).toHaveBeenCalledTimes(3);
   });
 
   it("filters out suppressed emails before sending", async () => {
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
-    const test_emails = test_recipients.map((r) => r.email);
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: [BobbyRecipient.email],
-      suppressed: [LucyRecipient.email, MarcieRecipient.email],
+      valid: [recipientBobby.email],
+      suppressed: [recipientLucy.email, recipientMarcie.email],
     });
-
     sendMailMock.mockResolvedValue(undefined);
 
-    await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    await sendGroupEmails({ ...defaultParams, recipients });
 
-    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
-    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: BobbyRecipient.email }));
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(recipients.map((r) => r.email));
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({ to: recipientBobby.email }));
     expect(sendMailMock).toHaveBeenCalledTimes(1);
   });
 
   it("generates unique unsubscribe token per recipient", async () => {
-    /* This test should be in its own file for unsubscribe-tokens.ts */
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: [BobbyRecipient.email, LucyRecipient.email, MarcieRecipient.email],
+      valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-
     sendMailMock.mockResolvedValue(undefined);
 
-    await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    await sendGroupEmails({ ...defaultParams, recipients });
 
     const tokens = sendMailMock.mock.calls.map(([fields]) => {
       const raw = fields.headers?.["List-Unsubscribe"]?.value as string;
@@ -117,60 +91,43 @@ describe("sendGroupEmails", () => {
     tokens.forEach((token) => expect(token).toBeTruthy());
     expect(new Set(tokens).size).toBe(tokens.length);
     expect(tokenSpy).toHaveBeenCalledTimes(3);
-    expect(tokenSpy).toHaveBeenCalledWith(BobbyRecipient.memberId, 123);
-    expect(tokenSpy).toHaveBeenCalledWith(LucyRecipient.memberId, 123);
-    expect(tokenSpy).toHaveBeenCalledWith(MarcieRecipient.memberId, 123);
+    expect(tokenSpy).toHaveBeenCalledWith(recipientBobby.memberId, 123);
+    expect(tokenSpy).toHaveBeenCalledWith(recipientLucy.memberId, 123);
+    expect(tokenSpy).toHaveBeenCalledWith(recipientMarcie.memberId, 123);
   });
 
-  it("includes List-Unsubscribe header (RFC 8058)", async () => {
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
-    const test_emails = test_recipients.map((r) => r.email);
+  it("includes RFC 8058 one-click unsubscribe headers", async () => {
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: test_emails,
+      valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-
     sendMailMock.mockResolvedValue(undefined);
 
-    await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    await sendGroupEmails({ ...defaultParams, recipients });
 
-    test_emails.forEach((email) => {
-      expect(sendMailMock).toHaveBeenCalledWith(
+    for (const [fields] of sendMailMock.mock.calls) {
+      expect(fields.headers).toEqual(
         expect.objectContaining({
-          to: email,
-          headers: expect.objectContaining({
-            "List-Unsubscribe": expect.any(Object),
+          "List-Unsubscribe": expect.objectContaining({
+            prepared: true,
+            value: expect.stringMatching(/^<https?:\/\/.*\/api\/unsubscribe\?token=.+>$/),
           }),
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
         }),
       );
-    });
+    }
   });
 
   it("appends CAN-SPAM footer with physical address", async () => {
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
-    const test_emails = test_recipients.map((r) => r.email);
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: test_emails,
+      valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-
     sendMailMock.mockResolvedValue(undefined);
 
-    await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    await sendGroupEmails({ ...defaultParams, recipients });
 
     expect(sendMailMock).toHaveBeenCalledTimes(3);
     for (const [fields] of sendMailMock.mock.calls) {
@@ -181,134 +138,87 @@ describe("sendGroupEmails", () => {
     }
   });
 
-  it("batches emails (10 per batch)", async () => {
-    vi.useFakeTimers();
-    const test_recipients = [
-      BobbyRecipient,
-      LucyRecipient,
-      MarcieRecipient,
-      CharlieRecipient,
-      SnoopyRecipient,
-      LinusRecipient,
-      PeppermintPattyRecipient,
-      SchroederRecipient,
-      SallyRecipient,
-      WoodstockRecipient,
-      FranklinRecipient,
-      PigpenRecipient,
-    ];
-    const test_emails = test_recipients.map((r) => r.email);
-    const BATCH_DELAY_MS = 1000;
-
-    filterSuppressedEmailsMock.mockResolvedValue({
-      valid: test_emails,
-      suppressed: [],
+  describe("batching", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
     });
 
-    sendMailMock.mockImplementation(async () => undefined);
-
-    const promise = sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    await Promise.resolve();
+    it("sends in batches of 10 with delay between batches", async () => {
+      const batchDelayMs = 1000;
+      filterSuppressedEmailsMock.mockResolvedValue({
+        valid: allRecipients.map((r) => r.email),
+        suppressed: [],
+      });
+      sendMailMock.mockImplementation(async () => undefined);
 
-    expect(sendMailMock).toHaveBeenCalledTimes(10);
+      const promise = sendGroupEmails({ ...defaultParams, recipients: allRecipients });
 
-    await vi.advanceTimersByTimeAsync(BATCH_DELAY_MS - 1);
-    await Promise.resolve();
-    expect(sendMailMock).toHaveBeenCalledTimes(10);
+      await Promise.resolve();
+      expect(sendMailMock).toHaveBeenCalledTimes(10);
 
-    await vi.advanceTimersByTimeAsync(1);
-    await Promise.resolve();
-    expect(sendMailMock).toHaveBeenCalledTimes(12);
+      await vi.advanceTimersByTimeAsync(batchDelayMs - 1);
+      await Promise.resolve();
+      expect(sendMailMock).toHaveBeenCalledTimes(10);
 
-    const { sent, failed, suppressed } = await promise;
-    expect(sent).toBe(12);
-    expect(failed).toBe(0);
-    expect(suppressed).toBe(0);
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+      expect(sendMailMock).toHaveBeenCalledTimes(12);
 
-    vi.useRealTimers();
+      const { sent, failed, suppressed } = await promise;
+      expect(sent).toBe(12);
+      expect(failed).toBe(0);
+      expect(suppressed).toBe(0);
+    });
   });
 
   it("returns correct send/fail counts", async () => {
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient, CharlieRecipient, SnoopyRecipient];
-    const test_emails = test_recipients.map((r) => r.email);
-
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie, recipientCharlie, recipientSnoopy];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: test_emails,
+      valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-
     sendMailMock
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("SMTP failure"))
       .mockResolvedValueOnce(undefined);
 
-    const { sent, failed, suppressed } = await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    const { sent, failed, suppressed } = await sendGroupEmails({ ...defaultParams, recipients });
 
-    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
     expect(sendMailMock).toHaveBeenCalledTimes(5);
     expect(sent).toBe(4);
     expect(failed).toBe(1);
     expect(suppressed).toBe(0);
   });
 
-  it("handles SMTP errors gracefully (no throw)", async () => {
-    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
-    const test_emails = test_recipients.map((r) => r.email);
-
+  it("handles SMTP errors gracefully without throwing", async () => {
+    const recipients = [recipientBobby, recipientLucy, recipientMarcie];
     filterSuppressedEmailsMock.mockResolvedValue({
-      valid: test_emails,
+      valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-
     sendMailMock.mockRejectedValueOnce(new Error("SMTP Error")).mockResolvedValue(undefined);
 
-    const { sent, failed, suppressed } = await sendGroupEmails({
-      recipients: test_recipients,
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    const { sent, failed, suppressed } = await sendGroupEmails({ ...defaultParams, recipients });
 
-    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
     expect(sendMailMock).toHaveBeenCalledTimes(3);
     expect(sent).toBe(2);
     expect(failed).toBe(1);
     expect(suppressed).toBe(0);
   });
 
-  it("returns {sent: 0, failed: 0} with empty recipient list", async () => {
+  it("returns zeros with empty recipient list", async () => {
     filterSuppressedEmailsMock.mockResolvedValue({
       valid: [],
       suppressed: [],
     });
 
-    const { sent, failed, suppressed } = await sendGroupEmails({
-      recipients: [],
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
-    });
+    const { sent, failed, suppressed } = await sendGroupEmails({ ...defaultParams, recipients: [] });
 
     expect(filterSuppressedEmailsMock).toHaveBeenCalledWith([]);
     expect(sent).toBe(0);
@@ -316,22 +226,18 @@ describe("sendGroupEmails", () => {
     expect(suppressed).toBe(0);
   });
 
-  it("returns {sent: 0, failed: 0, suppressed: n} with n suppressed returns", async () => {
+  it("counts all suppressed recipients", async () => {
     filterSuppressedEmailsMock.mockResolvedValue({
       valid: [],
-      suppressed: [LucyRecipient.email, MarcieRecipient.email],
+      suppressed: [recipientLucy.email, recipientMarcie.email],
     });
 
     const { sent, failed, suppressed } = await sendGroupEmails({
-      recipients: [LucyRecipient, MarcieRecipient],
-      subject: "",
-      body: "",
-      senderName: "",
-      replyTo: "",
-      groupId: 123,
+      ...defaultParams,
+      recipients: [recipientLucy, recipientMarcie],
     });
 
-    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith([LucyRecipient.email, MarcieRecipient.email]);
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith([recipientLucy.email, recipientMarcie.email]);
     expect(sent).toBe(0);
     expect(failed).toBe(0);
     expect(suppressed).toBe(2);

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 
 const sendMailMock = vi.hoisted(() => vi.fn());
 const filterSuppressedEmailsMock = vi.hoisted(() => vi.fn());
+const generateUnsubscribeTokenMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/email-suppression", async () => ({
   filterSuppressedEmails: filterSuppressedEmailsMock,
@@ -14,9 +15,11 @@ vi.mock("nodemailer", async () => ({
     })),
   },
 }));
+vi.mock("@/lib/unsubscribe-tokens", () => ({
+  generateUnsubscribeToken: generateUnsubscribeTokenMock,
+}));
 
 import { sendGroupEmails } from "@/services/email";
-import { filterSuppressedEmails } from "@/services/email-suppression";
 import {
   BobbyRecipient,
   CharlieRecipient,
@@ -171,7 +174,7 @@ describe("sendGroupEmails", () => {
       groupId: 123,
     });
 
-    expect(filterSuppressedEmails).toHaveBeenCalledWith([]);
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith([]);
     expect(sent).toBe(0);
     expect(failed).toBe(0);
     expect(suppressed).toBe(0);

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -110,7 +110,7 @@ describe("sendGroupEmails", () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("SMTP down"))
+      .mockRejectedValueOnce(undefined)
       .mockResolvedValueOnce(undefined);
 
     const { sent, failed, suppressed } = await sendGroupEmails({
@@ -130,7 +130,30 @@ describe("sendGroupEmails", () => {
   });
 
   it("handles SMTP errors gracefully (no throw)", async () => {
-    /* Test */
+    const test_recipients = [BobbyRecipient, LucyRecipient, MarcieRecipient];
+    const test_emails = test_recipients.map((r) => r.email);
+
+    filterSuppressedEmailsMock.mockResolvedValue({
+      valid: test_emails,
+      suppressed: [],
+    });
+
+    sendMailMock.mockRejectedValueOnce(new Error("SMTP Error")).mockResolvedValue(undefined);
+
+    const { sent, failed, suppressed } = await sendGroupEmails({
+      recipients: test_recipients,
+      subject: "",
+      body: "",
+      senderName: "",
+      replyTo: "",
+      groupId: 123,
+    });
+
+    expect(filterSuppressedEmailsMock).toHaveBeenCalledWith(test_emails);
+    expect(sendMailMock).toHaveBeenCalledTimes(3);
+    expect(sent).toBe(2);
+    expect(failed).toBe(1);
+    expect(suppressed).toBe(0);
   });
 
   it("returns {sent: 0, failed: 0} with empty recipient list", async () => {

--- a/test/services/email-suppression.test.ts
+++ b/test/services/email-suppression.test.ts
@@ -1,6 +1,6 @@
 import { prismaMock } from "../mocks/prisma";
 import { suppressedLucy, suppressedMarcie } from "../mocks/email-suppressions";
-import { isEmailSuppressed, suppressEmail, filterSuppressedEmails } from "@/services/email";
+import { isEmailSuppressed, suppressEmail, filterSuppressedEmails } from "@/services/email-suppression";
 
 describe("isEmailSuppressed", () => {
   it("returns true when email exists in suppression list", async () => {


### PR DESCRIPTION
## Developer

Sam Phan

Closes #68 

## What changed?

- src/services/email.ts has been refactored and split into src/services/email-suppression.ts
- new test file, /test/services/email-group.test.ts
- new mock file, /mocks/email-group.ts

## How to test

{Steps for reviewers to verify your changes work}

1. Run `npm run test`
2. Manual review?
3. ...

## Screenshots

None provided

## Checklist

- [ ] Code works and is readable
- [ ] Tested locally
- [ ] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] Assigned reviewers
