### PR TITLE
feat: sms consent card component

### DIFF
--- a/src/app/team/lin/page.tsx
+++ b/src/app/team/lin/page.tsx
@@ -1,10 +1,47 @@
 "use client";
-
+import { SmsConsentCard } from "@/components/settings/sms-consent-card";
 import { EntityCard } from "@/components/groups/entity-card";
+import { useState } from "react";
 
 export default function LinPage() {
+  const [hasConsent1, setHasConsent1] = useState(false);
+  const [hasConsent2, setHasConsent2] = useState(true);
+  const [isRevoking1, setIsRevoking1] = useState(false);
+  const [isRevoking2, setIsRevoking2] = useState(false);
+
+  const handleRevoke1 = async () => {
+    setIsRevoking1(true);
+    // Simulate async revoke call
+    await new Promise((r) => setTimeout(r, 1000));
+    setHasConsent1(false);
+    setIsRevoking1(false);
+  };
+
+  const handleRevoke2 = async () => {
+    setIsRevoking2(true);
+    // Simulate async revoke call
+    await new Promise((r) => setTimeout(r, 1000));
+    setHasConsent2(false);
+    setIsRevoking2(false);
+  };
+
   return (
     <div className="p-20 flex flex-col items-center gap-6 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-center">SMS Consent Card Preview</h1>
+
+      <SmsConsentCard
+        phone="+1 (111) 111-1111"
+        hasConsent={hasConsent1}
+        onRevoke={handleRevoke1}
+        isRevoking={isRevoking1}
+      />
+      <SmsConsentCard
+        phone="+1 (222) 222-2222"
+        hasConsent={hasConsent2}
+        onRevoke={handleRevoke2}
+        isRevoking={isRevoking2}
+      />
+
       <h1 className="text-2xl font-bold mb-4">Entity Card Preview</h1>
 
       <EntityCard

--- a/src/components/settings/sms-consent-card.tsx
+++ b/src/components/settings/sms-consent-card.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface SmsConsentCardProps {
+  phone: string;
+  hasConsent: boolean;
+  onRevoke: () => void;
+  isRevoking?: boolean;
+}
+
+export function SmsConsentCard({ phone, hasConsent, onRevoke, isRevoking = false }: SmsConsentCardProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleOptOutClick = () => {
+    setDialogOpen(true);
+  };
+
+  const handleConfirmRevoke = () => {
+    setDialogOpen(false);
+    onRevoke();
+  };
+
+  return (
+    <>
+      <Card className="rounded-2xl">
+        <CardContent className="p-6 space-y-3">
+          <p className="font-bold text-base">SMS Consent</p>
+
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">{phone}</p>
+
+            <p className="text-sm">{hasConsent ? "Opted in" : "Not opted in"}</p>
+          </div>
+
+          {hasConsent && (
+            <Button
+              variant="outline"
+              className="text-destructive border-destructive hover:bg-destructive/10"
+              onClick={handleOptOutClick}
+              disabled={isRevoking}
+            >
+              {isRevoking ? "Opting out…" : "Opt Out"}
+            </Button>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            Message &amp; data rates may apply. Reply STOP to any message to unsubscribe.
+          </p>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Opt out of SMS?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You will no longer receive SMS messages. You can opt back in at any time from your profile settings.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRevoking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmRevoke}
+              disabled={isRevoking}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Opt Out
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Developer

Kyle Lin

Closes #141

## What changed?

Made the SMS Consent Card Component

## How to test
- Open up the Lin Team Page
- Both types of the component should be in there to be displayed

## Screenshots

<img width="998" height="1210" alt="image" src="https://github.com/user-attachments/assets/295a8e07-5dc2-4183-b207-ae7deaf18dfc" />
## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers
