### PR TITLE
feat: add settings, profile, and sms consent backend services

### DIFF
--- a/src/actions/profile.ts
+++ b/src/actions/profile.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { verifySession } from "@/lib/dal";
+import { getMemberProfile } from "@/services/profile";
+import { transformError } from "@/utils/errors";
+import type { ActionResult } from "@/lib/action-types";
+import type { MemberProfile } from "@/services/profile";
+
+export async function fetchProfile(): Promise<ActionResult<MemberProfile>> {
+  try {
+    const session = await verifySession();
+    const profile = await getMemberProfile(session.ownerid, session.isAdmin);
+    return { success: true, data: profile };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { verifySession } from "@/lib/dal";
 import { UpdatePreferencesSchema, RevokeSmsConsentSchema } from "@/schema/settings";
 import { getMemberSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
@@ -25,6 +26,7 @@ export async function revokeSmsConsentAction(input: { method: string; message: s
     const session = await verifySession();
     const validated = RevokeSmsConsentSchema.parse(input);
     await revokeSmsConsent(session.ownerid, validated.method, validated.message);
+    revalidatePath("/settings");
     return { success: true };
   } catch (error) {
     const appError = transformError(error);
@@ -51,6 +53,7 @@ export async function updateUserPreferencesAction(input: {
     const session = await verifySession();
     const validated = UpdatePreferencesSchema.parse(input);
     const updated = await updateUserPreferences(session.ownerid, validated);
+    revalidatePath("/settings");
     return { success: true, data: updated };
   } catch (error) {
     const appError = transformError(error);

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { verifySession } from "@/lib/dal";
+import { UpdatePreferencesSchema, RevokeSmsConsentSchema } from "@/schema/settings";
+import { getMemberSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
+import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
+import { transformError } from "@/utils/errors";
+import type { ActionResult } from "@/lib/action-types";
+import type { SmsConsentRecord } from "@/services/sms-consent";
+import type { UserPreferenceData } from "@/services/user-preference";
+
+export async function fetchSmsConsent(): Promise<ActionResult<SmsConsentRecord | null>> {
+  try {
+    const session = await verifySession();
+    const consent = await getMemberSmsConsent(session.ownerid);
+    return { success: true, data: consent };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function revokeSmsConsentAction(input: { method: string; message: string | null }): Promise<ActionResult> {
+  try {
+    const session = await verifySession();
+    const validated = RevokeSmsConsentSchema.parse(input);
+    await revokeSmsConsent(session.ownerid, validated.method, validated.message);
+    return { success: true };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function fetchUserPreferences(): Promise<ActionResult<UserPreferenceData>> {
+  try {
+    const session = await verifySession();
+    const prefs = await getUserPreferences(session.ownerid);
+    return { success: true, data: prefs };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function updateUserPreferencesAction(input: {
+  notifyEmailDefault?: boolean;
+  notifySmsDefault?: boolean;
+}): Promise<ActionResult<UserPreferenceData>> {
+  try {
+    const session = await verifySession();
+    const validated = UpdatePreferencesSchema.parse(input);
+    const updated = await updateUserPreferences(session.ownerid, validated);
+    return { success: true, data: updated };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const UpdatePreferencesSchema = z
+  .object({
+    notifyEmailDefault: z.boolean().optional(),
+    notifySmsDefault: z.boolean().optional(),
+  })
+  .refine((data) => data.notifyEmailDefault !== undefined || data.notifySmsDefault !== undefined, {
+    message: "At least one notification preference must be provided",
+  });
+
+export const RevokeSmsConsentSchema = z.object({
+  method: z.string().min(1).max(50),
+  message: z.string().max(500).nullable(),
+});
+
+export type UpdatePreferences = z.infer<typeof UpdatePreferencesSchema>;
+export type RevokeSmsConsent = z.infer<typeof RevokeSmsConsentSchema>;

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,32 @@
+import "server-only";
+import { getMemberById } from "@/lib/api/member-api";
+import { splitName } from "@/utils/name";
+import { AppError } from "@/utils/errors";
+
+export interface MemberProfile {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  altPhone: string | undefined;
+  role: "Admin" | "Member";
+}
+
+export async function getMemberProfile(ownerid: number, isAdmin: boolean): Promise<MemberProfile> {
+  const member = await getMemberById(ownerid);
+
+  if (!member) {
+    throw new AppError("NOT_FOUND", "Member not found");
+  }
+
+  const { firstName, lastName } = splitName(member.ownername);
+
+  return {
+    firstName,
+    lastName,
+    email: member.owneremail,
+    phone: member.ownerphone,
+    altPhone: member.owneraltphone,
+    role: isAdmin ? "Admin" : "Member",
+  };
+}

--- a/src/services/sms-consent.ts
+++ b/src/services/sms-consent.ts
@@ -1,0 +1,65 @@
+import "server-only";
+import prisma from "@/lib/db";
+import { transformError } from "@/utils/errors";
+
+export interface SmsConsentRecord {
+  id: number;
+  memberId: number;
+  consentedAt: Date;
+  consentMethod: string;
+  consentText: string;
+  consentPurpose: string;
+  revokedAt: Date | null;
+  revokeMethod: string | null;
+}
+
+export async function getMemberSmsConsent(memberId: number): Promise<SmsConsentRecord | null> {
+  try {
+    const consent = await prisma.smsConsent.findFirst({
+      where: { memberId, revokedAt: null },
+      select: {
+        id: true,
+        memberId: true,
+        consentedAt: true,
+        consentMethod: true,
+        consentText: true,
+        consentPurpose: true,
+        revokedAt: true,
+        revokeMethod: true,
+      },
+      orderBy: { consentedAt: "desc" },
+    });
+
+    return consent;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function hasActiveConsent(memberId: number): Promise<boolean> {
+  try {
+    const consent = await prisma.smsConsent.findFirst({
+      where: { memberId, revokedAt: null },
+      select: { id: true },
+    });
+
+    return consent !== null;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function revokeSmsConsent(memberId: number, method: string, message: string | null): Promise<void> {
+  try {
+    await prisma.smsConsent.updateMany({
+      where: { memberId, revokedAt: null },
+      data: {
+        revokedAt: new Date(),
+        revokeMethod: method,
+        revokeMessage: message,
+      },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}

--- a/src/services/user-preference.ts
+++ b/src/services/user-preference.ts
@@ -1,0 +1,48 @@
+import "server-only";
+import prisma from "@/lib/db";
+import { transformError } from "@/utils/errors";
+
+export interface UserPreferenceData {
+  notifyEmailDefault: boolean;
+  notifySmsDefault: boolean;
+}
+
+const DEFAULTS: UserPreferenceData = {
+  notifyEmailDefault: true,
+  notifySmsDefault: false,
+};
+
+export async function getUserPreferences(memberId: number): Promise<UserPreferenceData> {
+  try {
+    const prefs = await prisma.userPreference.findUnique({
+      where: { memberId },
+      select: { notifyEmailDefault: true, notifySmsDefault: true },
+    });
+
+    return prefs ?? DEFAULTS;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function updateUserPreferences(
+  memberId: number,
+  data: Partial<UserPreferenceData>,
+): Promise<UserPreferenceData> {
+  try {
+    const updated = await prisma.userPreference.upsert({
+      where: { memberId },
+      create: {
+        memberId,
+        notifyEmailDefault: data.notifyEmailDefault ?? DEFAULTS.notifyEmailDefault,
+        notifySmsDefault: data.notifySmsDefault ?? DEFAULTS.notifySmsDefault,
+      },
+      update: data,
+      select: { notifyEmailDefault: true, notifySmsDefault: true },
+    });
+
+    return updated;
+  } catch (error) {
+    throw transformError(error);
+  }
+}

--- a/src/utils/name.ts
+++ b/src/utils/name.ts
@@ -1,0 +1,13 @@
+export function splitName(fullName: string): { firstName: string; lastName: string } {
+  const trimmed = fullName.trim();
+  const spaceIndex = trimmed.indexOf(" ");
+
+  if (spaceIndex === -1) {
+    return { firstName: trimmed, lastName: "" };
+  }
+
+  return {
+    firstName: trimmed.slice(0, spaceIndex),
+    lastName: trimmed.slice(spaceIndex + 1),
+  };
+}

--- a/test/actions/settings.test.ts
+++ b/test/actions/settings.test.ts
@@ -3,7 +3,13 @@ import "../mocks/dal";
 
 import { vi, type MockedFunction } from "vitest";
 import { AppError } from "@/utils/errors";
-import { mockVerifySession, mockRevalidatePath } from "../mocks";
+import {
+  mockVerifySession,
+  mockRevalidatePath,
+  activeConsentKermit,
+  defaultPreferences,
+  allDisabledPreferences,
+} from "../mocks";
 
 vi.mock("@/services/sms-consent", () => ({
   getMemberSmsConsent: vi.fn(),
@@ -29,17 +35,6 @@ const mockRevokeSmsConsent = revokeSmsConsent as MockedFunction<typeof revokeSms
 const mockGetUserPreferences = getUserPreferences as MockedFunction<typeof getUserPreferences>;
 const mockUpdateUserPreferences = updateUserPreferences as MockedFunction<typeof updateUserPreferences>;
 
-const fullConsent = {
-  id: 1,
-  memberId: 100001,
-  consentedAt: new Date("2026-01-15"),
-  consentMethod: "web_form",
-  consentText: "I agree to receive SMS messages",
-  consentPurpose: "group_notifications",
-  revokedAt: null,
-  revokeMethod: null,
-};
-
 describe("fetchSmsConsent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -47,11 +42,11 @@ describe("fetchSmsConsent", () => {
   });
 
   it("returns full consent record shape for authenticated member", async () => {
-    mockGetMemberSmsConsent.mockResolvedValue(fullConsent);
+    mockGetMemberSmsConsent.mockResolvedValue(activeConsentKermit);
 
     const result = await fetchSmsConsent();
 
-    expect(result).toEqual({ success: true, data: fullConsent });
+    expect(result).toEqual({ success: true, data: activeConsentKermit });
     expect(result.data).toHaveProperty("consentedAt");
     expect(result.data).toHaveProperty("consentMethod");
     expect(result.data).toHaveProperty("consentText");
@@ -117,14 +112,11 @@ describe("fetchUserPreferences", () => {
   });
 
   it("returns both preference fields", async () => {
-    mockGetUserPreferences.mockResolvedValue({ notifyEmailDefault: true, notifySmsDefault: false });
+    mockGetUserPreferences.mockResolvedValue(defaultPreferences);
 
     const result = await fetchUserPreferences();
 
-    expect(result).toEqual({
-      success: true,
-      data: { notifyEmailDefault: true, notifySmsDefault: false },
-    });
+    expect(result).toEqual({ success: true, data: defaultPreferences });
     expect(result.data).toHaveProperty("notifyEmailDefault");
     expect(result.data).toHaveProperty("notifySmsDefault");
   });
@@ -137,14 +129,11 @@ describe("updateUserPreferencesAction", () => {
   });
 
   it("returns updated preferences and revalidates settings path", async () => {
-    mockUpdateUserPreferences.mockResolvedValue({ notifyEmailDefault: false, notifySmsDefault: false });
+    mockUpdateUserPreferences.mockResolvedValue(allDisabledPreferences);
 
     const result = await updateUserPreferencesAction({ notifyEmailDefault: false });
 
-    expect(result).toEqual({
-      success: true,
-      data: { notifyEmailDefault: false, notifySmsDefault: false },
-    });
+    expect(result).toEqual({ success: true, data: allDisabledPreferences });
     expect(mockUpdateUserPreferences).toHaveBeenCalledWith(100001, { notifyEmailDefault: false });
     expect(mockRevalidatePath).toHaveBeenCalledWith("/settings");
   });

--- a/test/actions/settings.test.ts
+++ b/test/actions/settings.test.ts
@@ -1,13 +1,9 @@
+import "../mocks/next-cache";
+import "../mocks/dal";
+
 import { vi, type MockedFunction } from "vitest";
 import { AppError } from "@/utils/errors";
-
-vi.mock("next/cache", () => ({
-  revalidatePath: vi.fn(),
-}));
-
-vi.mock("@/lib/dal", () => ({
-  verifySession: vi.fn(),
-}));
+import { mockVerifySession, mockRevalidatePath } from "../mocks";
 
 vi.mock("@/services/sms-consent", () => ({
   getMemberSmsConsent: vi.fn(),
@@ -19,8 +15,6 @@ vi.mock("@/services/user-preference", () => ({
   updateUserPreferences: vi.fn(),
 }));
 
-import { revalidatePath } from "next/cache";
-import { verifySession } from "@/lib/dal";
 import { getMemberSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
 import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
 import {
@@ -30,8 +24,6 @@ import {
   updateUserPreferencesAction,
 } from "@/actions/settings";
 
-const mockRevalidatePath = revalidatePath as MockedFunction<typeof revalidatePath>;
-const mockVerifySession = verifySession as MockedFunction<typeof verifySession>;
 const mockGetMemberSmsConsent = getMemberSmsConsent as MockedFunction<typeof getMemberSmsConsent>;
 const mockRevokeSmsConsent = revokeSmsConsent as MockedFunction<typeof revokeSmsConsent>;
 const mockGetUserPreferences = getUserPreferences as MockedFunction<typeof getUserPreferences>;

--- a/test/actions/settings.test.ts
+++ b/test/actions/settings.test.ts
@@ -29,29 +29,53 @@ const mockRevokeSmsConsent = revokeSmsConsent as MockedFunction<typeof revokeSms
 const mockGetUserPreferences = getUserPreferences as MockedFunction<typeof getUserPreferences>;
 const mockUpdateUserPreferences = updateUserPreferences as MockedFunction<typeof updateUserPreferences>;
 
+const fullConsent = {
+  id: 1,
+  memberId: 100001,
+  consentedAt: new Date("2026-01-15"),
+  consentMethod: "web_form",
+  consentText: "I agree to receive SMS messages",
+  consentPurpose: "group_notifications",
+  revokedAt: null,
+  revokeMethod: null,
+};
+
 describe("fetchSmsConsent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
   });
 
-  it("returns consent record for authenticated member", async () => {
-    const consent = { id: 1, memberId: 100001, consentedAt: new Date() };
-    mockGetMemberSmsConsent.mockResolvedValue(consent as never);
+  it("returns full consent record shape for authenticated member", async () => {
+    mockGetMemberSmsConsent.mockResolvedValue(fullConsent);
 
     const result = await fetchSmsConsent();
 
-    expect(result.success).toBe(true);
-    expect(result.data).toEqual(consent);
+    expect(result).toEqual({ success: true, data: fullConsent });
+    expect(result.data).toHaveProperty("consentedAt");
+    expect(result.data).toHaveProperty("consentMethod");
+    expect(result.data).toHaveProperty("consentText");
+    expect(result.data).toHaveProperty("consentPurpose");
+    expect(result.data).toHaveProperty("revokedAt");
+    expect(result.data).toHaveProperty("revokeMethod");
   });
 
-  it("returns error when not authenticated", async () => {
+  it("returns null data when no active consent", async () => {
+    mockGetMemberSmsConsent.mockResolvedValue(null);
+
+    const result = await fetchSmsConsent();
+
+    expect(result).toEqual({ success: true, data: null });
+  });
+
+  it("returns error with no data field when not authenticated", async () => {
     mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
 
     const result = await fetchSmsConsent();
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Authentication required");
+    expect(result).not.toHaveProperty("data");
   });
 });
 
@@ -75,6 +99,14 @@ describe("revokeSmsConsentAction", () => {
     const result = await revokeSmsConsentAction({ method: "", message: null });
 
     expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result).not.toHaveProperty("data");
+  });
+
+  it("rejects method longer than 50 characters", async () => {
+    const result = await revokeSmsConsentAction({ method: "a".repeat(51), message: null });
+
+    expect(result.success).toBe(false);
   });
 });
 
@@ -84,14 +116,17 @@ describe("fetchUserPreferences", () => {
     mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
   });
 
-  it("returns preferences for authenticated member", async () => {
-    const prefs = { notifyEmailDefault: true, notifySmsDefault: false };
-    mockGetUserPreferences.mockResolvedValue(prefs);
+  it("returns both preference fields", async () => {
+    mockGetUserPreferences.mockResolvedValue({ notifyEmailDefault: true, notifySmsDefault: false });
 
     const result = await fetchUserPreferences();
 
-    expect(result.success).toBe(true);
-    expect(result.data).toEqual(prefs);
+    expect(result).toEqual({
+      success: true,
+      data: { notifyEmailDefault: true, notifySmsDefault: false },
+    });
+    expect(result.data).toHaveProperty("notifyEmailDefault");
+    expect(result.data).toHaveProperty("notifySmsDefault");
   });
 });
 
@@ -101,19 +136,29 @@ describe("updateUserPreferencesAction", () => {
     mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
   });
 
-  it("updates preferences and revalidates settings path", async () => {
-    const updated = { notifyEmailDefault: false, notifySmsDefault: false };
-    mockUpdateUserPreferences.mockResolvedValue(updated);
+  it("returns updated preferences and revalidates settings path", async () => {
+    mockUpdateUserPreferences.mockResolvedValue({ notifyEmailDefault: false, notifySmsDefault: false });
 
     const result = await updateUserPreferencesAction({ notifyEmailDefault: false });
 
-    expect(result.success).toBe(true);
+    expect(result).toEqual({
+      success: true,
+      data: { notifyEmailDefault: false, notifySmsDefault: false },
+    });
     expect(mockUpdateUserPreferences).toHaveBeenCalledWith(100001, { notifyEmailDefault: false });
     expect(mockRevalidatePath).toHaveBeenCalledWith("/settings");
   });
 
   it("rejects when no preference field provided", async () => {
     const result = await updateUserPreferencesAction({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result).not.toHaveProperty("data");
+  });
+
+  it("rejects non-boolean values", async () => {
+    const result = await updateUserPreferencesAction({ notifyEmailDefault: "yes" as never });
 
     expect(result.success).toBe(false);
   });

--- a/test/actions/settings.test.ts
+++ b/test/actions/settings.test.ts
@@ -1,0 +1,128 @@
+import { vi, type MockedFunction } from "vitest";
+import { AppError } from "@/utils/errors";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/dal", () => ({
+  verifySession: vi.fn(),
+}));
+
+vi.mock("@/services/sms-consent", () => ({
+  getMemberSmsConsent: vi.fn(),
+  revokeSmsConsent: vi.fn(),
+}));
+
+vi.mock("@/services/user-preference", () => ({
+  getUserPreferences: vi.fn(),
+  updateUserPreferences: vi.fn(),
+}));
+
+import { revalidatePath } from "next/cache";
+import { verifySession } from "@/lib/dal";
+import { getMemberSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
+import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
+import {
+  fetchSmsConsent,
+  revokeSmsConsentAction,
+  fetchUserPreferences,
+  updateUserPreferencesAction,
+} from "@/actions/settings";
+
+const mockRevalidatePath = revalidatePath as MockedFunction<typeof revalidatePath>;
+const mockVerifySession = verifySession as MockedFunction<typeof verifySession>;
+const mockGetMemberSmsConsent = getMemberSmsConsent as MockedFunction<typeof getMemberSmsConsent>;
+const mockRevokeSmsConsent = revokeSmsConsent as MockedFunction<typeof revokeSmsConsent>;
+const mockGetUserPreferences = getUserPreferences as MockedFunction<typeof getUserPreferences>;
+const mockUpdateUserPreferences = updateUserPreferences as MockedFunction<typeof updateUserPreferences>;
+
+describe("fetchSmsConsent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+  });
+
+  it("returns consent record for authenticated member", async () => {
+    const consent = { id: 1, memberId: 100001, consentedAt: new Date() };
+    mockGetMemberSmsConsent.mockResolvedValue(consent as never);
+
+    const result = await fetchSmsConsent();
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(consent);
+  });
+
+  it("returns error when not authenticated", async () => {
+    mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
+
+    const result = await fetchSmsConsent();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Authentication required");
+  });
+});
+
+describe("revokeSmsConsentAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+  });
+
+  it("revokes consent and revalidates settings path", async () => {
+    mockRevokeSmsConsent.mockResolvedValue(undefined);
+
+    const result = await revokeSmsConsentAction({ method: "user_settings", message: null });
+
+    expect(result.success).toBe(true);
+    expect(mockRevokeSmsConsent).toHaveBeenCalledWith(100001, "user_settings", null);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/settings");
+  });
+
+  it("rejects empty method string", async () => {
+    const result = await revokeSmsConsentAction({ method: "", message: null });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("fetchUserPreferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+  });
+
+  it("returns preferences for authenticated member", async () => {
+    const prefs = { notifyEmailDefault: true, notifySmsDefault: false };
+    mockGetUserPreferences.mockResolvedValue(prefs);
+
+    const result = await fetchUserPreferences();
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(prefs);
+  });
+});
+
+describe("updateUserPreferencesAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+  });
+
+  it("updates preferences and revalidates settings path", async () => {
+    const updated = { notifyEmailDefault: false, notifySmsDefault: false };
+    mockUpdateUserPreferences.mockResolvedValue(updated);
+
+    const result = await updateUserPreferencesAction({ notifyEmailDefault: false });
+
+    expect(result.success).toBe(true);
+    expect(mockUpdateUserPreferences).toHaveBeenCalledWith(100001, { notifyEmailDefault: false });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/settings");
+  });
+
+  it("rejects when no preference field provided", async () => {
+    const result = await updateUserPreferencesAction({});
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -7,3 +7,6 @@ export { mockGetIdempotentResponse, mockSetIdempotentResponse } from "./idempote
 export { mockValidateOrigin } from "./csrf";
 export { mockVerifySession, mockRequireAdmin } from "./dal";
 export { mockRevalidatePath } from "./next-cache";
+export { activeConsentKermit } from "./sms-consent";
+export { defaultPreferences, allEnabledPreferences, allDisabledPreferences } from "./user-preferences";
+export { memberKermit, memberAngelica } from "./members";

--- a/test/mocks/members.ts
+++ b/test/mocks/members.ts
@@ -1,0 +1,16 @@
+import type { MockMember } from "@/lib/mock-members";
+
+export const memberKermit: MockMember = {
+  ownerid: 100001,
+  ownername: "Kermit Komm",
+  owneremail: "kermit@coop.org",
+  ownerphone: "805-555-1234",
+  owneraltphone: "805-555-5678",
+};
+
+export const memberAngelica: MockMember = {
+  ownerid: 100003,
+  ownername: "Angelica Allison",
+  owneremail: "angelica@email.com",
+  ownerphone: "805-555-9876",
+};

--- a/test/mocks/sms-consent.ts
+++ b/test/mocks/sms-consent.ts
@@ -1,0 +1,12 @@
+import type { SmsConsentRecord } from "@/services/sms-consent";
+
+export const activeConsentKermit: SmsConsentRecord = {
+  id: 1,
+  memberId: 100001,
+  consentedAt: new Date("2026-01-15T10:00:00Z"),
+  consentMethod: "web_form",
+  consentText: "I agree to receive SMS messages from PRFC Connect",
+  consentPurpose: "group_notifications",
+  revokedAt: null,
+  revokeMethod: null,
+};

--- a/test/mocks/user-preferences.ts
+++ b/test/mocks/user-preferences.ts
@@ -1,0 +1,16 @@
+import type { UserPreferenceData } from "@/services/user-preference";
+
+export const defaultPreferences: UserPreferenceData = {
+  notifyEmailDefault: true,
+  notifySmsDefault: false,
+};
+
+export const allEnabledPreferences: UserPreferenceData = {
+  notifyEmailDefault: true,
+  notifySmsDefault: true,
+};
+
+export const allDisabledPreferences: UserPreferenceData = {
+  notifyEmailDefault: false,
+  notifySmsDefault: false,
+};

--- a/test/services/profile.test.ts
+++ b/test/services/profile.test.ts
@@ -6,16 +6,9 @@ vi.mock("@/lib/api/member-api", () => ({
 
 import { getMemberById } from "@/lib/api/member-api";
 import { getMemberProfile } from "@/services/profile";
+import { memberKermit } from "../mocks/members";
 
 const mockGetMemberById = getMemberById as MockedFunction<typeof getMemberById>;
-
-const mockMember = {
-  ownerid: 100001,
-  ownername: "Kermit Komm",
-  owneremail: "kermit@coop.org",
-  ownerphone: "805-555-1234",
-  owneraltphone: "805-555-5678",
-};
 
 describe("getMemberProfile", () => {
   beforeEach(() => {
@@ -23,7 +16,7 @@ describe("getMemberProfile", () => {
   });
 
   it("returns profile with split name and admin role", async () => {
-    mockGetMemberById.mockResolvedValue(mockMember);
+    mockGetMemberById.mockResolvedValue(memberKermit);
 
     const result = await getMemberProfile(100001, true);
 
@@ -38,7 +31,7 @@ describe("getMemberProfile", () => {
   });
 
   it("returns member role when isAdmin is false", async () => {
-    mockGetMemberById.mockResolvedValue(mockMember);
+    mockGetMemberById.mockResolvedValue(memberKermit);
 
     const result = await getMemberProfile(100001, false);
 
@@ -52,7 +45,7 @@ describe("getMemberProfile", () => {
   });
 
   it("handles member with no alt phone", async () => {
-    mockGetMemberById.mockResolvedValue({ ...mockMember, owneraltphone: undefined });
+    mockGetMemberById.mockResolvedValue({ ...memberKermit, owneraltphone: undefined });
 
     const result = await getMemberProfile(100001, false);
 

--- a/test/services/profile.test.ts
+++ b/test/services/profile.test.ts
@@ -1,0 +1,61 @@
+import { vi, type MockedFunction } from "vitest";
+
+vi.mock("@/lib/api/member-api", () => ({
+  getMemberById: vi.fn(),
+}));
+
+import { getMemberById } from "@/lib/api/member-api";
+import { getMemberProfile } from "@/services/profile";
+
+const mockGetMemberById = getMemberById as MockedFunction<typeof getMemberById>;
+
+const mockMember = {
+  ownerid: 100001,
+  ownername: "Kermit Komm",
+  owneremail: "kermit@coop.org",
+  ownerphone: "805-555-1234",
+  owneraltphone: "805-555-5678",
+};
+
+describe("getMemberProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns profile with split name and admin role", async () => {
+    mockGetMemberById.mockResolvedValue(mockMember);
+
+    const result = await getMemberProfile(100001, true);
+
+    expect(result).toEqual({
+      firstName: "Kermit",
+      lastName: "Komm",
+      email: "kermit@coop.org",
+      phone: "805-555-1234",
+      altPhone: "805-555-5678",
+      role: "Admin",
+    });
+  });
+
+  it("returns member role when isAdmin is false", async () => {
+    mockGetMemberById.mockResolvedValue(mockMember);
+
+    const result = await getMemberProfile(100001, false);
+
+    expect(result.role).toBe("Member");
+  });
+
+  it("throws NOT_FOUND when member does not exist", async () => {
+    mockGetMemberById.mockResolvedValue(null);
+
+    await expect(getMemberProfile(99999, false)).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("handles member with no alt phone", async () => {
+    mockGetMemberById.mockResolvedValue({ ...mockMember, owneraltphone: undefined });
+
+    const result = await getMemberProfile(100001, false);
+
+    expect(result.altPhone).toBeUndefined();
+  });
+});

--- a/test/services/sms-consent.test.ts
+++ b/test/services/sms-consent.test.ts
@@ -1,0 +1,113 @@
+import { prismaMock } from "../mocks/prisma";
+import { getMemberSmsConsent, hasActiveConsent, revokeSmsConsent } from "@/services/sms-consent";
+
+const activeConsent = {
+  id: 1,
+  memberId: 100001,
+  consentedAt: new Date("2026-01-15"),
+  consentMethod: "web_form",
+  consentText: "I agree to receive SMS messages",
+  consentPurpose: "group_notifications",
+  revokedAt: null,
+  revokeMethod: null,
+};
+
+describe("getMemberSmsConsent", () => {
+  it("returns active consent record when found", async () => {
+    prismaMock.smsConsent.findFirst.mockResolvedValue(activeConsent as never);
+
+    const result = await getMemberSmsConsent(100001);
+
+    expect(result).toEqual(activeConsent);
+  });
+
+  it("filters by revokedAt null to find only active consent", async () => {
+    prismaMock.smsConsent.findFirst.mockResolvedValue(null);
+
+    await getMemberSmsConsent(100001);
+
+    expect(prismaMock.smsConsent.findFirst).toHaveBeenCalledWith({
+      where: { memberId: 100001, revokedAt: null },
+      select: {
+        id: true,
+        memberId: true,
+        consentedAt: true,
+        consentMethod: true,
+        consentText: true,
+        consentPurpose: true,
+        revokedAt: true,
+        revokeMethod: true,
+      },
+      orderBy: { consentedAt: "desc" },
+    });
+  });
+
+  it("returns null when no active consent exists", async () => {
+    prismaMock.smsConsent.findFirst.mockResolvedValue(null);
+
+    const result = await getMemberSmsConsent(100001);
+
+    expect(result).toBeNull();
+  });
+
+  it("throws on database error", async () => {
+    prismaMock.smsConsent.findFirst.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getMemberSmsConsent(100001)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("hasActiveConsent", () => {
+  it("returns true when active consent exists", async () => {
+    prismaMock.smsConsent.findFirst.mockResolvedValue({ id: 1 } as never);
+
+    const result = await hasActiveConsent(100001);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when no active consent exists", async () => {
+    prismaMock.smsConsent.findFirst.mockResolvedValue(null);
+
+    const result = await hasActiveConsent(100001);
+
+    expect(result).toBe(false);
+  });
+
+  it("throws on database error", async () => {
+    prismaMock.smsConsent.findFirst.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(hasActiveConsent(100001)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("revokeSmsConsent", () => {
+  it("sets revokedAt and method on active records", async () => {
+    prismaMock.smsConsent.updateMany.mockResolvedValue({ count: 1 });
+
+    await revokeSmsConsent(100001, "user_settings", "No longer want SMS");
+
+    expect(prismaMock.smsConsent.updateMany).toHaveBeenCalledWith({
+      where: { memberId: 100001, revokedAt: null },
+      data: {
+        revokedAt: expect.any(Date),
+        revokeMethod: "user_settings",
+        revokeMessage: "No longer want SMS",
+      },
+    });
+  });
+
+  it("handles zero matching records without error", async () => {
+    prismaMock.smsConsent.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(revokeSmsConsent(100001, "user_settings", null)).resolves.toBeUndefined();
+  });
+
+  it("throws on database error", async () => {
+    prismaMock.smsConsent.updateMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(revokeSmsConsent(100001, "user_settings", null)).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+  });
+});

--- a/test/services/sms-consent.test.ts
+++ b/test/services/sms-consent.test.ts
@@ -1,24 +1,14 @@
 import { prismaMock } from "../mocks/prisma";
+import { activeConsentKermit } from "../mocks/sms-consent";
 import { getMemberSmsConsent, hasActiveConsent, revokeSmsConsent } from "@/services/sms-consent";
-
-const activeConsent = {
-  id: 1,
-  memberId: 100001,
-  consentedAt: new Date("2026-01-15"),
-  consentMethod: "web_form",
-  consentText: "I agree to receive SMS messages",
-  consentPurpose: "group_notifications",
-  revokedAt: null,
-  revokeMethod: null,
-};
 
 describe("getMemberSmsConsent", () => {
   it("returns active consent record when found", async () => {
-    prismaMock.smsConsent.findFirst.mockResolvedValue(activeConsent as never);
+    prismaMock.smsConsent.findFirst.mockResolvedValue(activeConsentKermit as never);
 
     const result = await getMemberSmsConsent(100001);
 
-    expect(result).toEqual(activeConsent);
+    expect(result).toEqual(activeConsentKermit);
   });
 
   it("filters by revokedAt null to find only active consent", async () => {

--- a/test/services/user-preference.test.ts
+++ b/test/services/user-preference.test.ts
@@ -1,0 +1,66 @@
+import { prismaMock } from "../mocks/prisma";
+import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
+
+describe("getUserPreferences", () => {
+  it("returns stored preferences when record exists", async () => {
+    prismaMock.userPreference.findUnique.mockResolvedValue({
+      notifyEmailDefault: false,
+      notifySmsDefault: true,
+    } as never);
+
+    const result = await getUserPreferences(100001);
+
+    expect(result).toEqual({ notifyEmailDefault: false, notifySmsDefault: true });
+  });
+
+  it("returns defaults when no record exists", async () => {
+    prismaMock.userPreference.findUnique.mockResolvedValue(null);
+
+    const result = await getUserPreferences(100001);
+
+    expect(result).toEqual({ notifyEmailDefault: true, notifySmsDefault: false });
+  });
+
+  it("throws on database error", async () => {
+    prismaMock.userPreference.findUnique.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getUserPreferences(100001)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("updateUserPreferences", () => {
+  it("upserts with provided fields and defaults for missing fields", async () => {
+    prismaMock.userPreference.upsert.mockResolvedValue({
+      notifyEmailDefault: false,
+      notifySmsDefault: false,
+    } as never);
+
+    await updateUserPreferences(100001, { notifyEmailDefault: false });
+
+    expect(prismaMock.userPreference.upsert).toHaveBeenCalledWith({
+      where: { memberId: 100001 },
+      create: { memberId: 100001, notifyEmailDefault: false, notifySmsDefault: false },
+      update: { notifyEmailDefault: false },
+      select: { notifyEmailDefault: true, notifySmsDefault: true },
+    });
+  });
+
+  it("returns updated preferences", async () => {
+    prismaMock.userPreference.upsert.mockResolvedValue({
+      notifyEmailDefault: true,
+      notifySmsDefault: true,
+    } as never);
+
+    const result = await updateUserPreferences(100001, { notifySmsDefault: true });
+
+    expect(result).toEqual({ notifyEmailDefault: true, notifySmsDefault: true });
+  });
+
+  it("throws on database error", async () => {
+    prismaMock.userPreference.upsert.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(updateUserPreferences(100001, { notifyEmailDefault: true })).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+  });
+});

--- a/test/utils/name.test.ts
+++ b/test/utils/name.test.ts
@@ -1,0 +1,23 @@
+import { splitName } from "@/utils/name";
+
+describe("splitName", () => {
+  it("splits two-word name into first and last", () => {
+    expect(splitName("Kermit Komm")).toEqual({ firstName: "Kermit", lastName: "Komm" });
+  });
+
+  it("returns full string as firstName when no space", () => {
+    expect(splitName("Kermit")).toEqual({ firstName: "Kermit", lastName: "" });
+  });
+
+  it("puts everything after first space into lastName", () => {
+    expect(splitName("Mary Jane Watson")).toEqual({ firstName: "Mary", lastName: "Jane Watson" });
+  });
+
+  it("handles empty string", () => {
+    expect(splitName("")).toEqual({ firstName: "", lastName: "" });
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(splitName("  Kermit Komm  ")).toEqual({ firstName: "Kermit", lastName: "Komm" });
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Added backend services, server actions, and Zod schemas for the Profile and Settings pages.

1. Profile service (src/services/profile.ts) - getMemberProfile() fetches member data via getMemberById(), splits ownername into firstName/lastName, and returns a typed profile shape with role. Name splitting handled by a new splitName() utility in src/utils/name.ts.

2. SMS consent service (src/services/sms-consent.ts) - three functions for the Settings page SMS consent card: getMemberSmsConsent() returns the active consent record, hasActiveConsent() does a boolean check, and revokeSmsConsent() sets revokedAt on all active consent records for a member.

3. User preference service (src/services/user-preference.ts) - getUserPreferences() returns the member's global notification defaults (notifyEmailDefault, notifySmsDefault) or falls back to defaults if no row exists. updateUserPreferences() upserts the row.

4. Zod schemas (src/schema/settings.ts) - UpdatePreferencesSchema requires at least one preference field (same refine pattern as UpdateNotificationSchema in schema/contact-group.ts). RevokeSmsConsentSchema validates method and optional message.

5. Server actions - fetchProfile(), fetchSmsConsent(), revokeSmsConsentAction(), fetchUserPreferences(), updateUserPreferencesAction(). All call verifySession() first and return ActionResult<T> following existing patterns.

## How to test

1. Run npx prisma generate - client generates without errors
2. Run npm run build - succeeds
3. Run npm run lint - no errors

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers