### PR TITLE
feat: add total members and events this month stat cards

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -5,6 +5,8 @@ import { MonthCalendar } from "@/components/events/month-calendar";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { CreateEventPopover } from "@/components/events/create-event-popover";
 import type { GroupOption, MemberOption } from "@/components/events/invitee-combobox";
+import { TotalMembersCard } from "@/components/dashboard/total-members-card";
+import { EventsThisMonthCard } from "@/components/dashboard/events-this-month-card";
 
 const PREVIEW_EVENT_DATES = new Set(["2026-04-13", "2026-04-15", "2026-04-16", "2026-04-17"]);
 
@@ -43,8 +45,19 @@ export function RutledgeContent() {
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
+          <h2 className="text-xl font-semibold">Dashboard Stat Cards Preview</h2>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <TotalMembersCard count={376} />
+            <TotalMembersCard count={0} />
+            <EventsThisMonthCard count={30} />
+            <EventsThisMonthCard count={0} />
+          </div>
+        </div>
+        <div className="mt-10">
           <h2 className="text-xl font-semibold">Month Calendar Preview</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Click any day to open the create event popover.</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Click any day to open the create event popover.
+          </p>
           <div className="mt-4">
             <MonthCalendar
               currentMonth={currentMonth}

--- a/src/components/dashboard/events-this-month-card.tsx
+++ b/src/components/dashboard/events-this-month-card.tsx
@@ -1,0 +1,29 @@
+import { StatCard } from "./stat-card";
+
+function CalendarStarIcon() {
+  return (
+    <svg
+      width="64"
+      height="64"
+      viewBox="0 0 64 64"
+      fill="none"
+      stroke="#5FDF7A"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="10" y="14" width="44" height="40" rx="4" />
+      <line x1="20" y1="8" x2="20" y2="18" />
+      <line x1="44" y1="8" x2="44" y2="18" />
+      <line x1="10" y1="24" x2="54" y2="24" />
+      <polygon points="40,34 43,40 50,41 45,46 46,53 40,50 34,53 35,46 30,41 37,40" fill="#5FDF7A" stroke="none" />
+    </svg>
+  );
+}
+
+type Props = { count: number };
+
+export function EventsThisMonthCard({ count }: Props) {
+  return <StatCard label="Events This Month" value={String(count)} icon={<CalendarStarIcon />} viewAllHref="/events" />;
+}

--- a/src/components/dashboard/stat-card.tsx
+++ b/src/components/dashboard/stat-card.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type StatCardProps = {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  viewAllHref: string;
+  className?: string;
+};
+
+export function StatCard({ label, value, icon, viewAllHref, className }: StatCardProps) {
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <div className="flex items-center justify-between p-6 pb-4">
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-foreground">{label}</p>
+          <p className="mt-3 text-4xl font-bold text-foreground">{value}</p>
+        </div>
+        <div className="ml-4 shrink-0">{icon}</div>
+      </div>
+      <div className="border-t border-prfc-border/20" />
+      <Link
+        href={viewAllHref}
+        className="flex items-center gap-1 px-6 py-3 text-sm text-muted-foreground hover:text-prfc-brown"
+      >
+        View all <ChevronRight className="h-4 w-4" />
+      </Link>
+    </Card>
+  );
+}

--- a/src/components/dashboard/total-members-card.tsx
+++ b/src/components/dashboard/total-members-card.tsx
@@ -1,0 +1,28 @@
+import { StatCard } from "./stat-card";
+
+const MEMBER_CAPACITY = 500;
+
+function TargetIcon() {
+  return (
+    <svg width="64" height="64" viewBox="0 0 64 64" aria-hidden="true">
+      <circle cx="32" cy="32" r="22" fill="#F5C35A" />
+      <circle cx="32" cy="32" r="14" fill="#F5A442" />
+      <circle cx="32" cy="32" r="6" fill="#E85730" />
+      <line x1="14" y1="50" x2="32" y2="32" stroke="#231F1F" strokeWidth="3" strokeLinecap="round" />
+      <polygon points="10,54 14,50 18,54 14,48" fill="#231F1F" />
+    </svg>
+  );
+}
+
+type Props = { count: number };
+
+export function TotalMembersCard({ count }: Props) {
+  return (
+    <StatCard
+      label="Total Members"
+      value={`${count}/${MEMBER_CAPACITY}`}
+      icon={<TargetIcon />}
+      viewAllHref="/referral-database"
+    />
+  );
+}

--- a/test/components/dashboard-cards.test.tsx
+++ b/test/components/dashboard-cards.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { TotalMembersCard } from "@/components/dashboard/total-members-card";
+import { EventsThisMonthCard } from "@/components/dashboard/events-this-month-card";
+
+describe("TotalMembersCard", () => {
+  it("renders the count formatted as fraction of 500", () => {
+    render(<TotalMembersCard count={376} />);
+    expect(screen.getByText("376/500")).toBeInTheDocument();
+    expect(screen.getByText("Total Members")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View all/ })).toHaveAttribute("href", "/referral-database");
+  });
+
+  it("renders the empty state as 0/500", () => {
+    render(<TotalMembersCard count={0} />);
+    expect(screen.getByText("0/500")).toBeInTheDocument();
+  });
+});
+
+describe("EventsThisMonthCard", () => {
+  it("renders the count as a plain number", () => {
+    render(<EventsThisMonthCard count={30} />);
+    expect(screen.getByText("30")).toBeInTheDocument();
+    expect(screen.getByText("Events This Month")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View all/ })).toHaveAttribute("href", "/events");
+  });
+
+  it("renders the empty state as 0", () => {
+    render(<EventsThisMonthCard count={0} />);
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});

--- a/test/components/stat-card.test.tsx
+++ b/test/components/stat-card.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { StatCard } from "@/components/dashboard/stat-card";
+
+describe("StatCard", () => {
+  it("renders label and value text", () => {
+    render(
+      <StatCard
+        label="Total Members"
+        value="376/500"
+        icon={<span data-testid="icon" />}
+        viewAllHref="/referral-database"
+      />,
+    );
+    expect(screen.getByText("Total Members")).toBeInTheDocument();
+    expect(screen.getByText("376/500")).toBeInTheDocument();
+  });
+
+  it("renders the provided icon", () => {
+    render(
+      <StatCard
+        label="Total Members"
+        value="1/500"
+        icon={<span data-testid="custom-icon">svg</span>}
+        viewAllHref="/referral-database"
+      />,
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
+  it("renders a View all link with the given href", () => {
+    render(<StatCard label="Total Members" value="1/500" icon={<span />} viewAllHref="/referral-database" />);
+    const link = screen.getByRole("link", { name: /View all/ });
+    expect(link).toHaveAttribute("href", "/referral-database");
+  });
+});

--- a/test/team/rutledge.test.tsx
+++ b/test/team/rutledge.test.tsx
@@ -8,8 +8,8 @@ describe("Rutledge Team Page", () => {
     expect(screen.getByText("Tech Lead")).toBeInTheDocument();
   });
 
-  it("renders the month calendar preview heading", () => {
+  it("renders the dashboard stat cards preview heading", () => {
     render(<Page />);
-    expect(screen.getByText("Month Calendar Preview")).toBeInTheDocument();
+    expect(screen.getByText("Dashboard Stat Cards Preview")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #111
Closes #112

## What changed?

The dashboard gets two sibling stat cards (#111 Total Members, #112 Events This Month) that share a new `StatCard` primitive. `StatCard` takes `{ label, value: string, icon, viewAllHref }` and renders a shadcn `Card` with the label top-left, the value below, the icon on the right, a thin separator, and a "View all >" `next/link` footer. `TotalMembersCard` passes `376/500` from a 500-member capacity constant and links to `/referral-database`. `EventsThisMonthCard` passes the plain count and links to `/events`. Both icons are inline SVGs local to their wrapper files, so the PR ships no new static assets. Bundling the twins extracts the primitive once instead of retrofitting when the second card lands later.

- `src/components/dashboard/stat-card.tsx` - shared primitive
- `src/components/dashboard/total-members-card.tsx`, `events-this-month-card.tsx` - wrappers with inline SVG icons
- `src/app/team/rutledge/rutledge-content.tsx` - 2x2 grid preview
- `test/components/stat-card.test.tsx`, `dashboard-cards.test.tsx` - 7 tests total

## How to test

1. `npm install`
2. `npm run build`
3. `npm test`
4. `npm run dev`, visit http://localhost:3000/team/rutledge
5. Confirm a 2x2 grid with Total Members "376/500" and "0/500" on top and Events This Month "30" and "0" below
6. Click "View all" on a Total Members card and confirm it navigates to `/referral-database`
7. Click "View all" on an Events This Month card and confirm it navigates to `/events`

## Screenshot
<img width="797" height="408" alt="01-total-members-card-preview" src="https://github.com/user-attachments/assets/632640d8-9c4d-49e1-8edb-eed52032dbac" />

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers