### PR TITLE
feat: add event, rsvp, and user preference schema with migration

### DIFF
--- a/prisma/migrations/20260404000000_add_events_rsvp_user_preferences/migration.sql
+++ b/prisma/migrations/20260404000000_add_events_rsvp_user_preferences/migration.sql
@@ -1,0 +1,58 @@
+-- CreateEnum
+-- EventType: social, networking, volunteer, meeting
+-- RsvpStatus: going, maybe, declined
+-- (Prisma handles MySQL enum mapping)
+
+-- CreateTable
+CREATE TABLE `event` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `title` VARCHAR(200) NOT NULL,
+    `description` TEXT NULL,
+    `location` VARCHAR(200) NULL,
+    `start_date` DATETIME(3) NOT NULL,
+    `end_date` DATETIME(3) NOT NULL,
+    `rsvp_deadline` DATETIME(3) NULL,
+    `event_type` ENUM('social', 'networking', 'volunteer', 'meeting') NOT NULL,
+    `ownerid` INTEGER NOT NULL,
+    `group_id` INTEGER NULL,
+
+    INDEX `event_ownerid_idx`(`ownerid`),
+    INDEX `event_group_id_idx`(`group_id`),
+    INDEX `event_start_date_idx`(`start_date`),
+    INDEX `event_event_type_idx`(`event_type`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `event_rsvp` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `event_id` INTEGER NOT NULL,
+    `member_id` INTEGER NOT NULL,
+    `status` ENUM('going', 'maybe', 'declined') NOT NULL,
+    `responded_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `event_rsvp_member_id_idx`(`member_id`),
+    UNIQUE INDEX `event_rsvp_event_id_member_id_key`(`event_id`, `member_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `user_preference` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `member_id` INTEGER NOT NULL,
+    `notify_email_default` BOOLEAN NOT NULL DEFAULT true,
+    `notify_sms_default` BOOLEAN NOT NULL DEFAULT false,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `user_preference_member_id_key`(`member_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `event` ADD CONSTRAINT `event_group_id_fkey` FOREIGN KEY (`group_id`) REFERENCES `contact_group`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `event_rsvp` ADD CONSTRAINT `event_rsvp_event_id_fkey` FOREIGN KEY (`event_id`) REFERENCES `event`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model ContactGroup {
 
   members  ContactGroupMember[]
   messages Message[]
+  events   Event[]
 
   @@index([ownerid])
   @@map("contact_group")
@@ -137,4 +138,66 @@ model MessageRecipient {
   @@index([memberId, sentAt])
   @@index([externalId])
   @@map("message_recipient")
+}
+
+enum EventType {
+  social
+  networking
+  volunteer
+  meeting
+}
+
+enum RsvpStatus {
+  going
+  maybe
+  declined
+}
+
+model Event {
+  id           Int        @id @default(autoincrement())
+  createdAt    DateTime   @default(now()) @map("created_at")
+  updatedAt    DateTime   @updatedAt @map("updated_at")
+  title        String     @db.VarChar(200)
+  description  String?    @db.Text
+  location     String?    @db.VarChar(200)
+  startDate    DateTime   @map("start_date")
+  endDate      DateTime   @map("end_date")
+  rsvpDeadline DateTime?  @map("rsvp_deadline")
+  eventType    EventType  @map("event_type")
+  ownerid      Int
+  groupId      Int?       @map("group_id")
+
+  group ContactGroup? @relation(fields: [groupId], references: [id], onDelete: SetNull)
+  rsvps EventRsvp[]
+
+  @@index([ownerid])
+  @@index([groupId])
+  @@index([startDate])
+  @@index([eventType])
+  @@map("event")
+}
+
+model EventRsvp {
+  id          Int        @id @default(autoincrement())
+  eventId     Int        @map("event_id")
+  memberId    Int        @map("member_id")
+  status      RsvpStatus
+  respondedAt DateTime   @default(now()) @map("responded_at")
+
+  event Event @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  @@unique([eventId, memberId])
+  @@index([memberId])
+  @@map("event_rsvp")
+}
+
+model UserPreference {
+  id                 Int      @id @default(autoincrement())
+  memberId           Int      @unique @map("member_id")
+  notifyEmailDefault Boolean  @default(true) @map("notify_email_default")
+  notifySmsDefault   Boolean  @default(false) @map("notify_sms_default")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
+
+  @@map("user_preference")
 }


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Added Prisma schema and migration for events, RSVP tracking, and user notification preferences.

1. Event model - stores title, description, location, start/end dates, RSVP deadline, event type (social/networking/volunteer/meeting), creator (ownerid), and optional group association. Foreign key to contact_group with SET NULL on delete (same pattern as Message.groupId).

2. EventRsvp model - tracks per-member RSVP status (going/maybe/declined) for each event. Unique constraint on (eventId, memberId) prevents duplicate RSVPs. Cascades on event delete.

3. UserPreference model - stores global notification defaults per member (notifyEmailDefault, notifySmsDefault). Separate from the per-group notifyEmail/notifySms on ContactGroupMember. One row per member (unique constraint on memberId).

4. EventType and RsvpStatus enums following the existing EmailSuppressionReason pattern.

All models follow existing conventions: Int autoincrement primary keys, camelCase Prisma fields with @map snake_case DB columns, ownerid as plain Int (member data lives in external Portal API), and minimal indexes for tables under 1000 rows.

## How to test

1. Run npx prisma generate - client generates without errors
2. Run npm run build - succeeds
3. Start Docker (npm run docker:up) and run npx prisma migrate dev - migration applies cleanly
4. Run npx prisma studio - verify event, event_rsvp, and user_preference tables exist with correct columns

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers