### PR TITLE
feat: add profile photo upload backend with vercel blob storage

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -48,3 +48,7 @@ APP_URL=http://localhost:3000
 # Rate Limiting (Upstash Redis)
 UPSTASH_REDIS_REST_URL=https://your-instance.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-token
+
+# Vercel Blob (profile photos)
+# Required in Vercel production. Optional locally if you do not exercise photo upload.
+# BLOB_READ_WRITE_TOKEN=vercel_blob_rw_xxx

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,7 @@ Six models will be added for Contact Groups with email/SMS messaging:
 - **CSRF protection** for state-changing requests
 - **Idempotency keys** prevent duplicate submissions
 - **Zod validation** on all inputs
-- **Security headers** set in `next.config.js` (CSP, HSTS, X-Frame-Options)
+- **Security headers** set in `next.config.ts` (CSP, HSTS, X-Frame-Options)
 
 ## Related Docs
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.public.blob.vercel-storage.com",
+        pathname: "/**",
+      },
+    ],
+  },
   async headers() {
     return [
       {
@@ -12,7 +21,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; object-src 'none'; frame-ancestors 'none';",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.public.blob.vercel-storage.com; font-src 'self'; object-src 'none'; frame-ancestors 'none';",
           },
         ],
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
@@ -34,4 +35,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@tidbcloud/serverless": "^0.2.0",
         "@upstash/ratelimit": "^2.0.7",
         "@upstash/redis": "^1.35.8",
+        "@vercel/blob": "^2.3.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -5400,6 +5401,22 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.3.tgz",
+      "integrity": "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
@@ -5853,6 +5870,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/asynckit": {
@@ -8759,6 +8794,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -8940,6 +8998,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -12721,6 +12785,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -13168,6 +13244,15 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@tidbcloud/serverless": "^0.2.0",
     "@upstash/ratelimit": "^2.0.7",
     "@upstash/redis": "^1.35.8",
+    "@vercel/blob": "^2.3.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/prisma/migrations/20260412054047_add_photo_url_to_user_preference/migration.sql
+++ b/prisma/migrations/20260412054047_add_photo_url_to_user_preference/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `user_preference` ADD COLUMN `photo_url` VARCHAR(500) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -196,6 +196,7 @@ model UserPreference {
   memberId           Int      @unique @map("member_id")
   notifyEmailDefault Boolean  @default(true) @map("notify_email_default")
   notifySmsDefault   Boolean  @default(false) @map("notify_sms_default")
+  photoUrl           String?  @map("photo_url") @db.VarChar(500)
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { verifySession } from "@/lib/dal";
 import { UpdatePreferencesSchema, RevokeSmsConsentSchema } from "@/schema/settings";
 import { getMemberSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
-import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
+import { getUserPreferences, updateUserPreferences, uploadProfilePhoto } from "@/services/user-preference";
 import { transformError } from "@/utils/errors";
 import type { ActionResult } from "@/lib/action-types";
 import type { SmsConsentRecord } from "@/services/sms-consent";
@@ -55,6 +55,22 @@ export async function updateUserPreferencesAction(input: {
     const updated = await updateUserPreferences(session.ownerid, validated);
     revalidatePath("/settings");
     return { success: true, data: updated };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function uploadPhotoAction(formData: FormData): Promise<ActionResult<{ url: string }>> {
+  try {
+    const session = await verifySession();
+    const file = formData.get("file");
+    if (!(file instanceof File) || file.size === 0) {
+      return { success: false, error: "No file provided" };
+    }
+    const url = await uploadProfilePhoto(session.ownerid, file);
+    revalidatePath("/settings");
+    return { success: true, data: { url } };
   } catch (error) {
     const appError = transformError(error);
     return { success: false, error: appError.message };

--- a/src/services/user-preference.ts
+++ b/src/services/user-preference.ts
@@ -1,6 +1,7 @@
 import "server-only";
+import { put, del } from "@vercel/blob";
 import prisma from "@/lib/db";
-import { transformError } from "@/utils/errors";
+import { AppError, transformError } from "@/utils/errors";
 
 export interface UserPreferenceData {
   notifyEmailDefault: boolean;
@@ -11,6 +12,9 @@ const DEFAULTS: UserPreferenceData = {
   notifyEmailDefault: true,
   notifySmsDefault: false,
 };
+
+export const MAX_PHOTO_BYTES = 2 * 1024 * 1024;
+export const ALLOWED_PHOTO_TYPES = new Set(["image/jpeg", "image/png"]);
 
 export async function getUserPreferences(memberId: number): Promise<UserPreferenceData> {
   try {
@@ -42,6 +46,79 @@ export async function updateUserPreferences(
     });
 
     return updated;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function uploadProfilePhoto(memberId: number, file: File): Promise<string> {
+  if (!ALLOWED_PHOTO_TYPES.has(file.type)) {
+    throw new AppError("VALIDATION_ERROR", "Profile photo must be JPG or PNG");
+  }
+  if (file.size === 0) {
+    throw new AppError("VALIDATION_ERROR", "Profile photo file is empty");
+  }
+  if (file.size > MAX_PHOTO_BYTES) {
+    throw new AppError("VALIDATION_ERROR", "Profile photo must be 2MB or smaller");
+  }
+  try {
+    const existing = await prisma.userPreference.findUnique({
+      where: { memberId },
+      select: { photoUrl: true },
+    });
+    if (existing?.photoUrl) {
+      try {
+        await del(existing.photoUrl);
+      } catch {
+        // Swallow not-found so a manually-deleted blob does not block re-upload.
+      }
+    }
+    const ext = file.type === "image/png" ? "png" : "jpg";
+    const blob = await put(`avatars/${memberId}.${ext}`, file, {
+      access: "public",
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    });
+    await prisma.userPreference.upsert({
+      where: { memberId },
+      create: { memberId, photoUrl: blob.url },
+      update: { photoUrl: blob.url },
+      select: { photoUrl: true },
+    });
+    return blob.url;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getProfilePhotoUrl(memberId: number): Promise<string | null> {
+  try {
+    const row = await prisma.userPreference.findUnique({
+      where: { memberId },
+      select: { photoUrl: true },
+    });
+    return row?.photoUrl ?? null;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function deleteProfilePhoto(memberId: number): Promise<void> {
+  try {
+    const existing = await prisma.userPreference.findUnique({
+      where: { memberId },
+      select: { photoUrl: true },
+    });
+    if (!existing?.photoUrl) return;
+    try {
+      await del(existing.photoUrl);
+    } catch {
+      // Swallow not-found.
+    }
+    await prisma.userPreference.update({
+      where: { memberId },
+      data: { photoUrl: null },
+    });
   } catch (error) {
     throw transformError(error);
   }

--- a/test/actions/settings.test.ts
+++ b/test/actions/settings.test.ts
@@ -19,21 +19,24 @@ vi.mock("@/services/sms-consent", () => ({
 vi.mock("@/services/user-preference", () => ({
   getUserPreferences: vi.fn(),
   updateUserPreferences: vi.fn(),
+  uploadProfilePhoto: vi.fn(),
 }));
 
 import { getMemberSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
-import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
+import { getUserPreferences, updateUserPreferences, uploadProfilePhoto } from "@/services/user-preference";
 import {
   fetchSmsConsent,
   revokeSmsConsentAction,
   fetchUserPreferences,
   updateUserPreferencesAction,
+  uploadPhotoAction,
 } from "@/actions/settings";
 
 const mockGetMemberSmsConsent = getMemberSmsConsent as MockedFunction<typeof getMemberSmsConsent>;
 const mockRevokeSmsConsent = revokeSmsConsent as MockedFunction<typeof revokeSmsConsent>;
 const mockGetUserPreferences = getUserPreferences as MockedFunction<typeof getUserPreferences>;
 const mockUpdateUserPreferences = updateUserPreferences as MockedFunction<typeof updateUserPreferences>;
+const mockUploadProfilePhoto = uploadProfilePhoto as MockedFunction<typeof uploadProfilePhoto>;
 
 describe("fetchSmsConsent", () => {
   beforeEach(() => {
@@ -150,5 +153,49 @@ describe("updateUserPreferencesAction", () => {
     const result = await updateUserPreferencesAction({ notifyEmailDefault: "yes" as never });
 
     expect(result.success).toBe(false);
+  });
+});
+
+describe("uploadPhotoAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: false });
+  });
+
+  it("calls uploadProfilePhoto with session ownerid and the FormData file, returns the url, revalidates settings", async () => {
+    const file = new File([new Uint8Array(1024)], "photo.jpg", { type: "image/jpeg" });
+    const formData = new FormData();
+    formData.set("file", file);
+    mockUploadProfilePhoto.mockResolvedValue("https://abc.public.blob.vercel-storage.com/avatars/100001.jpg");
+
+    const result = await uploadPhotoAction(formData);
+
+    expect(result).toEqual({
+      success: true,
+      data: { url: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg" },
+    });
+    expect(mockUploadProfilePhoto).toHaveBeenCalledWith(100001, file);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/settings");
+  });
+
+  it("returns error when no file is in the FormData", async () => {
+    const formData = new FormData();
+
+    const result = await uploadPhotoAction(formData);
+
+    expect(result).toEqual({ success: false, error: "No file provided" });
+    expect(mockUploadProfilePhoto).not.toHaveBeenCalled();
+  });
+
+  it("returns error when not authenticated", async () => {
+    mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
+    const formData = new FormData();
+    formData.set("file", new File([new Uint8Array(1024)], "photo.jpg", { type: "image/jpeg" }));
+
+    const result = await uploadPhotoAction(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Authentication required");
+    expect(mockUploadProfilePhoto).not.toHaveBeenCalled();
   });
 });

--- a/test/services/user-preference.test.ts
+++ b/test/services/user-preference.test.ts
@@ -1,5 +1,26 @@
+import { vi, type MockedFunction } from "vitest";
 import { mockPrisma } from "../mocks/prisma";
-import { getUserPreferences, updateUserPreferences } from "@/services/user-preference";
+
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+import { put, del } from "@vercel/blob";
+import {
+  getUserPreferences,
+  updateUserPreferences,
+  uploadProfilePhoto,
+  getProfilePhotoUrl,
+  deleteProfilePhoto,
+} from "@/services/user-preference";
+
+const mockPut = put as MockedFunction<typeof put>;
+const mockDel = del as MockedFunction<typeof del>;
+
+function makeFile(type: string, size: number): File {
+  return new File([new Uint8Array(size)], "photo", { type });
+}
 
 describe("getUserPreferences", () => {
   it("returns stored preferences when record exists", async () => {
@@ -62,5 +83,156 @@ describe("updateUserPreferences", () => {
     await expect(updateUserPreferences(100001, { notifyEmailDefault: true })).rejects.toMatchObject({
       code: "INTERNAL_ERROR",
     });
+  });
+});
+
+describe("uploadProfilePhoto", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects file types that are not JPG or PNG", async () => {
+    await expect(uploadProfilePhoto(100001, makeFile("image/gif", 1024))).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty files", async () => {
+    await expect(uploadProfilePhoto(100001, makeFile("image/jpeg", 0))).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("rejects files larger than 2MB", async () => {
+    await expect(uploadProfilePhoto(100001, makeFile("image/jpeg", 2 * 1024 * 1024 + 1))).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("uploads a JPEG to avatars/{memberId}.jpg and upserts photoUrl", async () => {
+    mockPrisma.userPreference.findUnique.mockResolvedValue(null);
+    mockPut.mockResolvedValue({
+      url: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg",
+    } as never);
+    mockPrisma.userPreference.upsert.mockResolvedValue({
+      photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg",
+    } as never);
+
+    const url = await uploadProfilePhoto(100001, makeFile("image/jpeg", 1024));
+
+    expect(mockPut).toHaveBeenCalledWith("avatars/100001.jpg", expect.any(File), {
+      access: "public",
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    });
+    expect(mockPrisma.userPreference.upsert).toHaveBeenCalledWith({
+      where: { memberId: 100001 },
+      create: { memberId: 100001, photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg" },
+      update: { photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg" },
+      select: { photoUrl: true },
+    });
+    expect(url).toBe("https://abc.public.blob.vercel-storage.com/avatars/100001.jpg");
+  });
+
+  it("uploads a PNG to avatars/{memberId}.png", async () => {
+    mockPrisma.userPreference.findUnique.mockResolvedValue(null);
+    mockPut.mockResolvedValue({
+      url: "https://abc.public.blob.vercel-storage.com/avatars/100001.png",
+    } as never);
+    mockPrisma.userPreference.upsert.mockResolvedValue({
+      photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.png",
+    } as never);
+
+    await uploadProfilePhoto(100001, makeFile("image/png", 1024));
+
+    expect(mockPut).toHaveBeenCalledWith("avatars/100001.png", expect.any(File), expect.any(Object));
+  });
+
+  it("deletes the existing blob before uploading when photoUrl is already set", async () => {
+    const oldUrl = "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg";
+    mockPrisma.userPreference.findUnique.mockResolvedValue({ photoUrl: oldUrl } as never);
+    mockDel.mockResolvedValue(undefined);
+    mockPut.mockResolvedValue({
+      url: "https://abc.public.blob.vercel-storage.com/avatars/100001.png",
+    } as never);
+    mockPrisma.userPreference.upsert.mockResolvedValue({
+      photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.png",
+    } as never);
+
+    await uploadProfilePhoto(100001, makeFile("image/png", 1024));
+
+    expect(mockDel).toHaveBeenCalledWith(oldUrl);
+    expect(mockDel).toHaveBeenCalledBefore(mockPut);
+  });
+
+  it("skips delete when no existing photoUrl", async () => {
+    mockPrisma.userPreference.findUnique.mockResolvedValue({ photoUrl: null } as never);
+    mockPut.mockResolvedValue({
+      url: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg",
+    } as never);
+    mockPrisma.userPreference.upsert.mockResolvedValue({
+      photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg",
+    } as never);
+
+    await uploadProfilePhoto(100001, makeFile("image/jpeg", 1024));
+
+    expect(mockDel).not.toHaveBeenCalled();
+  });
+});
+
+describe("getProfilePhotoUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the stored photoUrl", async () => {
+    mockPrisma.userPreference.findUnique.mockResolvedValue({
+      photoUrl: "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg",
+    } as never);
+
+    const result = await getProfilePhotoUrl(100001);
+
+    expect(result).toBe("https://abc.public.blob.vercel-storage.com/avatars/100001.jpg");
+  });
+
+  it("returns null when no record exists", async () => {
+    mockPrisma.userPreference.findUnique.mockResolvedValue(null);
+
+    const result = await getProfilePhotoUrl(100001);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("deleteProfilePhoto", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes the blob and clears photoUrl when set", async () => {
+    const url = "https://abc.public.blob.vercel-storage.com/avatars/100001.jpg";
+    mockPrisma.userPreference.findUnique.mockResolvedValue({ photoUrl: url } as never);
+    mockDel.mockResolvedValue(undefined);
+    mockPrisma.userPreference.update.mockResolvedValue({} as never);
+
+    await deleteProfilePhoto(100001);
+
+    expect(mockDel).toHaveBeenCalledWith(url);
+    expect(mockPrisma.userPreference.update).toHaveBeenCalledWith({
+      where: { memberId: 100001 },
+      data: { photoUrl: null },
+    });
+  });
+
+  it("no-ops when no photoUrl is set", async () => {
+    mockPrisma.userPreference.findUnique.mockResolvedValue({ photoUrl: null } as never);
+
+    await deleteProfilePhoto(100001);
+
+    expect(mockDel).not.toHaveBeenCalled();
+    expect(mockPrisma.userPreference.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #136

## What changed?

This PR adds the profile photo upload backend, including the Vercel Blob dependency, the `photoUrl` column on UserPreference, three service functions for upload/get/delete, the `uploadPhotoAction` server action, the `next/image` `remotePatterns` config, and the CSP `img-src` extension required for the browser to render blob-hosted images. The profile photo upload component (#137) and the profile page (#139) both depend on this work. The current avatar UI uses initials only, and there is no schema column, no upload pipeline, and no Vercel Blob package installed.

This PR also converts `next.config.js` to `next.config.ts`. The new file imports `NextConfig` from `next` and uses native types instead of the JSDoc `@type` hint, which resolves the TypeScript hint about CommonJS modules at its source and gives full type-checked autocomplete on the config object. Next.js 16 strips TypeScript from the config file via SWC at build time, so no build flags or script changes are needed. We use `.ts` rather than `.mts` because Next.js 16 only accepts `.js`, `.mjs`, or `.ts` for the config filename.

- `prisma/schema.prisma` adds `photoUrl String? @map("photo_url") @db.VarChar(500)` to the existing UserPreference model.
- `prisma/migrations/20260412054047_add_photo_url_to_user_preference/migration.sql` is a new hand-written migration that adds the column. Hand-written because the shadow DB user lacks ALTER privilege on the prisma_migrate_shadow database (same workaround used in #143).
- `src/services/user-preference.ts` exports `MAX_PHOTO_BYTES` and `ALLOWED_PHOTO_TYPES` constants for #137 to reuse, and adds three functions:
  - `uploadProfilePhoto(memberId, file)` validates the type (JPG/PNG), rejects empty files, rejects files over 2MB, deletes the existing blob first when `photoUrl` is set (try/catch swallows not-found so a manually-deleted blob does not block re-upload), uploads to the deterministic path `avatars/{memberId}.{ext}` with `addRandomSuffix: false, allowOverwrite: true`, and upserts the new URL.
  - `getProfilePhotoUrl(memberId)` returns the stored URL or null.
  - `deleteProfilePhoto(memberId)` deletes the blob and clears the column. No-op when no photo is set.
- `src/actions/settings.ts` adds `uploadPhotoAction(formData)` which verifies the session, guards against missing or empty file, calls `uploadProfilePhoto`, and revalidates `/settings`. The `/profile` route ships in #139 and is not revalidated here.
- `next.config.ts` (renamed from `next.config.js`) adds `images.remotePatterns` for `*.public.blob.vercel-storage.com`, extends the existing CSP `img-src` directive from `'self' data: blob:` to `'self' data: blob: https://*.public.blob.vercel-storage.com` (without the extension the browser blocks the request even though `next/image` accepts the URL), and switches to TypeScript ESM with `import type { NextConfig } from "next"` and `export default nextConfig`.
- `.env.local.example` documents `BLOB_READ_WRITE_TOKEN` as commented-out, with a note that it is required in Vercel production and optional locally if you do not exercise photo upload. Not added to `src/env.ts` because the package reads `process.env.BLOB_READ_WRITE_TOKEN` directly and we never reference `env.BLOB_READ_WRITE_TOKEN` in code.
- `package.json` and `package-lock.json` add `@vercel/blob@2.3.3`.
- `docs/architecture.md` updates the security headers reference from `next.config.js` to `next.config.ts`.
- `test/services/user-preference.test.ts` adds 11 tests with `vi.mock("@vercel/blob", ...)` at the top. Coverage: type rejection, empty rejection, size rejection, JPG upload path, PNG upload path, delete-before-upload-when-existing, skip-delete-when-no-existing, getProfilePhotoUrl returns the URL, getProfilePhotoUrl returns null, deleteProfilePhoto deletes and clears, deleteProfilePhoto no-ops when no photoUrl.
- `test/actions/settings.test.ts` adds 3 tests for `uploadPhotoAction`. Happy path with revalidate, missing file rejection, unauthenticated rejection. Extends the existing `vi.mock("@/services/user-preference", ...)` block.

## How to test

1. Check out `feat/profile-photo-backend`.
2. Run `npm install` so the new `@vercel/blob` package lands.
3. Run `npm run docker:up` to start the local MySQL container.
4. Run `npm run db:deploy` to apply the new migration.
5. Run `npm test` and confirm all 355 tests pass.
6. Run `npm run build` and confirm the production build succeeds.
7. Run `npm run lint` and confirm there are no errors.

## Screenshots

Backend-only PR. No screenshots.

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers
