### PR TITLE
feat: add message history, detail, recipient, and preview query services

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -22,10 +22,23 @@ import {
   removeMembersFromGroup,
   updateMemberNotifications,
 } from "@/services/contact-group";
-import { sendGroupMessage, sendBlastMessage } from "@/services/message";
+import {
+  sendGroupMessage,
+  sendBlastMessage,
+  getAllMessageHistory,
+  getMessageById,
+  getMessageRecipients,
+  previewRecipientCounts,
+} from "@/services/message";
 import { transformError } from "@/utils/errors";
 import type { ActionResult } from "@/lib/action-types";
-import type { MessageResult } from "@/services/message";
+import type {
+  MessageResult,
+  MessageHistoryItem,
+  MessageDetail,
+  RecipientStatus,
+  RecipientCounts,
+} from "@/services/message";
 
 export interface EnrichedGroupData {
   id: number;
@@ -253,6 +266,60 @@ export async function sendBlast(input: {
     const result = await sendBlastMessage(validated, session.ownerid);
 
     return { success: true, data: result };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function fetchMessageHistory(options: {
+  limit?: number;
+  offset?: number;
+  channel?: "email" | "sms";
+}): Promise<ActionResult<MessageHistoryItem[]>> {
+  try {
+    const session = await verifySession();
+    const senderId = session.isAdmin ? undefined : session.ownerid;
+    const messages = await getAllMessageHistory({ ...options, senderId });
+    return { success: true, data: messages };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function fetchMessageDetail(messageId: number): Promise<
+  ActionResult<{
+    message: MessageDetail;
+    recipients: RecipientStatus[];
+  }>
+> {
+  try {
+    const session = await verifySession();
+    const message = await getMessageById(messageId);
+
+    if (!session.isAdmin && message.senderId !== session.ownerid) {
+      return { success: false, error: "You do not have permission to view this message" };
+    }
+
+    const recipients = await getMessageRecipients(messageId);
+    return { success: true, data: { message, recipients } };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function fetchRecipientPreview(groupId: number): Promise<ActionResult<RecipientCounts>> {
+  try {
+    const session = await verifySession();
+
+    if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) {
+      return { success: false, error: "You do not have permission to preview recipients for this group" };
+    }
+
+    const counts = await previewRecipientCounts(groupId);
+    return { success: true, data: counts };
   } catch (error) {
     const appError = transformError(error);
     return { success: false, error: appError.message };

--- a/src/schema/contact-group.ts
+++ b/src/schema/contact-group.ts
@@ -42,12 +42,17 @@ export const UpdateNotificationSchema = z
     message: "At least one notification preference must be provided",
   });
 
-export const BaseMessageSchema = z.object({
-  subject: z.string().min(1).max(200),
-  body: z.string().min(1).max(5000),
-  sendEmail: z.boolean().default(true),
-  sendSms: z.boolean().default(false),
-});
+export const BaseMessageSchema = z
+  .object({
+    subject: z.string().min(1).max(200),
+    body: z.string().min(1).max(5000),
+    sendEmail: z.boolean().default(true),
+    sendSms: z.boolean().default(false),
+  })
+  .refine((data) => !data.sendSms || data.body.length <= 160, {
+    message: "SMS messages must be 160 characters or fewer",
+    path: ["body"],
+  });
 
 export const ComposeMessageSchema = BaseMessageSchema.extend({
   groupId: z.number().int().positive(),

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -26,6 +26,44 @@ export interface MessageSummary {
   failedCount: number;
 }
 
+export interface MessageHistoryItem {
+  id: number;
+  subject: string;
+  sentAt: Date;
+  emailCount: number;
+  smsCount: number;
+  failedCount: number;
+  isBlast: boolean;
+  groupName: string | null;
+}
+
+export interface MessageDetail {
+  id: number;
+  subject: string;
+  body: string;
+  sentAt: Date;
+  senderId: number;
+  emailCount: number;
+  smsCount: number;
+  failedCount: number;
+  isBlast: boolean;
+  groupName: string | null;
+}
+
+export interface RecipientStatus {
+  memberId: number;
+  memberName: string;
+  channel: string;
+  status: string;
+  sentAt: Date | null;
+}
+
+export interface RecipientCounts {
+  emailEligible: number;
+  smsEligible: number;
+  smsIneligible: number;
+}
+
 const DEFAULT_MESSAGE_HISTORY_LIMIT = 20;
 const MAX_MESSAGE_HISTORY_LIMIT = 100;
 
@@ -321,6 +359,138 @@ export async function sendBlastMessage(input: BlastMessage, senderId: number): P
       emailCount: emailsSent,
       smsCount: smsSent,
       failedCount: emailsFailed,
+    };
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getAllMessageHistory(options: {
+  senderId?: number;
+  limit?: number;
+  offset?: number;
+  channel?: "email" | "sms";
+}): Promise<MessageHistoryItem[]> {
+  try {
+    const { senderId, limit = 50, offset = 0, channel } = options;
+    const effectiveLimit = Math.min(Math.max(1, limit), MAX_MESSAGE_HISTORY_LIMIT);
+
+    const where: Record<string, unknown> = {};
+    if (senderId) where.senderId = senderId;
+    if (channel) {
+      where.recipients = { some: { channel } };
+    }
+
+    const messages = await prisma.message.findMany({
+      where,
+      select: {
+        id: true,
+        subject: true,
+        sentAt: true,
+        emailCount: true,
+        smsCount: true,
+        failedCount: true,
+        isBlast: true,
+        group: { select: { name: true } },
+      },
+      orderBy: { sentAt: "desc" },
+      take: effectiveLimit,
+      skip: offset,
+    });
+
+    return messages.map((m) => ({
+      id: m.id,
+      subject: m.subject,
+      sentAt: m.sentAt,
+      emailCount: m.emailCount,
+      smsCount: m.smsCount,
+      failedCount: m.failedCount,
+      isBlast: m.isBlast,
+      groupName: m.group?.name ?? null,
+    }));
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getMessageById(messageId: number): Promise<MessageDetail> {
+  try {
+    const message = await prisma.message.findUnique({
+      where: { id: messageId },
+      select: {
+        id: true,
+        subject: true,
+        body: true,
+        sentAt: true,
+        senderId: true,
+        emailCount: true,
+        smsCount: true,
+        failedCount: true,
+        isBlast: true,
+        group: { select: { name: true } },
+      },
+    });
+
+    if (!message) {
+      throw new AppError("NOT_FOUND", "Message not found");
+    }
+
+    return {
+      ...message,
+      groupName: message.group?.name ?? null,
+    };
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getMessageRecipients(messageId: number): Promise<RecipientStatus[]> {
+  try {
+    const recipients = await prisma.messageRecipient.findMany({
+      where: { messageId },
+      select: {
+        memberId: true,
+        channel: true,
+        status: true,
+        sentAt: true,
+      },
+      orderBy: { memberId: "asc" },
+    });
+
+    const memberIds = Array.from(new Set(recipients.map((r) => r.memberId)));
+    const members = await getMemberDetails(memberIds);
+    const memberMap = new Map(members.map((m) => [m.ownerid, m.ownername]));
+
+    return recipients.map((r) => ({
+      memberId: r.memberId,
+      memberName: memberMap.get(r.memberId) ?? "Unknown Member",
+      channel: r.channel,
+      status: r.status,
+      sentAt: r.sentAt,
+    }));
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function previewRecipientCounts(groupId: number): Promise<RecipientCounts> {
+  try {
+    const [emailEligible, smsEligible, totalMembers] = await Promise.all([
+      prisma.contactGroupMember.count({
+        where: { groupId, notifyEmail: true },
+      }),
+      prisma.contactGroupMember.count({
+        where: { groupId, notifySms: true },
+      }),
+      prisma.contactGroupMember.count({
+        where: { groupId },
+      }),
+    ]);
+
+    return {
+      emailEligible,
+      smsEligible,
+      smsIneligible: totalMembers - smsEligible,
     };
   } catch (error) {
     throw transformError(error);

--- a/test/actions/message-query.test.ts
+++ b/test/actions/message-query.test.ts
@@ -1,0 +1,185 @@
+import "../mocks/next-cache";
+import "../mocks/dal";
+
+import { vi, type MockedFunction } from "vitest";
+import { AppError } from "@/utils/errors";
+import { mockVerifySession } from "../mocks";
+
+vi.mock("@/services/message", () => ({
+  sendGroupMessage: vi.fn(),
+  sendBlastMessage: vi.fn(),
+  getAllMessageHistory: vi.fn(),
+  getMessageById: vi.fn(),
+  getMessageRecipients: vi.fn(),
+  previewRecipientCounts: vi.fn(),
+}));
+
+vi.mock("@/services/contact-group", () => ({
+  isGroupOwner: vi.fn(),
+}));
+
+import { getAllMessageHistory, getMessageById, getMessageRecipients, previewRecipientCounts } from "@/services/message";
+import { isGroupOwner } from "@/services/contact-group";
+import { fetchMessageHistory, fetchMessageDetail, fetchRecipientPreview } from "@/actions/contact-group";
+
+const mockGetAllMessageHistory = getAllMessageHistory as MockedFunction<typeof getAllMessageHistory>;
+const mockGetMessageById = getMessageById as MockedFunction<typeof getMessageById>;
+const mockGetMessageRecipients = getMessageRecipients as MockedFunction<typeof getMessageRecipients>;
+const mockPreviewRecipientCounts = previewRecipientCounts as MockedFunction<typeof previewRecipientCounts>;
+const mockIsGroupOwner = isGroupOwner as MockedFunction<typeof isGroupOwner>;
+
+describe("fetchMessageHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns all messages for admin", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
+    const messages = [
+      {
+        id: 1,
+        subject: "Test",
+        sentAt: new Date(),
+        emailCount: 5,
+        smsCount: 0,
+        failedCount: 0,
+        isBlast: false,
+        groupName: "Garden Club",
+      },
+    ];
+    mockGetAllMessageHistory.mockResolvedValue(messages);
+
+    const result = await fetchMessageHistory({});
+
+    expect(result).toEqual({ success: true, data: messages });
+    expect(mockGetAllMessageHistory).toHaveBeenCalledWith({ senderId: undefined });
+  });
+
+  it("filters by senderId for non-admin member", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
+    mockGetAllMessageHistory.mockResolvedValue([]);
+
+    await fetchMessageHistory({});
+
+    expect(mockGetAllMessageHistory).toHaveBeenCalledWith({ senderId: 100003 });
+  });
+
+  it("passes channel filter through", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
+    mockGetAllMessageHistory.mockResolvedValue([]);
+
+    await fetchMessageHistory({ channel: "email" });
+
+    expect(mockGetAllMessageHistory).toHaveBeenCalledWith(expect.objectContaining({ channel: "email" }));
+  });
+
+  it("returns error when not authenticated", async () => {
+    mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
+
+    const result = await fetchMessageHistory({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Authentication required");
+  });
+});
+
+describe("fetchMessageDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const messageDetail = {
+    id: 1,
+    subject: "Hello",
+    body: "Body text",
+    sentAt: new Date(),
+    senderId: 100001,
+    emailCount: 5,
+    smsCount: 0,
+    failedCount: 0,
+    isBlast: false,
+    groupName: "Garden Club",
+  };
+
+  const recipients = [
+    { memberId: 100001, memberName: "Kermit Komm", channel: "email", status: "sent", sentAt: new Date() },
+  ];
+
+  it("returns message detail with recipients for message sender", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+    mockGetMessageById.mockResolvedValue(messageDetail);
+    mockGetMessageRecipients.mockResolvedValue(recipients);
+
+    const result = await fetchMessageDetail(1);
+
+    expect(result).toEqual({ success: true, data: { message: messageDetail, recipients } });
+  });
+
+  it("returns message detail for admin regardless of sender", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100099, isAdmin: true });
+    mockGetMessageById.mockResolvedValue(messageDetail);
+    mockGetMessageRecipients.mockResolvedValue(recipients);
+
+    const result = await fetchMessageDetail(1);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-sender non-admin access", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
+    mockGetMessageById.mockResolvedValue(messageDetail);
+
+    const result = await fetchMessageDetail(1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockGetMessageRecipients).not.toHaveBeenCalled();
+  });
+
+  it("returns error when message not found", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
+    mockGetMessageById.mockRejectedValue(new AppError("NOT_FOUND", "Message not found"));
+
+    const result = await fetchMessageDetail(999);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Message not found");
+  });
+});
+
+describe("fetchRecipientPreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns counts for group owner", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(true);
+    mockPreviewRecipientCounts.mockResolvedValue({ emailEligible: 10, smsEligible: 6, smsIneligible: 4 });
+
+    const result = await fetchRecipientPreview(1);
+
+    expect(result).toEqual({ success: true, data: { emailEligible: 10, smsEligible: 6, smsIneligible: 4 } });
+  });
+
+  it("returns counts for admin without owner check", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100099, isAdmin: true });
+    mockPreviewRecipientCounts.mockResolvedValue({ emailEligible: 10, smsEligible: 6, smsIneligible: 4 });
+
+    const result = await fetchRecipientPreview(1);
+
+    expect(result.success).toBe(true);
+    expect(mockIsGroupOwner).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-owner non-admin access", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await fetchRecipientPreview(1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+    expect(mockPreviewRecipientCounts).not.toHaveBeenCalled();
+  });
+});

--- a/test/schema/message.test.ts
+++ b/test/schema/message.test.ts
@@ -1,0 +1,47 @@
+import { BaseMessageSchema } from "@/schema/contact-group";
+
+describe("BaseMessageSchema SMS body length", () => {
+  it("allows long body when sendSms is false", () => {
+    const result = BaseMessageSchema.safeParse({
+      subject: "Test",
+      body: "a".repeat(500),
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("allows 160 character body when sendSms is true", () => {
+    const result = BaseMessageSchema.safeParse({
+      subject: "Test",
+      body: "a".repeat(160),
+      sendEmail: false,
+      sendSms: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects body over 160 characters when sendSms is true", () => {
+    const result = BaseMessageSchema.safeParse({
+      subject: "Test",
+      body: "a".repeat(161),
+      sendEmail: false,
+      sendSms: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("allows long body when both channels enabled but sendSms is false", () => {
+    const result = BaseMessageSchema.safeParse({
+      subject: "Test",
+      body: "a".repeat(500),
+      sendEmail: true,
+      sendSms: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/test/services/message-query.test.ts
+++ b/test/services/message-query.test.ts
@@ -1,0 +1,228 @@
+import { vi, type MockedFunction } from "vitest";
+import { mockPrisma } from "../mocks/prisma";
+
+vi.mock("@/services/contact-group", () => ({
+  getGroupRecipients: vi.fn(),
+}));
+
+vi.mock("@/services/email", () => ({
+  sendGroupEmails: vi.fn(),
+}));
+
+vi.mock("@/lib/api/member-api", () => ({
+  getMemberDetails: vi.fn(),
+  getAllActiveMemberIds: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: { SMS_ENABLED: false, FROM_EMAIL: "no-reply@prfc.coop" },
+}));
+
+import { getMemberDetails } from "@/lib/api/member-api";
+import { getAllMessageHistory, getMessageById, getMessageRecipients, previewRecipientCounts } from "@/services/message";
+
+const mockGetMemberDetails = getMemberDetails as MockedFunction<typeof getMemberDetails>;
+
+describe("getAllMessageHistory", () => {
+  it("returns messages with group names", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([
+      {
+        id: 1,
+        subject: "Hello",
+        sentAt: new Date("2026-04-01"),
+        emailCount: 5,
+        smsCount: 0,
+        failedCount: 0,
+        isBlast: false,
+        group: { name: "Garden Club" },
+      },
+    ] as never);
+
+    const result = await getAllMessageHistory({});
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        subject: "Hello",
+        sentAt: new Date("2026-04-01"),
+        emailCount: 5,
+        smsCount: 0,
+        failedCount: 0,
+        isBlast: false,
+        groupName: "Garden Club",
+      },
+    ]);
+  });
+
+  it("returns null groupName for blast messages", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([
+      {
+        id: 2,
+        subject: "Blast",
+        sentAt: new Date("2026-04-01"),
+        emailCount: 100,
+        smsCount: 0,
+        failedCount: 0,
+        isBlast: true,
+        group: null,
+      },
+    ] as never);
+
+    const result = await getAllMessageHistory({});
+
+    expect(result[0].groupName).toBeNull();
+    expect(result[0].isBlast).toBe(true);
+  });
+
+  it("filters by senderId when provided", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+
+    await getAllMessageHistory({ senderId: 100001 });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ senderId: 100001 }),
+      }),
+    );
+  });
+
+  it("filters by channel when provided", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+
+    await getAllMessageHistory({ channel: "email" });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ recipients: { some: { channel: "email" } } }),
+      }),
+    );
+  });
+
+  it("applies limit and offset", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+
+    await getAllMessageHistory({ limit: 10, offset: 20 });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 10, skip: 20 }));
+  });
+
+  it("caps limit at 100", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+
+    await getAllMessageHistory({ limit: 500 });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 100 }));
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.message.findMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getAllMessageHistory({})).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("getMessageById", () => {
+  it("returns message with group name", async () => {
+    mockPrisma.message.findUnique.mockResolvedValue({
+      id: 1,
+      subject: "Hello",
+      body: "Body text",
+      sentAt: new Date("2026-04-01"),
+      senderId: 100001,
+      emailCount: 5,
+      smsCount: 0,
+      failedCount: 0,
+      isBlast: false,
+      group: { name: "Garden Club" },
+    } as never);
+
+    const result = await getMessageById(1);
+
+    expect(result).toHaveProperty("groupName", "Garden Club");
+    expect(result).toHaveProperty("body", "Body text");
+    expect(result).toHaveProperty("senderId", 100001);
+  });
+
+  it("throws NOT_FOUND when message does not exist", async () => {
+    mockPrisma.message.findUnique.mockResolvedValue(null);
+
+    await expect(getMessageById(999)).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.message.findUnique.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getMessageById(1)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("getMessageRecipients", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns recipients with member names and delivery status", async () => {
+    mockPrisma.messageRecipient.findMany.mockResolvedValue([
+      { memberId: 100001, channel: "email", status: "sent", sentAt: new Date("2026-04-01") },
+      { memberId: 100003, channel: "email", status: "pending", sentAt: null },
+    ] as never);
+    mockGetMemberDetails.mockResolvedValue([
+      { ownerid: 100001, ownername: "Kermit Komm", owneremail: "k@test.com", ownerphone: "805-555-0001" },
+      { ownerid: 100003, ownername: "Angelica Allison", owneremail: "a@test.com", ownerphone: "805-555-0003" },
+    ]);
+
+    const result = await getMessageRecipients(1);
+
+    expect(result).toEqual([
+      { memberId: 100001, memberName: "Kermit Komm", channel: "email", status: "sent", sentAt: new Date("2026-04-01") },
+      { memberId: 100003, memberName: "Angelica Allison", channel: "email", status: "pending", sentAt: null },
+    ]);
+  });
+
+  it("deduplicates member IDs before fetching names", async () => {
+    mockPrisma.messageRecipient.findMany.mockResolvedValue([
+      { memberId: 100001, channel: "email", status: "sent", sentAt: new Date() },
+      { memberId: 100001, channel: "sms", status: "sent", sentAt: new Date() },
+    ] as never);
+    mockGetMemberDetails.mockResolvedValue([
+      { ownerid: 100001, ownername: "Kermit Komm", owneremail: "k@test.com", ownerphone: "805-555-0001" },
+    ]);
+
+    await getMessageRecipients(1);
+
+    expect(mockGetMemberDetails).toHaveBeenCalledWith([100001]);
+  });
+
+  it("returns 'Unknown Member' for unresolved member IDs", async () => {
+    mockPrisma.messageRecipient.findMany.mockResolvedValue([
+      { memberId: 99999, channel: "email", status: "sent", sentAt: new Date() },
+    ] as never);
+    mockGetMemberDetails.mockResolvedValue([]);
+
+    const result = await getMessageRecipients(1);
+
+    expect(result[0].memberName).toBe("Unknown Member");
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.messageRecipient.findMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getMessageRecipients(1)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("previewRecipientCounts", () => {
+  it("returns email eligible, sms eligible, and sms ineligible counts", async () => {
+    mockPrisma.contactGroupMember.count.mockResolvedValueOnce(10).mockResolvedValueOnce(6).mockResolvedValueOnce(12);
+
+    const result = await previewRecipientCounts(1);
+
+    expect(result).toEqual({ emailEligible: 10, smsEligible: 6, smsIneligible: 6 });
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.contactGroupMember.count.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(previewRecipientCounts(1)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Added query services, server actions, and tests for the message history and compose pages.

1. Four new service functions in message.ts - getAllMessageHistory() lists messages across all groups with optional senderId/channel filters and pagination. getMessageById() returns a single message with group name. getMessageRecipients() returns per-recipient delivery status with member names resolved via member API. previewRecipientCounts() returns email/SMS eligible and ineligible counts for a group before sending.

2. Three new server actions in contact-group.ts - fetchMessageHistory() shows all messages for admin, filtered to own messages for members. fetchMessageDetail() returns message + recipients with authorization (sender or admin only). fetchRecipientPreview() returns eligible counts with authorization (group owner or admin only).

3. SMS body length validation - added refine() to BaseMessageSchema that rejects body over 160 characters when sendSms is true. Enforces SMS segment limits at the Zod validation boundary.

4. New types - MessageHistoryItem, MessageDetail, RecipientStatus, and RecipientCounts exported from message.ts for frontend consumption.

## How to test

1. Run npm test - 303 tests pass (31 new)
2. Run npm run build - succeeds
3. Run npm run lint - no errors

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers