### PR TITLE
feat: add profile photo upload component

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { MonthCalendar } from "@/components/events/month-calendar";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { CreateEventPopover } from "@/components/events/create-event-popover";
 import type { GroupOption, MemberOption } from "@/components/events/invitee-combobox";
 import { TotalMembersCard } from "@/components/dashboard/total-members-card";
 import { EventsThisMonthCard } from "@/components/dashboard/events-this-month-card";
+import { ProfilePhotoUpload } from "@/components/profile/profile-photo-upload";
 
 const PREVIEW_EVENT_DATES = new Set(["2026-04-13", "2026-04-15", "2026-04-16", "2026-04-17"]);
 
@@ -32,6 +34,8 @@ export function RutledgeContent() {
   const [currentMonth, setCurrentMonth] = useState(new Date("2026-04-01"));
   const [dialogOpen, setDialogOpen] = useState(false);
   const [defaultDate, setDefaultDate] = useState<Date>();
+  const [uploadingA, setUploadingA] = useState(false);
+  const [uploadingB, setUploadingB] = useState(false);
 
   const handleDayClick = (date: Date) => {
     const withDefaultTime = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 10, 0);
@@ -39,11 +43,34 @@ export function RutledgeContent() {
     setDialogOpen(true);
   };
 
+  const handlePreviewUpload = (setter: (v: boolean) => void) => (file: File) => {
+    setter(true);
+    toast.info(`Upload fired: ${file.name} (${(file.size / 1024).toFixed(1)} KB)`);
+    setTimeout(() => setter(false), 800);
+  };
+
   return (
     <div className="min-h-screen bg-background p-8">
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
+        <div className="mt-10">
+          <h2 className="text-xl font-semibold">Profile Photo Upload Preview</h2>
+          <div className="mt-4 space-y-3">
+            <ProfilePhotoUpload
+              name="Kevin Rutledge"
+              photoUrl="/assets/produce.jpg"
+              onUpload={handlePreviewUpload(setUploadingA)}
+              isUploading={uploadingA}
+            />
+            <ProfilePhotoUpload
+              name="Tom Wilson"
+              photoUrl={null}
+              onUpload={handlePreviewUpload(setUploadingB)}
+              isUploading={uploadingB}
+            />
+          </div>
+        </div>
         <div className="mt-10">
           <h2 className="text-xl font-semibold">Dashboard Stat Cards Preview</h2>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/src/components/profile/profile-photo-upload.tsx
+++ b/src/components/profile/profile-photo-upload.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useRef } from "react";
+import { Upload, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { getAvatarColor, getInitials } from "@/utils/avatar";
+import { MAX_PHOTO_BYTES, ALLOWED_PHOTO_TYPES } from "@/lib/photo-constraints";
+
+type Props = {
+  name: string;
+  photoUrl: string | null;
+  onUpload: (file: File) => void;
+  isUploading?: boolean;
+};
+
+export function ProfilePhotoUpload({ name, photoUrl, onUpload, isUploading = false }: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!ALLOWED_PHOTO_TYPES.has(file.type)) {
+      toast.error("Profile photo must be JPG or PNG");
+      e.target.value = "";
+      return;
+    }
+    if (file.size === 0) {
+      toast.error("Profile photo file is empty");
+      e.target.value = "";
+      return;
+    }
+    if (file.size > MAX_PHOTO_BYTES) {
+      toast.error("Profile photo must be 2MB or smaller");
+      e.target.value = "";
+      return;
+    }
+    onUpload(file);
+    e.target.value = "";
+  };
+
+  return (
+    <div className="flex items-center gap-4 rounded-full border border-prfc-border/30 bg-white p-3 pr-4">
+      <Avatar className="h-16 w-16">
+        {photoUrl && <AvatarImage src={photoUrl} alt={name} />}
+        <AvatarFallback
+          style={{ backgroundColor: getAvatarColor(name), color: "#ffffff" }}
+          className="text-lg font-semibold"
+        >
+          {getInitials(name)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="font-semibold text-foreground">Profile Photo</p>
+        <p className="text-sm text-muted-foreground">JPG or PNG. Max size of 2MB</p>
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png"
+        onChange={handleFileChange}
+        className="hidden"
+        aria-label="Upload profile photo"
+      />
+      <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
+        {isUploading ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <>
+            <Upload className="mr-2 h-4 w-4" />
+            Upload
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/photo-constraints.ts
+++ b/src/lib/photo-constraints.ts
@@ -1,0 +1,2 @@
+export const MAX_PHOTO_BYTES = 2 * 1024 * 1024;
+export const ALLOWED_PHOTO_TYPES = new Set(["image/jpeg", "image/png"]);

--- a/src/services/user-preference.ts
+++ b/src/services/user-preference.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { put, del } from "@vercel/blob";
 import prisma from "@/lib/db";
 import { AppError, transformError } from "@/utils/errors";
+import { MAX_PHOTO_BYTES, ALLOWED_PHOTO_TYPES } from "@/lib/photo-constraints";
 
 export interface UserPreferenceData {
   notifyEmailDefault: boolean;
@@ -12,9 +13,6 @@ const DEFAULTS: UserPreferenceData = {
   notifyEmailDefault: true,
   notifySmsDefault: false,
 };
-
-export const MAX_PHOTO_BYTES = 2 * 1024 * 1024;
-export const ALLOWED_PHOTO_TYPES = new Set(["image/jpeg", "image/png"]);
 
 export async function getUserPreferences(memberId: number): Promise<UserPreferenceData> {
   try {

--- a/test/components/profile-photo-upload.test.tsx
+++ b/test/components/profile-photo-upload.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import { ProfilePhotoUpload } from "@/components/profile/profile-photo-upload";
+
+describe("ProfilePhotoUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders initials fallback when photoUrl is null", () => {
+    render(<ProfilePhotoUpload name="Kevin Rutledge" photoUrl={null} onUpload={vi.fn()} />);
+    expect(screen.getByText("KR")).toBeInTheDocument();
+    expect(screen.getByText("Profile Photo")).toBeInTheDocument();
+    expect(screen.getByText("JPG or PNG. Max size of 2MB")).toBeInTheDocument();
+  });
+
+  it("rejects files larger than 2MB and does not call onUpload", () => {
+    const onUpload = vi.fn();
+    render(<ProfilePhotoUpload name="Kevin" photoUrl={null} onUpload={onUpload} />);
+    const file = new File([new Uint8Array(2 * 1024 * 1024 + 1)], "big.jpg", { type: "image/jpeg" });
+    const input = screen.getByLabelText("Upload profile photo") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Profile photo must be 2MB or smaller");
+  });
+
+  it("rejects non-JPG/PNG file types", () => {
+    const onUpload = vi.fn();
+    render(<ProfilePhotoUpload name="Kevin" photoUrl={null} onUpload={onUpload} />);
+    const file = new File([new Uint8Array(1024)], "photo.gif", { type: "image/gif" });
+    const input = screen.getByLabelText("Upload profile photo") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Profile photo must be JPG or PNG");
+  });
+
+  it("calls onUpload with valid JPG under 2MB", () => {
+    const onUpload = vi.fn();
+    render(<ProfilePhotoUpload name="Kevin" photoUrl={null} onUpload={onUpload} />);
+    const file = new File([new Uint8Array(1024)], "photo.jpg", { type: "image/jpeg" });
+    const input = screen.getByLabelText("Upload profile photo") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onUpload).toHaveBeenCalledWith(file);
+  });
+});

--- a/test/team/rutledge.test.tsx
+++ b/test/team/rutledge.test.tsx
@@ -8,8 +8,8 @@ describe("Rutledge Team Page", () => {
     expect(screen.getByText("Tech Lead")).toBeInTheDocument();
   });
 
-  it("renders the dashboard stat cards preview heading", () => {
+  it("renders the profile photo upload preview heading", () => {
     render(<Page />);
-    expect(screen.getByText("Dashboard Stat Cards Preview")).toBeInTheDocument();
+    expect(screen.getByText("Profile Photo Upload Preview")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #137

## What changed?

I added a `ProfilePhotoUpload` presentational client component that renders a circular shadcn `Avatar` next to a "Profile Photo" label and an "Upload" button. Clicking Upload opens a hidden file input restricted to `image/jpeg,image/png`, and the component validates MIME type and file size before firing `onUpload(file)` via `toast.error` on rejection. The 2MB limit and allowed MIME set are the server's source of truth, so I extracted `MAX_PHOTO_BYTES` and `ALLOWED_PHOTO_TYPES` from `src/services/user-preference.ts` (which has `import "server-only"`) into a new client-safe `src/lib/photo-constraints.ts` and have the service import them back. The component uses shadcn `AvatarImage` directly rather than `next/image` because `next.config.ts` already whitelists `*.public.blob.vercel-storage.com` in `remotePatterns` and CSP, and next/image's responsive-sizing wins do not apply to a fixed 64px avatar. The rutledge preview mounts two instances side by side: one with a local sample photo that exercises the `AvatarImage` branch, and one with `photoUrl={null}` that exercises the initials fallback.

- `src/components/profile/profile-photo-upload.tsx` - new presentational component
- `src/lib/photo-constraints.ts` - new client-safe shared constants
- `src/services/user-preference.ts` - imports constants from the new shared module
- `src/app/team/rutledge/rutledge-content.tsx` - two hardcoded preview instances
- `test/components/profile-photo-upload.test.tsx` - 4 tests
- `test/team/rutledge.test.tsx` - updated heading assertion

## How to test

1. `npm install`
2. `npm run build`
3. `npm test`
4. `npm run dev`, visit http://localhost:3000/team/rutledge
5. Confirm the first preview shows the produce photo inside a circular avatar and the second shows "TW" initials on a colored background
6. Click "Upload" on either card and confirm the file picker opens with JPG and PNG only
7. Select a PNG under 2MB and confirm the button shows a spinning loader for ~800ms and a toast fires
8. Select a file larger than 2MB and confirm a red toast fires and `onUpload` never runs
9. Select a GIF and confirm a red toast fires rejecting the MIME type

## Screenshot

<img width="795" height="261" alt="27-profile-photo-upload-preview" src="https://github.com/user-attachments/assets/3e7af85e-8207-4def-adf4-b2c91e764ea7" />

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers