### PR TITLE
feat: home dashboard page (#88)

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -14,8 +14,8 @@ setup("authenticate as admin", async ({ page }) => {
   await page.getByLabel("Select Member").selectOption("100001");
   await page.getByRole("button", { name: "Login" }).click();
 
-  await page.waitForURL("/");
-  await expect(page).toHaveURL("/");
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
   await page.context().storageState({ path: ADMIN_AUTH_FILE });
 });
 
@@ -26,7 +26,7 @@ setup("authenticate as member", async ({ page }) => {
   await page.getByLabel("Select Member").selectOption("100003");
   await page.getByRole("button", { name: "Login" }).click();
 
-  await page.waitForURL("/");
-  await expect(page).toHaveURL("/");
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
   await page.context().storageState({ path: MEMBER_AUTH_FILE });
 });

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, type Page, type Locator } from "@playwright/test";
 
+let seedGroupName: string;
+
 function getOpenDialog(page: Page): Locator {
   return page.locator('[role="dialog"][data-state="open"]');
 }
@@ -12,11 +14,63 @@ function getGroupCards(page: Page): Locator {
   return page.locator("button").filter({ hasText: /\d+ members?/ });
 }
 
+function isServerAction(resp: { request: () => { method: () => string; headers: () => Record<string, string> } }) {
+  return resp.request().method() === "POST" && !!resp.request().headers()["next-action"];
+}
+
+async function clickCardAndWaitForDetail(page: Page, card: Locator) {
+  const actionPromise = page.waitForResponse((resp) => isServerAction(resp));
+  await card.click();
+  await actionPromise;
+  await expect(getOpenDialog(page)).toBeVisible();
+}
+
+async function deleteGroupByName(page: Page, name: string) {
+  await page.goto("/groups");
+  const card = page.getByText(name, { exact: true });
+  if ((await card.count()) === 0) return;
+
+  await clickCardAndWaitForDetail(page, card.first());
+  await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
+  await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();
+  await getOpenDialog(page).getByRole("button", { name: "Delete" }).click();
+  await expect(getOpenAlertDialog(page)).toBeVisible();
+
+  const deletePromise = page.waitForResponse((resp) => isServerAction(resp));
+  await getOpenAlertDialog(page).getByRole("button", { name: "Confirm" }).click();
+  await deletePromise;
+  await expect(page.getByText("Group deleted successfully")).toBeVisible();
+}
+
+test.beforeAll(async ({ browser }) => {
+  seedGroupName = `E2E Seed ${Date.now()} ${Math.random().toString(36).slice(2, 6)}`;
+  const page = await browser.newPage();
+  await page.goto("/groups");
+  await page.getByRole("button", { name: "Add new group" }).click();
+  const dialog = getOpenDialog(page);
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel("Group Name").fill(seedGroupName);
+
+  const createPromise = page.waitForResponse((resp) => isServerAction(resp));
+  await dialog.getByRole("button", { name: "Create Group" }).click();
+  await createPromise;
+  await expect(page.getByText("Group created successfully")).toBeVisible();
+  await expect(getOpenDialog(page)).not.toBeVisible();
+  await page.close();
+});
+
+test.afterAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  await deleteGroupByName(page, seedGroupName);
+  await page.close();
+});
+
 test.describe("Groups page load", () => {
   test("displays group cards and add card", async ({ page }) => {
     await page.goto("/groups");
 
     await expect(page.getByRole("button", { name: "Add new group" })).toBeVisible();
+    await expect(getGroupCards(page).first()).toBeVisible();
   });
 
   test("shows correct heading for role", async ({ page }) => {
@@ -33,29 +87,17 @@ test.describe("Group detail modal", () => {
   test("clicking a group card opens the detail modal", async ({ page }) => {
     await page.goto("/groups");
 
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
 
-    await cards.first().click();
-
-    const dialog = getOpenDialog(page);
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByLabel("Group Name")).toBeVisible();
+    await expect(getOpenDialog(page).getByLabel("Group Name")).toBeVisible();
   });
 
   test("detail modal shows group name, description, and members section", async ({ page }) => {
     await page.goto("/groups");
 
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
-    await cards.first().click();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
 
     const dialog = getOpenDialog(page);
-    await expect(dialog).toBeVisible();
-
     await expect(dialog.getByLabel("Group Name")).toBeVisible();
     await expect(dialog.getByText("Members")).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Edit" })).toBeVisible();
@@ -65,12 +107,7 @@ test.describe("Group detail modal", () => {
   test("detail modal closes via Escape key", async ({ page }) => {
     await page.goto("/groups");
 
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
-    await cards.first().click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
 
     await page.keyboard.press("Escape");
     await expect(getOpenDialog(page)).not.toBeVisible();
@@ -79,15 +116,9 @@ test.describe("Group detail modal", () => {
   test("Edit button transitions to edit modal with Save Changes", async ({ page }) => {
     await page.goto("/groups");
 
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
 
-    await cards.first().click();
-    const dialog = getOpenDialog(page);
-    await expect(dialog).toBeVisible();
-
-    await dialog.getByRole("button", { name: "Edit" }).click();
+    await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
 
     const editDialog = getOpenDialog(page);
     await expect(editDialog.getByRole("button", { name: "Save Changes" })).toBeVisible();
@@ -97,22 +128,16 @@ test.describe("Group detail modal", () => {
 test.describe("Group edit modal", () => {
   async function openEditModal(page: Page) {
     await page.goto("/groups");
-    const cards = getGroupCards(page);
-    await cards.first().click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
     await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();
   }
 
   test("pre-populates name and description from the group", async ({ page }) => {
     await page.goto("/groups");
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
 
-    await cards.first().click();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
     const detailDialog = getOpenDialog(page);
-    await expect(detailDialog).toBeVisible();
     const groupName = await detailDialog.getByLabel("Group Name").inputValue();
 
     await detailDialog.getByRole("button", { name: "Edit" }).click();
@@ -123,11 +148,6 @@ test.describe("Group edit modal", () => {
   });
 
   test("submitting with empty name shows validation error", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openEditModal(page);
 
     const dialog = getOpenDialog(page);
@@ -138,11 +158,6 @@ test.describe("Group edit modal", () => {
   });
 
   test("saving valid changes shows success toast and closes modal", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openEditModal(page);
 
     const dialog = getOpenDialog(page);
@@ -151,28 +166,28 @@ test.describe("Group edit modal", () => {
 
     await nameInput.clear();
     await nameInput.fill(originalName + " Edited");
+
+    const savePromise = page.waitForResponse((resp) => isServerAction(resp));
     await dialog.getByRole("button", { name: "Save Changes" }).click();
+    await savePromise;
 
     await expect(page.getByText("Group updated successfully")).toBeVisible();
     await expect(getOpenDialog(page)).not.toBeVisible();
 
-    await page.getByText(originalName + " Edited").click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, page.getByText(originalName + " Edited"));
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
     await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();
     const restoreInput = getOpenDialog(page).getByLabel("Group Name");
     await restoreInput.clear();
     await restoreInput.fill(originalName);
+
+    const restorePromise = page.waitForResponse((resp) => isServerAction(resp));
     await getOpenDialog(page).getByRole("button", { name: "Save Changes" }).click();
+    await restorePromise;
     await expect(page.getByText("Group updated successfully")).toBeVisible();
   });
 
   test("Delete button opens delete confirmation", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openEditModal(page);
 
     await getOpenDialog(page).getByRole("button", { name: "Delete" }).click();
@@ -183,11 +198,6 @@ test.describe("Group edit modal", () => {
   });
 
   test("Add Members button opens add members modal", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openEditModal(page);
 
     await getOpenDialog(page).getByRole("button", { name: "Add members to group" }).click();
@@ -201,9 +211,7 @@ test.describe("Group edit modal", () => {
 test.describe("Delete group modal", () => {
   async function openDeleteModal(page: Page) {
     await page.goto("/groups");
-    const cards = getGroupCards(page);
-    await cards.first().click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
     await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();
     await getOpenDialog(page).getByRole("button", { name: "Delete" }).click();
@@ -211,11 +219,6 @@ test.describe("Delete group modal", () => {
   }
 
   test("cancel returns to edit modal", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openDeleteModal(page);
 
     await getOpenAlertDialog(page).getByRole("button", { name: "Cancel" }).click();
@@ -266,20 +269,25 @@ test.describe("Create group modal", () => {
     const dialog = getOpenDialog(page);
     await dialog.getByLabel("Group Name").fill(uniqueName);
     await dialog.getByLabel("Description (Optional)").fill("Created by e2e test");
+
+    const createPromise = page.waitForResponse((resp) => isServerAction(resp));
     await dialog.getByRole("button", { name: "Create Group" }).click();
+    await createPromise;
 
     await expect(page.getByText("Group created successfully")).toBeVisible();
     await expect(getOpenDialog(page)).not.toBeVisible();
 
     await expect(page.getByText(uniqueName)).toBeVisible();
 
-    await page.getByText(uniqueName).click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, page.getByText(uniqueName));
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
     await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();
     await getOpenDialog(page).getByRole("button", { name: "Delete" }).click();
     await expect(getOpenAlertDialog(page)).toBeVisible();
+
+    const deletePromise = page.waitForResponse((resp) => isServerAction(resp));
     await getOpenAlertDialog(page).getByRole("button", { name: "Confirm" }).click();
+    await deletePromise;
     await expect(page.getByText("Group deleted successfully")).toBeVisible();
   });
 
@@ -301,9 +309,7 @@ test.describe("Create group modal", () => {
 test.describe("Add members modal", () => {
   async function openAddMembersModal(page: Page) {
     await page.goto("/groups");
-    const cards = getGroupCards(page);
-    await cards.first().click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
     await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();
     await getOpenDialog(page).getByRole("button", { name: "Add members to group" }).click();
@@ -311,11 +317,6 @@ test.describe("Add members modal", () => {
   }
 
   test("shows member list with checkboxes", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openAddMembersModal(page);
 
     const dialog = getOpenDialog(page);
@@ -325,11 +326,6 @@ test.describe("Add members modal", () => {
   });
 
   test("search filters members by name", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openAddMembersModal(page);
 
     const dialog = getOpenDialog(page);
@@ -346,11 +342,6 @@ test.describe("Add members modal", () => {
   });
 
   test("saving with no new selections returns to edit modal", async ({ page }) => {
-    const cards = getGroupCards(page);
-    await page.goto("/groups");
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
     await openAddMembersModal(page);
 
     await getOpenDialog(page).getByRole("button", { name: "Save" }).click();
@@ -364,12 +355,7 @@ test.describe("Full modal navigation chains", () => {
   test("card → detail → edit → delete → cancel → back to edit → close", async ({ page }) => {
     await page.goto("/groups");
 
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
-    await cards.first().click();
-    await expect(getOpenDialog(page)).toBeVisible({ timeout: 10000 });
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
     await expect(getOpenDialog(page).getByRole("button", { name: "Edit" })).toBeVisible();
 
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
@@ -389,12 +375,7 @@ test.describe("Full modal navigation chains", () => {
   test("card → detail → edit → add members → save → back to edit", async ({ page }) => {
     await page.goto("/groups");
 
-    const cards = getGroupCards(page);
-    const cardCount = await cards.count();
-    test.skip(cardCount === 0, "no groups to test with");
-
-    await cards.first().click();
-    await expect(getOpenDialog(page)).toBeVisible();
+    await clickCardAndWaitForDetail(page, getGroupCards(page).first());
 
     await getOpenDialog(page).getByRole("button", { name: "Edit" }).click();
     await expect(getOpenDialog(page).getByRole("button", { name: "Save Changes" })).toBeVisible();

--- a/e2e/home-dashboard-member.spec.ts
+++ b/e2e/home-dashboard-member.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home dashboard - member", () => {
+  test("shows greeting with member name", async ({ page }) => {
+    await page.goto("/home");
+
+    const heading = page.getByRole("heading", { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText("America Rempel");
+  });
+
+  test("shows My Groups heading for member", async ({ page }) => {
+    await page.goto("/home");
+
+    await expect(page.getByRole("heading", { level: 2, name: "My Groups" })).toBeVisible();
+  });
+
+  test("shows empty state or member-specific groups", async ({ page }) => {
+    await page.goto("/home");
+
+    const cards = page.locator("div").filter({ hasText: /\d+ members?/ });
+    const cardCount = await cards.count();
+
+    if (cardCount === 0) {
+      await expect(page.getByText("No groups yet.")).toBeVisible();
+    } else {
+      await expect(cards.first()).toBeVisible();
+    }
+  });
+});

--- a/e2e/home-dashboard.spec.ts
+++ b/e2e/home-dashboard.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home dashboard - admin", () => {
+  test("shows greeting with admin name", async ({ page }) => {
+    await page.goto("/home");
+
+    const heading = page.getByRole("heading", { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText("Toby Deckow");
+  });
+
+  test("greeting starts with time-of-day prefix", async ({ page }) => {
+    await page.goto("/home");
+
+    const heading = page.getByRole("heading", { level: 1 });
+    const text = await heading.textContent();
+    expect(text).toMatch(/^Good (Morning|Afternoon|Evening)/);
+  });
+
+  test("shows All Groups heading for admin", async ({ page }) => {
+    await page.goto("/home");
+
+    await expect(page.getByRole("heading", { level: 2, name: "All Groups" })).toBeVisible();
+  });
+
+  test("displays group cards or empty state", async ({ page }) => {
+    await page.goto("/home");
+
+    const cards = page.locator("div").filter({ hasText: /\d+ members?/ });
+    const cardCount = await cards.count();
+
+    if (cardCount === 0) {
+      await expect(page.getByText("No groups yet.")).toBeVisible();
+    } else {
+      await expect(cards.first()).toBeVisible();
+    }
+  });
+
+  test("group cards are not interactive on dashboard", async ({ page }) => {
+    await page.goto("/home");
+
+    const cards = page.locator("div").filter({ hasText: /\d+ members?/ });
+    const cardCount = await cards.count();
+    test.skip(cardCount === 0, "no groups to test with");
+
+    const buttons = page.locator("button").filter({ hasText: /\d+ members?/ });
+    await expect(buttons).toHaveCount(0);
+  });
+
+  test("shows sidebar and top bar layout", async ({ page }) => {
+    await page.goto("/home");
+
+    await expect(page.getByLabel("Go to home")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Notifications" })).toBeVisible();
+    await expect(page.getByLabel("User menu")).toBeVisible();
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,5 +1,17 @@
 import { test, expect } from "@playwright/test";
 
+test.describe("Home dashboard - unauthenticated", () => {
+  test("cannot access /home without session", async ({ page }) => {
+    const response = await page.goto("/home");
+
+    const url = page.url();
+    const status = response?.status() ?? 0;
+    const isRedirected = !url.includes("/home");
+    const isErrorStatus = status >= 400;
+    expect(isRedirected || isErrorStatus).toBe(true);
+  });
+});
+
 test.describe("Home Page", () => {
   test("shows referral form elements", async ({ page }) => {
     await page.goto("/");

--- a/e2e/referral-database.spec.ts
+++ b/e2e/referral-database.spec.ts
@@ -5,7 +5,7 @@ async function loginAsAdmin(page: import("@playwright/test").Page) {
   await page.getByText("Dev Tools").click();
   await page.getByLabel("Select Member").selectOption("100001");
   await page.getByRole("button", { name: "Login" }).click();
-  await page.waitForURL("/");
+  await page.waitForURL("/home");
   await page.goto("/referral-database");
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
-      testIgnore: /.*groups.*\.spec\.ts/,
+      testIgnore: [/.*groups.*\.spec\.ts/, /.*home-dashboard.*\.spec\.ts/],
     },
     {
       name: "groups-admin",
@@ -36,6 +36,24 @@ export default defineConfig({
         storageState: "playwright/.auth/member.json",
       },
       testMatch: /.*groups.*\.spec\.ts/,
+      dependencies: ["setup"],
+    },
+    {
+      name: "home-admin",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "playwright/.auth/admin.json",
+      },
+      testMatch: /home-dashboard\.spec\.ts/,
+      dependencies: ["setup"],
+    },
+    {
+      name: "home-member",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "playwright/.auth/member.json",
+      },
+      testMatch: /home-dashboard-member\.spec\.ts/,
       dependencies: ["setup"],
     },
   ],

--- a/src/app/(protected)/error.tsx
+++ b/src/app/(protected)/error.tsx
@@ -21,7 +21,7 @@ export default function ProtectedError({ error, reset }: { error: Error & { dige
             Try again
           </button>
           <Link
-            href="/"
+            href="/home"
             className="bg-prfc-border text-white px-6 py-3 rounded font-montserrat hover:bg-prfc-dark-brown transition-colors"
           >
             Go home

--- a/src/app/(protected)/home/page.tsx
+++ b/src/app/(protected)/home/page.tsx
@@ -1,0 +1,43 @@
+import { getSessionWithName } from "@/lib/dal";
+import { getAllGroups, getGroupsByOwner } from "@/services/contact-group";
+import { EntityCard } from "@/components/groups/entity-card";
+
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return "Good Morning";
+  if (hour < 17) return "Good Afternoon";
+  return "Good Evening";
+}
+
+export default async function HomePage() {
+  const session = await getSessionWithName();
+  const groups = session.isAdmin ? await getAllGroups() : await getGroupsByOwner(session.ownerid);
+
+  const greeting = getGreeting();
+  const sectionHeading = session.isAdmin ? "All Groups" : "My Groups";
+
+  return (
+    <div>
+      <h1 className="font-angkor text-3xl text-prfc-red mb-2">
+        {greeting}, {session.ownername}!
+      </h1>
+      <h2 className="font-khula font-bold text-xl mb-6">{sectionHeading}</h2>
+
+      {groups.length === 0 ? (
+        <p className="text-muted-foreground">No groups yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {groups.map((group) => (
+            <EntityCard
+              key={group.id}
+              variant="group"
+              name={group.name}
+              memberCount={group.memberCount}
+              description={group.description}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.redirect(new URL("/", req.url));
   }
 
-  const response = NextResponse.redirect(new URL("/", req.url));
+  const response = NextResponse.redirect(new URL("/home", req.url));
 
   response.cookies.set(AUTH_COOKIE, token, {
     httpOnly: true,

--- a/src/components/groups/entity-card.tsx
+++ b/src/components/groups/entity-card.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, Plus, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { getAvatarColor, getInitials } from "@/utils/avatar";
@@ -19,41 +20,50 @@ export function EntityCard({
   onClick,
 }: EntityCardProps) {
   const isAdd = variant === "add";
+  const isInteractive = !!onClick;
+  const Component = isInteractive ? "button" : "div";
+
+  const content = isAdd ? (
+    <div className="flex h-full items-center justify-center">
+      <Plus className="h-14 w-14 text-prfc-brown" />
+      <Users className="h-32 w-32 text-prfc-brown" />
+    </div>
+  ) : (
+    <div className="flex flex-col gap-4">
+      <Avatar className="h-14 w-14">
+        <AvatarFallback style={{ backgroundColor: getAvatarColor(name) }} className="text-white font-semibold">
+          {getInitials(name)}
+        </AvatarFallback>
+      </Avatar>
+
+      <div className="font-bold text-xl">{name}</div>
+
+      <div className="flex gap-2">
+        <div className="inline-flex items-center gap-2 bg-prfc-red text-white px-4 py-2 rounded-full text-sm">
+          <Users className="h-4 w-4" />
+          {memberCount} {memberCount === 1 ? "member" : "members"}
+        </div>
+      </div>
+
+      {description ? <p className="text-sm text-muted-foreground line-clamp-2">{description}</p> : null}
+
+      {isInteractive ? (
+        <ChevronRight className="absolute right-5 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
+      ) : null}
+    </div>
+  );
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <Component
+      {...(isInteractive ? { type: "button" as const, onClick } : {})}
       aria-label={isAdd ? "Add new group" : undefined}
-      className="relative w-full cursor-pointer rounded-2xl border bg-white text-left shadow-sm hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 p-5 min-h-[160px]"
-    >
-      {isAdd ? (
-        <div className="flex h-full items-center justify-center">
-          <Plus className="h-14 w-14 text-prfc-brown" />
-          <Users className="h-32 w-32 text-prfc-brown" />
-        </div>
-      ) : (
-        <div className="flex flex-col gap-4">
-          <Avatar className="h-14 w-14">
-            <AvatarFallback style={{ backgroundColor: getAvatarColor(name) }} className="text-white font-semibold">
-              {getInitials(name)}
-            </AvatarFallback>
-          </Avatar>
-
-          <div className="font-bold text-xl">{name}</div>
-
-          <div className="flex gap-2">
-            <div className="inline-flex items-center gap-2 bg-prfc-red text-white px-4 py-2 rounded-full text-sm">
-              <Users className="h-4 w-4" />
-              {memberCount} {memberCount === 1 ? "member" : "members"}
-            </div>
-          </div>
-
-          {description ? <p className="text-sm text-muted-foreground line-clamp-2">{description}</p> : null}
-
-          <ChevronRight className="absolute right-5 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
-        </div>
+      className={cn(
+        "relative w-full rounded-2xl border bg-white text-left shadow-sm p-5 min-h-[160px]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isInteractive && "cursor-pointer hover:shadow-md",
       )}
-    </button>
+    >
+      {content}
+    </Component>
   );
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -17,7 +17,7 @@ interface SidebarNavItem {
 }
 
 const SIDEBAR_ITEMS: SidebarNavItem[] = [
-  { label: "Home", href: "/", icon: LayoutGrid },
+  { label: "Home", href: "/home", icon: LayoutGrid },
   { label: "Messages", href: "/messages", icon: MessageSquareMore },
   { label: "Groups", href: "/groups", icon: UsersRound },
   { label: "Events", href: "/events", icon: CalendarDays },
@@ -25,9 +25,6 @@ const SIDEBAR_ITEMS: SidebarNavItem[] = [
 ];
 
 function isItemActive(pathname: string, href: string): boolean {
-  if (href === "/") {
-    return pathname === "/";
-  }
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -24,7 +24,7 @@ export function TopBar({ userName, userRole }: TopBarProps) {
   return (
     <header className="sticky top-0 z-30 flex h-[var(--header-height)] w-full items-center border-b border-border bg-background px-4 md:px-6">
       <div className="flex w-full items-center gap-3 md:gap-4">
-        <Link href="/" className="shrink-0 md:w-[220px]" aria-label="Go to home">
+        <Link href="/home" className="shrink-0 md:w-[220px]" aria-label="Go to home">
           <Image
             src="/assets/logo.png"
             alt="Paso Food Co-op logo"

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -12,7 +12,7 @@ export const NAV_CONFIG: Record<AuthState, NavItem[]> = {
     { label: "Sign In", href: "https://pasofoodcooperative.coop/accounts/", external: true },
   ],
   member: [
-    { label: "Home", href: "/" },
+    { label: "Home", href: "/home" },
     { label: "My Groups", href: "/groups" },
     { label: "Messages", href: "/messages" },
     { label: "Events", href: "/events" },
@@ -20,7 +20,7 @@ export const NAV_CONFIG: Record<AuthState, NavItem[]> = {
     { label: "Settings", href: "/settings" },
   ],
   admin: [
-    { label: "Home", href: "/" },
+    { label: "Home", href: "/home" },
     { label: "Groups", href: "/groups" },
     { label: "Messages", href: "/messages" },
     { label: "Events", href: "/events" },


### PR DESCRIPTION
## Developer

Sue Sue

Closes #88

## What changed?

- Created `/(protected)/home/page.tsx` — authenticated home dashboard at `/home` with time-of-day greeting, group card grid (3-column responsive), and empty state
- Updated sidebar Home link from `/` to `/home` to avoid routing conflict with the public referral page at `/`

## How to test

1. Start Docker and dev server: `npm run docker:up && npm run dev`
2. Log in via mock portal: http://localhost:3000/dev/mock-portal
3. Click "Home" in the sidebar or go to http://localhost:3000/home
4. Verify greeting shows correct time-of-day and your name
5. Verify groups display in a card grid (or empty state if no groups)
6. Log in as a member — confirm heading says "My Groups"
7. Log in as an admin — confirm heading says "All Groups"

## Screenshot
<img width="1685" height="624" alt="image" src="https://github.com/user-attachments/assets/0fc61a59-4405-429e-adce-57801db590c0" />
<img width="1688" height="758" alt="image" src="https://github.com/user-attachments/assets/eb6caf32-ef41-4aa4-9fb8-66f9917a3ef2" />

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers