### PR TITLE
View message modal

### DIFF
--- a/src/app/team/kakani/page.tsx
+++ b/src/app/team/kakani/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { AddMembersModal } from "@/components/groups/add-members-modal";
 import { Button } from "@/components/ui/button";
+import { ViewMessageModal } from "@/components/messages/view-message-modal";
 
 const mockMembers = [
   { memberId: 1, ownername: "Alice Johnson", isOwner: true, isSelected: true },
@@ -15,10 +16,42 @@ const mockMembers = [
   { memberId: 8, ownername: "Hank Taylor", isOwner: false, isSelected: false },
 ];
 
+const mockMessage = {
+  id: 1,
+  subject: "Garden Party Reminder",
+  body: "Garden party at 4pm. Be there or be square.",
+  sentAt: new Date("2024-01-06T19:57:01Z"),
+  groupName: "Garden Club",
+  isBlast: false,
+};
+
+const mockRecipients = [
+  { memberId: 1, memberName: "Angelica Allison", status: "sent" as const, photoUrl: null },
+  { memberId: 2, memberName: "Aya Gallagher", status: "pending" as const, photoUrl: null },
+  { memberId: 3, memberName: "Brandon Schwartz", status: "sent" as const, photoUrl: null },
+  { memberId: 4, memberName: "Carol White", status: "sent" as const, photoUrl: null },
+  { memberId: 5, memberName: "David Brown", status: "pending" as const, photoUrl: null },
+  { memberId: 6, memberName: "Eve Davis", status: "sent" as const, photoUrl: null },
+  { memberId: 7, memberName: "Frank Miller", status: "sent" as const, photoUrl: null },
+  { memberId: 8, memberName: "Grace Wilson", status: "pending" as const, photoUrl: null },
+];
+
+const mockBlastMessage = {
+  id: 2,
+  subject: "All Hands Update",
+  body: "Monthly meeting this Friday at noon. Attendance is mandatory.",
+  sentAt: new Date("2024-01-06T19:57:01Z"),
+  groupName: null,
+  isBlast: true,
+};
+
 export default function KakaniPage() {
   const [open, setOpen] = useState(false);
   const [submittingOpen, setSubmittingOpen] = useState(false);
   const [members, setMembers] = useState(mockMembers);
+
+  const [viewOpen, setViewOpen] = useState(false);
+  const [blastViewOpen, setBlastViewOpen] = useState(false);
 
   const handleSelectionChange = (memberId: number, selected: boolean) => {
     setMembers((prev) => prev.map((m) => (m.memberId === memberId ? { ...m, isSelected: selected } : m)));
@@ -52,6 +85,27 @@ export default function KakaniPage() {
         onConfirm={() => {}}
         isSubmitting
       />
+
+      <div className="w-full border-t pt-8 mt-4 flex flex-col items-center gap-4">
+        <h1 className="text-2xl font-bold mb-4">View Message Modal Preview</h1>
+
+        <Button onClick={() => setViewOpen(true)}>Group Message (collapsed → expand to see recipients)</Button>
+        <Button onClick={() => setBlastViewOpen(true)}>Blast Message (All Members)</Button>
+
+        <ViewMessageModal
+          open={viewOpen}
+          onOpenChange={setViewOpen}
+          message={mockMessage}
+          recipients={mockRecipients}
+        />
+
+        <ViewMessageModal
+          open={blastViewOpen}
+          onOpenChange={setBlastViewOpen}
+          message={mockBlastMessage}
+          recipients={mockRecipients}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/messages/view-message-modal.tsx
+++ b/src/components/messages/view-message-modal.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { UsersRound, ChevronRight, ChevronDown } from "lucide-react";
+import { getInitials, getAvatarColor } from "@/utils/avatar";
+
+export interface ViewMessageModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  message: {
+    id: number;
+    subject: string;
+    body: string;
+    sentAt: Date;
+    groupName: string | null;
+    isBlast: boolean;
+  };
+  recipients: Array<{
+    memberId: number;
+    memberName: string;
+    status: "sent" | "pending" | "failed";
+    photoUrl?: string | null;
+  }>;
+}
+
+function formatTimestamp(date: Date): string {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Los_Angeles",
+    month: "numeric",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  }).format(date);
+  return `${formatted} PST`;
+}
+
+const MAX_VISIBLE_AVATARS = 6;
+
+export function ViewMessageModal({ open, onOpenChange, message, recipients }: ViewMessageModalProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setExpanded(false);
+    onOpenChange(next);
+  };
+
+  const groupLabel = message.isBlast ? "All Members" : (message.groupName ?? "Unknown Group");
+  const visibleAvatars = recipients.slice(0, MAX_VISIBLE_AVATARS);
+  const overflowCount = recipients.length - MAX_VISIBLE_AVATARS;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="font-angkor text-3xl font-normal">View Message</DialogTitle>
+          <DialogDescription className="sr-only">View details for this sent message.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <p>To: {groupLabel}</p>
+            <p>Delivered: {formatTimestamp(message.sentAt)}</p>
+          </div>
+
+          {/* Avatar row — collapsed */}
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className="flex items-center gap-2 w-full text-left"
+            aria-expanded={expanded}
+          >
+            <UsersRound className="h-5 w-5 text-muted-foreground shrink-0" />
+            <div className="flex items-center -space-x-2">
+              {visibleAvatars.map((r) => (
+                <Avatar key={r.memberId} className="h-8 w-8 border-2 border-background">
+                  {r.photoUrl && <AvatarImage src={r.photoUrl} alt={r.memberName} />}
+                  <AvatarFallback
+                    style={{ backgroundColor: getAvatarColor(r.memberName) }}
+                    className="text-xs font-semibold text-white"
+                  >
+                    {getInitials(r.memberName)}
+                  </AvatarFallback>
+                </Avatar>
+              ))}
+              {overflowCount > 0 && (
+                <div className="h-8 w-8 rounded-full bg-blue-100 border-2 border-background flex items-center justify-center text-xs font-semibold text-prfc-blue">
+                  +{overflowCount}
+                </div>
+              )}
+            </div>
+            <span className="ml-auto">
+              {expanded ? (
+                <ChevronDown className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-5 w-5 text-muted-foreground" />
+              )}
+            </span>
+          </button>
+
+          {/* Expanded members table */}
+          {expanded && (
+            <div className="rounded-lg border bg-background p-4">
+              <div className="flex justify-between px-2 pb-2 font-semibold text-sm">
+                <span>Members</span>
+                <span>Status</span>
+              </div>
+              <ul className="flex flex-col gap-3 overflow-y-auto max-h-[220px] pr-1">
+                {recipients.map((r) => (
+                  <li key={r.memberId} className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <Avatar className="h-8 w-8 shrink-0">
+                        {r.photoUrl && <AvatarImage src={r.photoUrl} alt={r.memberName} />}
+                        <AvatarFallback
+                          style={{ backgroundColor: getAvatarColor(r.memberName) }}
+                          className="text-xs font-semibold text-white"
+                        >
+                          {getInitials(r.memberName)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="text-sm">{r.memberName}</span>
+                    </div>
+                    {r.status === "sent" ? (
+                      <span className="text-xs border border-green-500 text-green-600 rounded-full px-3 py-0.5">
+                        Received
+                      </span>
+                    ) : (
+                      <span className="text-xs border border-orange-400 text-orange-500 rounded-full px-3 py-0.5">
+                        Pending
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Message body */}
+          <div className="rounded-lg bg-gray-100 p-4 min-h-[120px]">
+            <p className="text-sm">{message.body}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <DialogClose asChild>
+            <Button className="bg-prfc-brown hover:bg-prfc-dark-brown text-white font-semibold px-6 rounded-md">
+              Close
+            </Button>
+          </DialogClose>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/messages/view-message-modal.tsx
+++ b/src/components/messages/view-message-modal.tsx
@@ -63,7 +63,7 @@ export function ViewMessageModal({ open, onOpenChange, message, recipients }: Vi
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg font-khula !leading-none">
         <DialogHeader>
           <DialogTitle className="font-angkor text-3xl font-normal">View Message</DialogTitle>
           <DialogDescription className="sr-only">View details for this sent message.</DialogDescription>


### PR DESCRIPTION
## Developer

Snehil Kakani

Closes #131 

## What changed?

Added ViewMessageModal component, which shows a sent message's group, delivery timestamp, recipient avatar stack, and message body. Clicking the avatar row expands a the table with delivery badges. Set up a preview on /team/kakani with hardcoded data.

## How to test

1. Run npm run dev and go to /team/kakani
2. Interact with the group message and blast buttons to see the modals

## Screenshots
<img width="1002" height="736" alt="Screenshot 2026-04-25 at 4 10 19 PM" src="https://github.com/user-attachments/assets/9f8a2432-fcfe-4b45-8866-64700ffe4135" />
<img width="996" height="1320" alt="Screenshot 2026-04-25 at 4 10 22 PM" src="https://github.com/user-attachments/assets/cbd7ae00-e4b4-4012-b977-40f828acc8e7" />

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Assigned reviewers
