### PR TITLE
feat: add create event popover with expandable fields

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -2,11 +2,40 @@
 
 import { useState } from "react";
 import { MonthCalendar } from "@/components/events/month-calendar";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { CreateEventPopover } from "@/components/events/create-event-popover";
+import type { GroupOption, MemberOption } from "@/components/events/invitee-combobox";
 
 const PREVIEW_EVENT_DATES = new Set(["2026-04-13", "2026-04-15", "2026-04-16", "2026-04-17"]);
 
+const MOCK_GROUPS: GroupOption[] = [
+  { id: 1, name: "Board of Directors", memberCount: 7 },
+  { id: 2, name: "General Members", memberCount: 142 },
+  { id: 3, name: "Volunteers", memberCount: 23 },
+  { id: 4, name: "Garden Committee", memberCount: 12 },
+];
+
+const MOCK_MEMBERS: MemberOption[] = [
+  { ownerid: 100001, ownername: "Kevin Rutledge" },
+  { ownerid: 100002, ownername: "Mary Jones" },
+  { ownerid: 100003, ownername: "Tom Wilson" },
+  { ownerid: 100004, ownername: "Sarah Chen" },
+  { ownerid: 100005, ownername: "Derek Phan" },
+  { ownerid: 100006, ownername: "Amy Lin" },
+  { ownerid: 100007, ownername: "Jordan Ma" },
+  { ownerid: 100008, ownername: "Priya Kakani" },
+];
+
 export function RutledgeContent() {
   const [currentMonth, setCurrentMonth] = useState(new Date("2026-04-01"));
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [defaultDate, setDefaultDate] = useState<Date>();
+
+  const handleDayClick = (date: Date) => {
+    const withDefaultTime = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 10, 0);
+    setDefaultDate(withDefaultTime);
+    setDialogOpen(true);
+  };
 
   return (
     <div className="min-h-screen bg-background p-8">
@@ -15,15 +44,27 @@ export function RutledgeContent() {
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
           <h2 className="text-xl font-semibold">Month Calendar Preview</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Click any day to open the create event popover.</p>
           <div className="mt-4">
             <MonthCalendar
               currentMonth={currentMonth}
               onMonthChange={setCurrentMonth}
               eventDates={PREVIEW_EVENT_DATES}
+              onDayClick={handleDayClick}
             />
           </div>
         </div>
       </div>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-[820px] gap-0 p-0">
+          <CreateEventPopover
+            onClose={() => setDialogOpen(false)}
+            defaultDate={defaultDate}
+            groups={MOCK_GROUPS}
+            members={MOCK_MEMBERS}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/events/create-event-popover.tsx
+++ b/src/components/events/create-event-popover.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { Clock, MapPin, CalendarCheck, List, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import { InviteeCombobox, type GroupOption, type MemberOption } from "@/components/events/invitee-combobox";
+import { createEventAction } from "@/actions/event";
+import { cn } from "@/lib/utils";
+import type { EventType } from "@/generated/prisma/client";
+
+type Props = {
+  onClose: () => void;
+  defaultDate?: Date;
+  groups: GroupOption[];
+  members: MemberOption[];
+  onSaved?: (eventId: number) => void;
+};
+
+const EVENT_TYPES: { value: EventType; label: string; dot: string }[] = [
+  { value: "social", label: "Social", dot: "bg-prfc-brown" },
+  { value: "networking", label: "Networking", dot: "bg-amber-600" },
+  { value: "meeting", label: "Meeting", dot: "bg-prfc-red" },
+  { value: "volunteer", label: "Volunteer", dot: "bg-green-700" },
+];
+
+function defaultEndFor(start: Date): Date {
+  return new Date(start.getTime() + 60 * 60 * 1000);
+}
+
+export function CreateEventPopover({ onClose, defaultDate, groups, members, onSaved }: Props) {
+  const titleRef = useRef<HTMLInputElement>(null);
+  const [title, setTitle] = useState("");
+  const [eventType, setEventType] = useState<EventType>("social");
+  const [range, setRange] = useState<{ start: Date | null; end: Date | null }>({
+    start: defaultDate ?? null,
+    end: defaultDate ? defaultEndFor(defaultDate) : null,
+  });
+  const [location, setLocation] = useState("");
+  const [rsvpDeadline, setRsvpDeadline] = useState<Date | null>(null);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<number>>(new Set());
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<number>>(new Set());
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const toggleGroup = (id: number) => {
+    setSelectedGroupIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleMember = (id: number) => {
+    setSelectedMemberIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    setError("");
+    if (!title.trim()) {
+      setError("Title is required");
+      titleRef.current?.focus();
+      return;
+    }
+    if (!range.start || !range.end) {
+      setError("Date and time are required");
+      return;
+    }
+    if (range.end <= range.start) {
+      setError("End time must be after start time");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await createEventAction({
+        title: title.trim(),
+        eventType,
+        startDate: range.start!,
+        endDate: range.end!,
+        location: location.trim() || null,
+        description: description.trim() || null,
+        rsvpDeadline: rsvpDeadline,
+        groupIds: Array.from(selectedGroupIds),
+        memberIds: Array.from(selectedMemberIds),
+      });
+      if (result.success) {
+        toast.success("Event created");
+        onSaved?.(result.data!.id);
+        onClose();
+      } else {
+        const message = result.error ?? "Failed to create event";
+        toast.error(message);
+        setError(message);
+      }
+    });
+  };
+
+  return (
+    <div className="flex max-h-[85vh] flex-col overflow-hidden bg-white">
+      <DialogTitle className="sr-only">Create event</DialogTitle>
+      <DialogDescription className="sr-only">
+        Fill in the event details and click Save to create a new event.
+      </DialogDescription>
+      <div className="flex-1 space-y-3 overflow-y-auto p-6">
+        <input
+          ref={titleRef}
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="New Event Title"
+          maxLength={200}
+          className="w-full border-none bg-transparent font-angkor text-3xl text-prfc-red outline-none placeholder:text-foreground"
+          aria-label="Event title"
+        />
+
+        <div className="flex flex-wrap gap-2">
+          {EVENT_TYPES.map((type) => {
+            const isSelected = eventType === type.value;
+            return (
+              <button
+                key={type.value}
+                type="button"
+                onClick={() => setEventType(type.value)}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors",
+                  isSelected
+                    ? "border-prfc-brown bg-paso-light-brown text-prfc-brown"
+                    : "border-prfc-border/40 text-muted-foreground hover:bg-paso-grey",
+                )}
+              >
+                <span className={cn("h-2 w-2 rounded-full", type.dot)} />
+                {type.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <DateTimePicker mode="range" label="Date and time" icon={Clock} value={range} onChange={setRange} />
+
+        <div className="flex items-center gap-3 rounded-lg border border-prfc-border/30 bg-paso-grey px-4 py-3">
+          <MapPin className="h-5 w-5 shrink-0 text-prfc-brown" />
+          <Input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Add Location"
+            maxLength={200}
+            className="border-none bg-transparent p-0 shadow-none focus-visible:ring-0"
+          />
+        </div>
+
+        <DateTimePicker
+          mode="single"
+          label="RSVP Deadline"
+          icon={CalendarCheck}
+          value={rsvpDeadline}
+          onChange={setRsvpDeadline}
+        />
+
+        <InviteeCombobox
+          groups={groups}
+          members={members}
+          selectedGroupIds={selectedGroupIds}
+          selectedMemberIds={selectedMemberIds}
+          onToggleGroup={toggleGroup}
+          onToggleMember={toggleMember}
+        />
+
+        <div className="flex items-start gap-3 rounded-lg border border-prfc-border/30 bg-paso-grey px-4 py-3">
+          <List className="mt-2 h-5 w-5 shrink-0 text-prfc-brown" />
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Add a description"
+            maxLength={5000}
+            rows={3}
+            className="min-h-[80px] border-none bg-transparent p-0 shadow-none focus-visible:ring-0"
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-prfc-border/30 bg-white px-6 py-4">
+        <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={isPending}
+          className="bg-prfc-brown text-white hover:bg-prfc-dark-brown"
+        >
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/invitee-avatar-stack.tsx
+++ b/src/components/events/invitee-avatar-stack.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getAvatarColor, getInitials } from "@/utils/avatar";
+
+export type InviteeAvatar = {
+  id: string;
+  name: string;
+  photoUrl?: string | null;
+};
+
+type Props = {
+  invitees: InviteeAvatar[];
+  max?: number;
+};
+
+export function InviteeAvatarStack({ invitees, max = 6 }: Props) {
+  if (invitees.length === 0) return null;
+
+  const visible = invitees.slice(0, max);
+  const overflow = invitees.length - visible.length;
+
+  return (
+    <div className="flex items-center">
+      {visible.map((inv, idx) => (
+        <Avatar
+          key={inv.id}
+          className="h-8 w-8 border-2 border-white"
+          style={{ marginLeft: idx === 0 ? 0 : -8, zIndex: visible.length - idx }}
+        >
+          {inv.photoUrl && <AvatarImage src={inv.photoUrl} alt={inv.name} />}
+          <AvatarFallback
+            style={{ backgroundColor: getAvatarColor(inv.name), color: "#ffffff" }}
+            className="text-xs font-semibold"
+          >
+            {getInitials(inv.name)}
+          </AvatarFallback>
+        </Avatar>
+      ))}
+      {overflow > 0 && (
+        <span
+          className="ml-[-8px] flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-paso-light-brown text-xs font-semibold text-prfc-brown"
+          style={{ zIndex: 0 }}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/events/invitee-combobox.tsx
+++ b/src/components/events/invitee-combobox.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown, UsersRound, Check } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import { cn } from "@/lib/utils";
+import { InviteeAvatarStack, type InviteeAvatar } from "@/components/events/invitee-avatar-stack";
+
+export type GroupOption = {
+  id: number;
+  name: string;
+  memberCount: number;
+};
+
+export type MemberOption = {
+  ownerid: number;
+  ownername: string;
+  photoUrl?: string | null;
+};
+
+type Props = {
+  groups: GroupOption[];
+  members: MemberOption[];
+  selectedGroupIds: Set<number>;
+  selectedMemberIds: Set<number>;
+  onToggleGroup: (id: number) => void;
+  onToggleMember: (id: number) => void;
+};
+
+export function InviteeCombobox({
+  groups,
+  members,
+  selectedGroupIds,
+  selectedMemberIds,
+  onToggleGroup,
+  onToggleMember,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const filteredGroups = useFuzzySearch(groups, { keys: ["name"] }, query);
+  const filteredMembers = useFuzzySearch(members, { keys: ["ownername"] }, query);
+
+  const selectedInvitees = useMemo<InviteeAvatar[]>(() => {
+    const groupInvitees: InviteeAvatar[] = groups
+      .filter((g) => selectedGroupIds.has(g.id))
+      .map((g) => ({ id: `g-${g.id}`, name: g.name }));
+    const memberInvitees: InviteeAvatar[] = members
+      .filter((m) => selectedMemberIds.has(m.ownerid))
+      .map((m) => ({ id: `m-${m.ownerid}`, name: m.ownername, photoUrl: m.photoUrl }));
+    return [...groupInvitees, ...memberInvitees];
+  }, [groups, members, selectedGroupIds, selectedMemberIds]);
+
+  const selectedCount = selectedInvitees.length;
+  const noOptions = groups.length === 0 && members.length === 0;
+
+  return (
+    <div className="rounded-lg border border-prfc-border/30 bg-paso-grey">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-paso-light-brown/40"
+      >
+        <UsersRound className="h-5 w-5 shrink-0 text-prfc-brown" />
+        <span className="flex-1 text-sm">
+          {selectedCount > 0 ? (
+            <span className="text-foreground">
+              {selectedCount} {selectedCount === 1 ? "invitee" : "invitees"} selected
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Add Group/Members</span>
+          )}
+        </span>
+        {selectedCount > 0 && (
+          <div className="mr-2">
+            <InviteeAvatarStack invitees={selectedInvitees} max={6} />
+          </div>
+        )}
+        <ChevronDown className={cn("h-5 w-5 text-prfc-brown transition-transform", expanded && "rotate-180")} />
+      </button>
+      {expanded && (
+        <div className="border-t border-prfc-border/30 bg-white">
+          {noOptions ? (
+            <p className="p-4 text-sm text-muted-foreground">Nothing to invite yet.</p>
+          ) : (
+            <Command shouldFilter={false}>
+              <CommandInput value={query} onValueChange={setQuery} placeholder="Search groups or members..." />
+              <CommandList>
+                {filteredGroups.length === 0 && filteredMembers.length === 0 && <CommandEmpty>No matches</CommandEmpty>}
+                {filteredGroups.length > 0 && (
+                  <CommandGroup heading="Groups">
+                    {filteredGroups.map((g) => {
+                      const isSelected = selectedGroupIds.has(g.id);
+                      return (
+                        <CommandItem
+                          key={`g-${g.id}`}
+                          value={`g-${g.id}-${g.name}`}
+                          onSelect={() => onToggleGroup(g.id)}
+                          className="flex items-center gap-2"
+                        >
+                          <Check
+                            className={cn("h-4 w-4 shrink-0", isSelected ? "text-prfc-brown" : "text-transparent")}
+                          />
+                          <span className="flex-1">{g.name}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {g.memberCount} {g.memberCount === 1 ? "member" : "members"}
+                          </span>
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                )}
+                {filteredGroups.length > 0 && filteredMembers.length > 0 && <CommandSeparator />}
+                {filteredMembers.length > 0 && (
+                  <CommandGroup heading="Members">
+                    {filteredMembers.map((m) => {
+                      const isSelected = selectedMemberIds.has(m.ownerid);
+                      return (
+                        <CommandItem
+                          key={`m-${m.ownerid}`}
+                          value={`m-${m.ownerid}-${m.ownername}`}
+                          onSelect={() => onToggleMember(m.ownerid)}
+                          className="flex items-center gap-2"
+                        >
+                          <Check
+                            className={cn("h-4 w-4 shrink-0", isSelected ? "text-prfc-brown" : "text-transparent")}
+                          />
+                          <span className="flex-1">{m.ownername}</span>
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                )}
+              </CommandList>
+            </Command>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { DayPicker, type DayPickerProps } from "react-day-picker";
+import { cn } from "@/lib/utils";
+
+export type CalendarProps = DayPickerProps;
+
+export function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col space-y-4",
+        month: "space-y-4",
+        month_caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-semibold text-prfc-brown",
+        nav: "flex items-center gap-1",
+        button_previous: "inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-paso-light-brown",
+        button_next: "inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-paso-light-brown",
+        month_grid: "w-full border-collapse",
+        weekdays: "grid grid-cols-7",
+        weekday: "text-xs font-medium text-muted-foreground py-2 text-center",
+        week: "grid grid-cols-7",
+        day: "aspect-square p-0 text-center",
+        day_button:
+          "h-9 w-9 rounded-md hover:bg-paso-light-brown focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-prfc-red",
+        today: "bg-prfc-red text-white rounded-md",
+        selected: "bg-prfc-brown text-white rounded-md",
+        outside: "text-muted-foreground opacity-50",
+        disabled: "text-muted-foreground opacity-30",
+        ...classNames,
+      }}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState } from "react";
+import { format } from "date-fns";
+import type { LucideIcon } from "lucide-react";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+type SingleProps = {
+  mode: "single";
+  value: Date | null;
+  onChange: (d: Date | null) => void;
+  label: string;
+  icon?: LucideIcon;
+};
+
+type RangeProps = {
+  mode: "range";
+  value: { start: Date | null; end: Date | null };
+  onChange: (v: { start: Date | null; end: Date | null }) => void;
+  label: string;
+  icon?: LucideIcon;
+};
+
+export type DateTimePickerProps = SingleProps | RangeProps;
+
+const TIME_SLOTS = buildTimeSlots();
+
+function buildTimeSlots(): { value: string; label: string }[] {
+  const slots: { value: string; label: string }[] = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 15) {
+      const hh = String(h).padStart(2, "0");
+      const mm = String(m).padStart(2, "0");
+      const value = `${hh}:${mm}`;
+      const period = h >= 12 ? "PM" : "AM";
+      const hour12 = h % 12 === 0 ? 12 : h % 12;
+      slots.push({ value, label: `${hour12}:${mm} ${period}` });
+    }
+  }
+  return slots;
+}
+
+function toTimeValue(d: Date | null): string | undefined {
+  if (!d) return undefined;
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function applyTime(base: Date, timeValue: string): Date {
+  const [h, m] = timeValue.split(":").map(Number);
+  return new Date(base.getFullYear(), base.getMonth(), base.getDate(), h, m);
+}
+
+function formatRange(start: Date | null, end: Date | null): string {
+  if (!start || !end) return "";
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+  if (sameDay) {
+    return `${format(start, "EEE, MMM d")} · ${format(start, "h:mm a")} - ${format(end, "h:mm a")}`;
+  }
+  return `${format(start, "EEE, MMM d h:mm a")} - ${format(end, "MMM d h:mm a")}`;
+}
+
+export function DateTimePicker(props: DateTimePickerProps) {
+  const [open, setOpen] = useState(false);
+  const Icon = props.icon;
+
+  const displayValue =
+    props.mode === "single"
+      ? props.value
+        ? format(props.value, "EEE, MMM d · h:mm a")
+        : ""
+      : formatRange(props.value.start, props.value.end);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-3 rounded-lg border border-prfc-border/30 bg-paso-grey px-4 py-3 text-left hover:bg-paso-light-brown/40"
+        >
+          {Icon && <Icon className="h-5 w-5 shrink-0 text-prfc-brown" />}
+          <span className={cn("flex-1 text-sm", displayValue ? "text-foreground" : "text-muted-foreground")}>
+            {displayValue || props.label}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        {props.mode === "single" ? (
+          <SinglePicker value={props.value} onChange={props.onChange} />
+        ) : (
+          <RangePicker value={props.value} onChange={props.onChange} />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function SinglePicker({ value, onChange }: { value: Date | null; onChange: (d: Date | null) => void }) {
+  return (
+    <div className="p-3">
+      <Calendar
+        mode="single"
+        selected={value ?? undefined}
+        onSelect={(d) => {
+          if (!d) {
+            onChange(null);
+            return;
+          }
+          const existing = value ?? new Date();
+          onChange(new Date(d.getFullYear(), d.getMonth(), d.getDate(), existing.getHours(), existing.getMinutes()));
+        }}
+      />
+      <div className="mt-3 border-t pt-3">
+        <label className="mb-1 block text-xs font-semibold text-prfc-brown">Time</label>
+        <Select
+          value={toTimeValue(value)}
+          onValueChange={(t) => {
+            const base = value ?? new Date();
+            onChange(applyTime(base, t));
+          }}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select time" />
+          </SelectTrigger>
+          <SelectContent className="max-h-60">
+            {TIME_SLOTS.map((s) => (
+              <SelectItem key={s.value} value={s.value}>
+                {s.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function RangePicker({
+  value,
+  onChange,
+}: {
+  value: { start: Date | null; end: Date | null };
+  onChange: (v: { start: Date | null; end: Date | null }) => void;
+}) {
+  const { start, end } = value;
+  const baseDate = start ?? end ?? new Date();
+
+  return (
+    <div className="p-3">
+      <Calendar
+        mode="single"
+        selected={start ?? undefined}
+        onSelect={(d) => {
+          if (!d) {
+            onChange({ start: null, end: null });
+            return;
+          }
+          const startHour = start ? start.getHours() : 9;
+          const startMin = start ? start.getMinutes() : 0;
+          const newStart = new Date(d.getFullYear(), d.getMonth(), d.getDate(), startHour, startMin);
+          const endHour = end ? end.getHours() : startHour + 1;
+          const endMin = end ? end.getMinutes() : startMin;
+          const newEnd = new Date(d.getFullYear(), d.getMonth(), d.getDate(), endHour, endMin);
+          onChange({ start: newStart, end: newEnd });
+        }}
+      />
+      <div className="mt-3 grid grid-cols-2 gap-3 border-t pt-3">
+        <div>
+          <label className="mb-1 block text-xs font-semibold text-prfc-brown">Start</label>
+          <Select
+            value={toTimeValue(start)}
+            onValueChange={(t) => {
+              const newStart = applyTime(start ?? baseDate, t);
+              onChange({ start: newStart, end });
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Time" />
+            </SelectTrigger>
+            <SelectContent className="max-h-60">
+              {TIME_SLOTS.map((s) => (
+                <SelectItem key={`s-${s.value}`} value={s.value}>
+                  {s.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-semibold text-prfc-brown">End</label>
+          <Select
+            value={toTimeValue(end)}
+            onValueChange={(t) => {
+              const newEnd = applyTime(end ?? baseDate, t);
+              onChange({ start, end: newEnd });
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Time" />
+            </SelectTrigger>
+            <SelectContent className="max-h-60">
+              {TIME_SLOTS.map((s) => (
+                <SelectItem key={`e-${s.value}`} value={s.value}>
+                  {s.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/src/hooks/use-fuzzy-search.ts
+++ b/src/hooks/use-fuzzy-search.ts
@@ -8,9 +8,10 @@ interface UseFuzzySearchOptions {
   threshold?: number;
 }
 
-export function useFuzzySearch<T>(items: T[], options: UseFuzzySearchOptions): T[] {
-  const query = useSearchQuery();
-  const debouncedQuery = useDebounce(query, 300);
+export function useFuzzySearch<T>(items: T[], options: UseFuzzySearchOptions, query?: string): T[] {
+  const contextQuery = useSearchQuery();
+  const activeQuery = query ?? contextQuery;
+  const debouncedQuery = useDebounce(activeQuery, 300);
 
   const fuse = useMemo(
     () =>

--- a/test/components/create-event-popover.test.tsx
+++ b/test/components/create-event-popover.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, type MockedFunction } from "vitest";
+import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+vi.mock("@/actions/event", () => ({
+  createEventAction: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { createEventAction } from "@/actions/event";
+import { toast } from "sonner";
+import { CreateEventPopover } from "@/components/events/create-event-popover";
+
+const mockCreateEventAction = createEventAction as MockedFunction<typeof createEventAction>;
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <TopBarSearchProvider>
+      <Dialog open onOpenChange={() => {}}>
+        <DialogContent>{ui}</DialogContent>
+      </Dialog>
+    </TopBarSearchProvider>
+  );
+}
+
+describe("CreateEventPopover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks submit when title is empty", () => {
+    render(
+      wrap(
+        <CreateEventPopover onClose={vi.fn()} defaultDate={new Date("2026-04-13T10:00:00")} groups={[]} members={[]} />,
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByText("Title is required")).toBeInTheDocument();
+    expect(mockCreateEventAction).not.toHaveBeenCalled();
+  });
+
+  it("submits with trimmed fields and maps empty optional fields to null", async () => {
+    mockCreateEventAction.mockResolvedValue({ success: true, data: { id: 42 } });
+    const onClose = vi.fn();
+    const onSaved = vi.fn();
+
+    render(
+      wrap(
+        <CreateEventPopover
+          onClose={onClose}
+          defaultDate={new Date("2026-04-13T10:00:00")}
+          groups={[]}
+          members={[]}
+          onSaved={onSaved}
+        />,
+      ),
+    );
+
+    fireEvent.change(screen.getByLabelText("Event title"), {
+      target: { value: "  Board Meeting  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockCreateEventAction).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockCreateEventAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Board Meeting",
+        eventType: "social",
+        location: null,
+        description: null,
+        rsvpDeadline: null,
+        groupIds: [],
+        memberIds: [],
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Event created");
+    expect(onSaved).toHaveBeenCalledWith(42);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("surfaces server error in toast and keeps form state", async () => {
+    mockCreateEventAction.mockResolvedValue({ success: false, error: "Something broke" });
+    const onClose = vi.fn();
+
+    render(
+      wrap(
+        <CreateEventPopover onClose={onClose} defaultDate={new Date("2026-04-13T10:00:00")} groups={[]} members={[]} />,
+      ),
+    );
+
+    fireEvent.change(screen.getByLabelText("Event title"), {
+      target: { value: "Board Meeting" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Something broke");
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue("Board Meeting")).toBeInTheDocument();
+  });
+});

--- a/test/components/invitee-combobox.test.tsx
+++ b/test/components/invitee-combobox.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import { InviteeCombobox } from "@/components/events/invitee-combobox";
+import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
+
+function wrap(ui: React.ReactElement) {
+  return <TopBarSearchProvider>{ui}</TopBarSearchProvider>;
+}
+
+const GROUPS = [
+  { id: 1, name: "Board of Directors", memberCount: 7 },
+  { id: 2, name: "Volunteers", memberCount: 23 },
+];
+
+const MEMBERS = [
+  { ownerid: 100001, ownername: "Kevin Rutledge" },
+  { ownerid: 100002, ownername: "Mary Jones" },
+];
+
+describe("InviteeCombobox", () => {
+  it("renders empty state when no groups or members", () => {
+    render(
+      wrap(
+        <InviteeCombobox
+          groups={[]}
+          members={[]}
+          selectedGroupIds={new Set()}
+          selectedMemberIds={new Set()}
+          onToggleGroup={vi.fn()}
+          onToggleMember={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByText("Add Group/Members"));
+    expect(screen.getByText("Nothing to invite yet.")).toBeInTheDocument();
+  });
+
+  it("shows selected count in the header when groups are selected", () => {
+    render(
+      wrap(
+        <InviteeCombobox
+          groups={GROUPS}
+          members={MEMBERS}
+          selectedGroupIds={new Set([1])}
+          selectedMemberIds={new Set([100001])}
+          onToggleGroup={vi.fn()}
+          onToggleMember={vi.fn()}
+        />,
+      ),
+    );
+    expect(screen.getByText("2 invitees selected")).toBeInTheDocument();
+  });
+
+  it("calls onToggleGroup when a group item is clicked", () => {
+    const onToggleGroup = vi.fn();
+    render(
+      wrap(
+        <InviteeCombobox
+          groups={GROUPS}
+          members={MEMBERS}
+          selectedGroupIds={new Set()}
+          selectedMemberIds={new Set()}
+          onToggleGroup={onToggleGroup}
+          onToggleMember={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByText("Add Group/Members"));
+    fireEvent.click(screen.getByText("Board of Directors"));
+    expect(onToggleGroup).toHaveBeenCalledWith(1);
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -22,6 +22,13 @@ if (typeof window !== "undefined") {
   window.HTMLElement.prototype.hasPointerCapture = vi.fn();
   window.HTMLElement.prototype.releasePointerCapture = vi.fn();
 
+  class MockResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #127

## What changed?

I added a `CreateEventPopover` client component that renders inside a shadcn `Dialog` and wires to `createEventAction`. The form has a title, a 4-pill event-type selector, a date-time range picker, location, RSVP deadline, an inline-expanding invitee combobox with a +N avatar stack, and a description. Four new primitives ship with it: `ui/calendar.tsx` (shadcn recipe over react-day-picker v9), `ui/date-time-picker.tsx` (discriminated `mode: single | range` with 15-minute slots), `events/invitee-combobox.tsx` (Command-based, two `Set<number>`), and `events/invitee-avatar-stack.tsx` (overlapping avatars with +N overflow). The event-type selector fills a spec gap since the backend schema requires `eventType` but the hi-fi omits it, and I extended `useFuzzySearch` with an optional third `query` param so the combobox can drive search locally. Research on `<dialog>` vs popover established that multi-field forms belong in a modal for focus trap and inertness, so I used `Dialog` and lightened the shared overlay from `bg-black/80` to `bg-black/30` so the calendar stays visible behind the form.

- `src/components/events/create-event-popover.tsx` - new main form component
- `src/components/events/invitee-combobox.tsx` - new Command-based multi-select
- `src/components/events/invitee-avatar-stack.tsx` - new avatar stack with overflow
- `src/components/ui/calendar.tsx` - new shadcn calendar primitive
- `src/components/ui/date-time-picker.tsx` - new date-time picker
- `src/components/ui/dialog.tsx` - overlay opacity `bg-black/80` to `bg-black/30`
- `src/hooks/use-fuzzy-search.ts` - optional 3rd `query` param
- `src/app/team/rutledge/rutledge-content.tsx` - hardcoded preview mounting the dialog on day click
- `vitest.setup.ts` - `ResizeObserver` mock for cmdk
- `test/components/create-event-popover.test.tsx`, `test/components/invitee-combobox.test.tsx` - 3 tests each

## How to test

1. `npm install`
2. `npm run build`
3. `npm test`
4. `npm run dev`, visit http://localhost:3000/team/rutledge
5. Click any day in the month grid
6. Confirm the centered dialog opens over a lighter backdrop and the month calendar is still visible behind it
7. Title field autofocuses; typing changes the color from near-black to `prfc-red`
8. Click a different event-type pill and confirm the fill color changes
9. Click "Add Group/Members" and confirm the combobox expands inline with mock groups and members
10. Click Save with an empty title and confirm the error message renders without calling the action
11. Fill the title and click Save; confirm the success toast fires, the dialog closes, and reopening shows an empty form

## Screenshot

<img width="895" height="719" alt="17-create-event-popover-preview" src="https://github.com/user-attachments/assets/4ee8733b-2086-4502-a265-58f33620dcd3" />

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers