### PR TITLE
feat: add session name, member enrichment, avatar utility, message history

### DIFF
--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -3,6 +3,7 @@ import { cache } from "react";
 import { cookies } from "next/headers";
 import { createHmac, timingSafeEqual } from "crypto";
 import { AppError } from "@/utils/errors";
+import { getMemberById } from "@/lib/api/member-api";
 
 export const AUTH_COOKIE = "prfc_auth";
 const TOKEN_EXPIRY_MS = 3600000;
@@ -22,6 +23,10 @@ export function getSecret(): string {
 export interface Session {
   ownerid: number;
   isAdmin: boolean;
+}
+
+export interface SessionWithName extends Session {
+  ownername: string;
 }
 
 function verifyHmac(payload: string, signature: string, secret: string): boolean {
@@ -79,6 +84,12 @@ export const getSession = cache(async (): Promise<Session | null> => {
   }
 
   return validateToken(authCookie.value, getSecret());
+});
+
+export const getSessionWithName = cache(async (): Promise<SessionWithName> => {
+  const session = await verifySession();
+  const member = await getMemberById(session.ownerid);
+  return { ...session, ownername: member?.ownername ?? "Member" };
 });
 
 export async function requireAdmin(): Promise<Session> {

--- a/src/services/contact-group.ts
+++ b/src/services/contact-group.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import prisma from "@/lib/db";
 import { AppError, transformError } from "@/utils/errors";
+import { getMemberDetails } from "@/lib/api/member-api";
 import type { ContactGroup, ContactGroupMember } from "@/generated/prisma/client";
 import type { CreateContactGroup, UpdateContactGroup, GroupMember, UpdateNotification } from "@/schema/contact-group";
 
@@ -12,6 +13,16 @@ export interface GroupWithCount extends ContactGroup {
 
 export interface GroupWithMembers extends ContactGroup {
   members: ContactGroupMember[];
+  memberCount: number;
+}
+
+export interface EnrichedGroupMember extends ContactGroupMember {
+  ownername: string;
+  owneremail: string;
+}
+
+export interface GroupWithEnrichedMembers extends ContactGroup {
+  members: EnrichedGroupMember[];
   memberCount: number;
 }
 
@@ -203,6 +214,35 @@ export async function getGroupRecipients(groupId: number, channel: "email" | "sm
       select: { memberId: true },
     });
     return members.map((m) => m.memberId);
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function enrichGroupMembers(group: GroupWithMembers): Promise<GroupWithEnrichedMembers> {
+  const memberIds = group.members.map((m) => m.memberId);
+
+  if (memberIds.length === 0) {
+    return { ...group, members: [] };
+  }
+
+  try {
+    const details = await getMemberDetails(memberIds);
+    const detailMap = new Map(details.map((d) => [d.ownerid, d]));
+
+    const enrichedMembers: EnrichedGroupMember[] = group.members.map((member) => {
+      const detail = detailMap.get(member.memberId);
+      return {
+        ...member,
+        ownername: detail?.ownername ?? "Unknown Member",
+        owneremail: detail?.owneremail ?? "",
+      };
+    });
+
+    return {
+      ...group,
+      members: enrichedMembers,
+    };
   } catch (error) {
     throw transformError(error);
   }

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -15,6 +15,49 @@ export interface MessageResult {
   failedCount: number;
 }
 
+export interface MessageSummary {
+  id: number;
+  subject: string;
+  body: string;
+  sentAt: Date;
+  senderId: number;
+  emailCount: number;
+  smsCount: number;
+  failedCount: number;
+}
+
+const DEFAULT_MESSAGE_HISTORY_LIMIT = 20;
+const MAX_MESSAGE_HISTORY_LIMIT = 100;
+
+export async function getGroupMessageHistory(
+  groupId: number,
+  limit: number = DEFAULT_MESSAGE_HISTORY_LIMIT,
+): Promise<MessageSummary[]> {
+  try {
+    const effectiveLimit = Math.min(Math.max(1, limit), MAX_MESSAGE_HISTORY_LIMIT);
+
+    const messages = await prisma.message.findMany({
+      where: { groupId },
+      select: {
+        id: true,
+        subject: true,
+        body: true,
+        sentAt: true,
+        senderId: true,
+        emailCount: true,
+        smsCount: true,
+        failedCount: true,
+      },
+      orderBy: { sentAt: "desc" },
+      take: effectiveLimit,
+    });
+
+    return messages;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
 export function isQuietHours(): boolean {
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Los_Angeles",

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,34 @@
+const AVATAR_COLORS = [
+  "#831002", // paso red
+  "#523019", // paso brown
+  "#8b5e3c", // tawny
+  "#a0522d", // sienna
+  "#6b7c5e", // olive
+  "#5f7a8a", // slate
+  "#9c6b7a", // dusty rose
+  "#b06840", // terracotta
+] as const;
+
+export function getInitials(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "?";
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0][0].toUpperCase();
+  }
+
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function getAvatarColor(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return AVATAR_COLORS[0];
+
+  let hash = 0;
+  for (let i = 0; i < trimmed.length; i++) {
+    hash = (hash * 31 + trimmed.charCodeAt(i)) | 0;
+  }
+
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}

--- a/test/lib/dal-session-name.test.ts
+++ b/test/lib/dal-session-name.test.ts
@@ -1,0 +1,111 @@
+import { vi, type MockedFunction } from "vitest";
+
+const { mockCookieStore } = vi.hoisted(() => ({
+  mockCookieStore: {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue(mockCookieStore),
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual("react");
+  return { ...actual, cache: (fn: unknown) => fn };
+});
+
+vi.mock("@/lib/api/member-api", () => ({
+  getMemberById: vi.fn(),
+}));
+
+import { generateToken, getSessionWithName, AUTH_COOKIE } from "@/lib/dal";
+import { getMemberById } from "@/lib/api/member-api";
+
+const mockGetMemberById = getMemberById as MockedFunction<typeof getMemberById>;
+
+describe("getSessionWithName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns session with member name for valid cookie", async () => {
+    const token = generateToken(100001, true);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: token });
+    mockGetMemberById.mockResolvedValue({
+      ownerid: 100001,
+      ownername: "Kermit",
+      owneremail: "kermit@example.com",
+      ownerphone: "+15550001",
+    });
+
+    const session = await getSessionWithName();
+
+    expect(session).toEqual({ ownerid: 100001, isAdmin: true, ownername: "Kermit" });
+  });
+
+  it("falls back to Member when getMemberById returns null", async () => {
+    const token = generateToken(100001, false);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: token });
+    mockGetMemberById.mockResolvedValue(null);
+
+    const session = await getSessionWithName();
+
+    expect(session.ownername).toBe("Member");
+  });
+
+  it("throws UNAUTHORIZED when no cookie present", async () => {
+    mockCookieStore.get.mockReturnValue(undefined);
+
+    await expect(getSessionWithName()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("throws UNAUTHORIZED when token is expired", async () => {
+    const payload = `100001|1|${Date.now() - 3_600_001}`;
+    const crypto = await import("crypto");
+    const secret = (await import("@/lib/dal")).getSecret();
+    const signature = crypto.createHmac("sha256", secret).update(payload).digest("hex").slice(0, 8);
+    const expiredToken = `${payload}|${signature}`;
+
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: expiredToken });
+
+    await expect(getSessionWithName()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("calls getMemberById with session ownerid", async () => {
+    const token = generateToken(100050, false);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: token });
+    mockGetMemberById.mockResolvedValue({
+      ownerid: 100050,
+      ownername: "Alice",
+      owneremail: "alice@example.com",
+      ownerphone: "+15550050",
+    });
+
+    await getSessionWithName();
+
+    expect(mockGetMemberById).toHaveBeenCalledWith(100050);
+  });
+
+  it("propagates error when getMemberById throws", async () => {
+    const token = generateToken(100001, true);
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: token });
+    mockGetMemberById.mockRejectedValue(new Error("API unavailable"));
+
+    await expect(getSessionWithName()).rejects.toThrow("API unavailable");
+  });
+
+  it("throws UNAUTHORIZED for empty cookie value", async () => {
+    mockCookieStore.get.mockReturnValue({ name: AUTH_COOKIE, value: "" });
+
+    await expect(getSessionWithName()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+});

--- a/test/services/contact-group-enrichment.test.ts
+++ b/test/services/contact-group-enrichment.test.ts
@@ -1,0 +1,114 @@
+import { vi } from "vitest";
+import { groupAlpha, memberAlice, memberBob } from "../mocks/contact-groups";
+import { enrichGroupMembers } from "@/services/contact-group";
+import type { GroupWithMembers } from "@/services/contact-group";
+
+vi.mock("@/lib/api/member-api", () => ({
+  getMemberDetails: vi.fn(),
+}));
+
+import { getMemberDetails } from "@/lib/api/member-api";
+
+const mockGroup: GroupWithMembers = {
+  ...groupAlpha,
+  members: [memberAlice, memberBob],
+  memberCount: 2,
+};
+
+describe("enrichGroupMembers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps member details onto group members", async () => {
+    vi.mocked(getMemberDetails).mockResolvedValue([
+      { ownerid: 10, ownername: "Alice Smith", owneremail: "alice@example.com", ownerphone: "+15550001" },
+      { ownerid: 20, ownername: "Bob Jones", owneremail: "bob@example.com", ownerphone: "+15550002" },
+    ]);
+
+    const result = await enrichGroupMembers(mockGroup);
+
+    expect(result.members).toHaveLength(2);
+    expect(result.members[0].ownername).toBe("Alice Smith");
+    expect(result.members[0].owneremail).toBe("alice@example.com");
+    expect(result.members[1].ownername).toBe("Bob Jones");
+    expect(result.members[1].owneremail).toBe("bob@example.com");
+    expect(result.memberCount).toBe(2);
+  });
+
+  it("handles empty member list without calling API", async () => {
+    const emptyGroup: GroupWithMembers = { ...groupAlpha, members: [], memberCount: 0 };
+
+    const result = await enrichGroupMembers(emptyGroup);
+
+    expect(result.members).toEqual([]);
+    expect(getMemberDetails).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Unknown Member when member not found in portal", async () => {
+    vi.mocked(getMemberDetails).mockResolvedValue([
+      { ownerid: 10, ownername: "Alice Smith", owneremail: "alice@example.com", ownerphone: "+15550001" },
+    ]);
+
+    const result = await enrichGroupMembers(mockGroup);
+
+    expect(result.members[0].ownername).toBe("Alice Smith");
+    expect(result.members[1].ownername).toBe("Unknown Member");
+    expect(result.members[1].owneremail).toBe("");
+  });
+
+  it("handles partial API response", async () => {
+    vi.mocked(getMemberDetails).mockResolvedValue([
+      { ownerid: 20, ownername: "Bob Jones", owneremail: "bob@example.com", ownerphone: "+15550002" },
+    ]);
+
+    const result = await enrichGroupMembers(mockGroup);
+
+    expect(result.members[0].ownername).toBe("Unknown Member");
+    expect(result.members[1].ownername).toBe("Bob Jones");
+  });
+
+  it("calls getMemberDetails once with all member IDs", async () => {
+    vi.mocked(getMemberDetails).mockResolvedValue([
+      { ownerid: 10, ownername: "Alice Smith", owneremail: "alice@example.com", ownerphone: "+15550001" },
+      { ownerid: 20, ownername: "Bob Jones", owneremail: "bob@example.com", ownerphone: "+15550002" },
+    ]);
+
+    await enrichGroupMembers(mockGroup);
+
+    expect(getMemberDetails).toHaveBeenCalledTimes(1);
+    expect(getMemberDetails).toHaveBeenCalledWith([10, 20]);
+  });
+
+  it("falls back for all members when API returns empty array", async () => {
+    vi.mocked(getMemberDetails).mockResolvedValue([]);
+
+    const result = await enrichGroupMembers(mockGroup);
+
+    expect(result.members[0].ownername).toBe("Unknown Member");
+    expect(result.members[0].owneremail).toBe("");
+    expect(result.members[1].ownername).toBe("Unknown Member");
+    expect(result.members[1].owneremail).toBe("");
+  });
+
+  it("preserves original member fields alongside enriched fields", async () => {
+    vi.mocked(getMemberDetails).mockResolvedValue([
+      { ownerid: 10, ownername: "Alice Smith", owneremail: "alice@example.com", ownerphone: "+15550001" },
+    ]);
+
+    const result = await enrichGroupMembers(mockGroup);
+
+    expect(result.members[0].memberId).toBe(10);
+    expect(result.members[0].groupId).toBe(1);
+    expect(result.members[0].notifyEmail).toBe(true);
+    expect(result.members[0].ownername).toBe("Alice Smith");
+  });
+
+  it("throws on API error", async () => {
+    vi.mocked(getMemberDetails).mockRejectedValue(new Error("API unavailable"));
+
+    await expect(enrichGroupMembers(mockGroup)).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+  });
+});

--- a/test/services/message-history.test.ts
+++ b/test/services/message-history.test.ts
@@ -1,0 +1,147 @@
+import { prismaMock } from "../mocks/prisma";
+import { getGroupMessageHistory } from "@/services/message";
+
+vi.mock("@/services/contact-group", () => ({
+  getGroupRecipients: vi.fn(),
+}));
+
+vi.mock("@/services/email", () => ({
+  sendGroupEmails: vi.fn(),
+}));
+
+vi.mock("@/lib/api/member-api", () => ({
+  getMemberDetails: vi.fn(),
+  getAllActiveMemberIds: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: { SMS_ENABLED: false, FROM_EMAIL: "no-reply@prfc.coop" },
+}));
+
+const testMessages = [
+  {
+    id: 3,
+    subject: "Latest Update",
+    body: "Body of latest update",
+    sentAt: new Date("2024-01-17T10:00:00Z"),
+    senderId: 100001,
+    emailCount: 5,
+    smsCount: 0,
+    failedCount: 0,
+  },
+  {
+    id: 2,
+    subject: "Second Message",
+    body: "Body of second message",
+    sentAt: new Date("2024-01-16T10:00:00Z"),
+    senderId: 100001,
+    emailCount: 3,
+    smsCount: 0,
+    failedCount: 1,
+  },
+  {
+    id: 1,
+    subject: "First Message",
+    body: "Body of first message",
+    sentAt: new Date("2024-01-15T10:00:00Z"),
+    senderId: 100002,
+    emailCount: 4,
+    smsCount: 0,
+    failedCount: 0,
+  },
+];
+
+describe("getGroupMessageHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns messages ordered by sentAt desc", async () => {
+    prismaMock.message.findMany.mockResolvedValue(testMessages as never);
+
+    const result = await getGroupMessageHistory(5);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe(3);
+    expect(result[1].id).toBe(2);
+    expect(result[2].id).toBe(1);
+  });
+
+  it("uses select with only summary fields", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    await getGroupMessageHistory(5);
+
+    expect(prismaMock.message.findMany).toHaveBeenCalledWith({
+      where: { groupId: 5 },
+      select: {
+        id: true,
+        subject: true,
+        body: true,
+        sentAt: true,
+        senderId: true,
+        emailCount: true,
+        smsCount: true,
+        failedCount: true,
+      },
+      orderBy: { sentAt: "desc" },
+      take: 20,
+    });
+  });
+
+  it("applies default limit of 20", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    await getGroupMessageHistory(5);
+
+    expect(prismaMock.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 20 }));
+  });
+
+  it("respects custom limit", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    await getGroupMessageHistory(5, 10);
+
+    expect(prismaMock.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 10 }));
+  });
+
+  it("clamps limit to max of 100", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    await getGroupMessageHistory(5, 500);
+
+    expect(prismaMock.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 100 }));
+  });
+
+  it("clamps zero limit to 1", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    await getGroupMessageHistory(5, 0);
+
+    expect(prismaMock.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 1 }));
+  });
+
+  it("clamps negative limit to 1", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    await getGroupMessageHistory(5, -5);
+
+    expect(prismaMock.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 1 }));
+  });
+
+  it("returns empty array when no messages exist", async () => {
+    prismaMock.message.findMany.mockResolvedValue([] as never);
+
+    const result = await getGroupMessageHistory(999);
+
+    expect(result).toEqual([]);
+  });
+
+  it("throws INTERNAL_ERROR on database failure", async () => {
+    prismaMock.message.findMany.mockRejectedValue(new Error("Database down"));
+
+    await expect(getGroupMessageHistory(5)).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+  });
+});

--- a/test/utils/avatar.test.ts
+++ b/test/utils/avatar.test.ts
@@ -1,0 +1,59 @@
+import { getInitials, getAvatarColor } from "@/utils/avatar";
+
+describe("getInitials", () => {
+  it("returns two initials from first and last name", () => {
+    expect(getInitials("John Smith")).toBe("JS");
+  });
+
+  it("returns single initial for single name", () => {
+    expect(getInitials("Alice")).toBe("A");
+  });
+
+  it("returns first and last initials for three-part name", () => {
+    expect(getInitials("Mary Jane Watson")).toBe("MW");
+  });
+
+  it("handles extra whitespace", () => {
+    expect(getInitials("  Bob  Lee  ")).toBe("BL");
+  });
+
+  it("returns ? for empty string", () => {
+    expect(getInitials("")).toBe("?");
+  });
+
+  it("returns ? for whitespace-only string", () => {
+    expect(getInitials("   ")).toBe("?");
+  });
+
+  it("uppercases lowercase input", () => {
+    expect(getInitials("john smith")).toBe("JS");
+  });
+
+  it("handles accented characters", () => {
+    expect(getInitials("José García")).toBe("JG");
+  });
+
+  it("handles names with apostrophes", () => {
+    expect(getInitials("O'Brien Smith")).toBe("OS");
+  });
+
+  it("handles hyphenated names as single parts", () => {
+    expect(getInitials("Mary-Jane Watson")).toBe("MW");
+  });
+});
+
+describe("getAvatarColor", () => {
+  it("is deterministic", () => {
+    const color1 = getAvatarColor("Kermit");
+    const color2 = getAvatarColor("Kermit");
+    expect(color1).toBe(color2);
+  });
+
+  it("returns a valid hex color", () => {
+    expect(getAvatarColor("Kermit")).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it("returns a color from the palette for empty string", () => {
+    expect(getAvatarColor("")).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,22 +8,45 @@ nextEnv.loadEnvConfig(process.cwd());
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
-    environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
-    include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
-    exclude: ["node_modules", ".next", "e2e"],
-    environmentMatchGlobs: [
-      ["test/services/**", "node"],
-      ["test/actions/**", "node"],
-      ["test/api/**", "node"],
-      ["test/utils/errors.test.ts", "node"],
-      ["test/auth/**", "node"],
-    ],
     coverage: {
       provider: "v8",
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/components/ui/**", "src/generated/**"],
     },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "node",
+          environment: "node",
+          include: [
+            "test/services/**",
+            "test/actions/**",
+            "test/api/**",
+            "test/auth/**",
+            "test/lib/**",
+            "test/utils/errors.test.ts",
+          ],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "jsdom",
+          environment: "jsdom",
+          include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
+          exclude: [
+            "test/services/**",
+            "test/actions/**",
+            "test/api/**",
+            "test/auth/**",
+            "test/lib/**",
+            "test/utils/errors.test.ts",
+          ],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #77

## What changed?

- Added `getSessionWithName()` to `src/lib/dal.ts` for member display name in UI
- Added `enrichGroupMembers()` to `src/services/contact-group.ts` for member name/email lookup
- Created `src/utils/avatar.ts` with `getInitials()` and `getAvatarColor()` for avatar fallbacks
- Added `getGroupMessageHistory()` to `src/services/message.ts` for group message history query
- Modernized `vitest.config.mts` to use projects with `extends: true`

## How to test

1. Run `npm run build` - should pass
2. Run `npm run test` - all 243 tests should pass
3. Verify no regressions in existing auth, contact-group, and message tests

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers