### PR TITLE
feat: update create group modal with inline member selection

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -78,16 +78,26 @@ export async function fetchEnrichedGroup(groupId: number): Promise<ActionResult<
   }
 }
 
-export async function createContactGroup(formData: FormData): Promise<ActionResult<{ id: number }>> {
+export async function createContactGroup(input: {
+  name: string;
+  description: string | null;
+  memberIds?: number[];
+}): Promise<ActionResult<{ id: number }>> {
   try {
     const session = await verifySession();
 
-    const validated = CreateContactGroupSchema.parse({
-      name: formData.get("name"),
-      description: formData.get("description") || null,
-    });
+    const validated = CreateContactGroupSchema.parse(input);
+    const { memberIds, ...groupData } = validated;
 
-    const group = await createGroup(validated, session.ownerid);
+    const group = await createGroup(groupData, session.ownerid);
+
+    if (memberIds && memberIds.length > 0) {
+      await addMembersToGroup(
+        group.id,
+        memberIds.map((id) => ({ memberId: id, notifyEmail: true, notifySms: false })),
+        session.ownerid,
+      );
+    }
 
     revalidatePath("/groups");
     return { success: true, data: { id: group.id } };

--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -10,14 +10,16 @@ import { useSetTopBarAction } from "@/components/layout/top-bar-action-context";
 import { useGroupsModal, EMPTY_GROUP } from "@/hooks/use-groups-modal";
 import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
 import type { GroupWithCount } from "@/services/contact-group";
+import type { MemberSummary } from "@/lib/api/member-api";
 
 interface GroupsContentProps {
   groups: GroupWithCount[];
   isAdmin: boolean;
   ownerId: number;
+  members: MemberSummary[];
 }
 
-export function GroupsContent({ groups, isAdmin, ownerId }: GroupsContentProps) {
+export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsContentProps) {
   const {
     modal,
     isPending,
@@ -103,6 +105,7 @@ export function GroupsContent({ groups, isAdmin, ownerId }: GroupsContentProps) 
           if (!open) closeModal();
         }}
         onSubmit={handleCreateSubmit}
+        members={members.map((m) => ({ memberId: m.ownerid, ownername: m.ownername }))}
         isSubmitting={modal.type === "create" && isPending}
       />
 

--- a/src/app/(protected)/groups/page.tsx
+++ b/src/app/(protected)/groups/page.tsx
@@ -1,12 +1,16 @@
 import { getSessionWithName } from "@/lib/dal";
 import { getAllGroups, getGroupsByOwner } from "@/services/contact-group";
+import { getAllMembers } from "@/lib/api/member-api";
 import { GroupsContent } from "./groups-content";
 
 export default async function GroupsPage() {
   const session = await getSessionWithName();
   const isAdmin = session.isAdmin;
 
-  const groups = isAdmin ? await getAllGroups() : await getGroupsByOwner(session.ownerid);
+  const [groups, members] = await Promise.all([
+    isAdmin ? getAllGroups() : getGroupsByOwner(session.ownerid),
+    getAllMembers(),
+  ]);
 
-  return <GroupsContent groups={groups} isAdmin={isAdmin} ownerId={session.ownerid} />;
+  return <GroupsContent groups={groups} isAdmin={isAdmin} ownerId={session.ownerid} members={members} />;
 }

--- a/src/app/team/ma/page.tsx
+++ b/src/app/team/ma/page.tsx
@@ -4,6 +4,12 @@ import { useState } from "react";
 import { CreateGroupModal } from "@/components/groups/create-group-modal";
 import { Button } from "@/components/ui/button";
 
+const MOCK_MEMBERS = [
+  { memberId: 100001, ownername: "Kevin Rutledge" },
+  { memberId: 100002, ownername: "Mary Jones" },
+  { memberId: 100003, ownername: "Tom Wilson" },
+];
+
 export default function MaPage() {
   const [defaultOpen, setDefaultOpen] = useState(false);
   const [submittingOpen, setSubmittingOpen] = useState(false);
@@ -22,9 +28,16 @@ export default function MaPage() {
           alert(JSON.stringify(data, null, 2));
           setDefaultOpen(false);
         }}
+        members={MOCK_MEMBERS}
       />
 
-      <CreateGroupModal open={submittingOpen} onOpenChange={setSubmittingOpen} onSubmit={() => {}} isSubmitting />
+      <CreateGroupModal
+        open={submittingOpen}
+        onOpenChange={setSubmittingOpen}
+        onSubmit={() => {}}
+        members={MOCK_MEMBERS}
+        isSubmitting
+      />
     </div>
   );
 }

--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,45 +1,46 @@
 "use client";
 
-import { RecentMessagesCard } from "@/components/dashboard/recent-messages-card";
+import { useState } from "react";
+import { CreateGroupModal } from "@/components/groups/create-group-modal";
+import { Button } from "@/components/ui/button";
+
+const MOCK_MEMBERS = [
+  { memberId: 100001, ownername: "Kevin Rutledge" },
+  { memberId: 100002, ownername: "Mary Jones" },
+  { memberId: 100003, ownername: "Tom Wilson" },
+  { memberId: 100004, ownername: "Sarah Chen" },
+  { memberId: 100005, ownername: "Derek Phan" },
+  { memberId: 100006, ownername: "Amy Lin" },
+  { memberId: 100007, ownername: "Jordan Ma" },
+  { memberId: 100008, ownername: "Priya Kakani" },
+];
 
 export function RutledgeContent() {
+  const [open, setOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-background p-8">
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
-          <h2 className="text-xl font-semibold">Recent Messages Card Preview</h2>
-          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <RecentMessagesCard
-              messages={[
-                {
-                  id: 1,
-                  subject: "Meeting tonight at 6 PM",
-                  groupName: "PRFC Members",
-                  isBlast: false,
-                  sentAt: new Date("2026-04-25T10:00:00"),
-                },
-                {
-                  id: 2,
-                  subject: "Volunteer signup for Saturday",
-                  groupName: "Volunteers",
-                  isBlast: false,
-                  sentAt: new Date("2026-04-24T14:00:00"),
-                },
-                {
-                  id: 3,
-                  subject: "April newsletter",
-                  groupName: null,
-                  isBlast: true,
-                  sentAt: new Date("2026-04-23T09:00:00"),
-                },
-              ]}
-            />
-            <RecentMessagesCard messages={[]} />
+          <h2 className="text-xl font-semibold">Create Group Modal Preview</h2>
+          <div className="mt-4">
+            <Button onClick={() => setOpen(true)} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
+              Open Create Group Modal
+            </Button>
           </div>
         </div>
       </div>
+      <CreateGroupModal
+        open={open}
+        onOpenChange={setOpen}
+        onSubmit={(data) => {
+          console.log("Create group:", data);
+          setOpen(false);
+        }}
+        members={MOCK_MEMBERS}
+      />
     </div>
   );
 }

--- a/src/components/groups/create-group-modal.tsx
+++ b/src/components/groups/create-group-modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Search } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -14,19 +15,38 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import { getAvatarColor, getInitials } from "@/utils/avatar";
+
+interface MemberOption {
+  memberId: number;
+  ownername: string;
+  photoUrl?: string | null;
+}
 
 interface CreateGroupModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (data: { name: string; description: string | null }) => void;
+  onSubmit: (data: { name: string; description: string | null; memberIds: number[] }) => void;
+  members: MemberOption[];
   isSubmitting?: boolean;
 }
 
-export function CreateGroupModal({ open, onOpenChange, onSubmit, isSubmitting = false }: CreateGroupModalProps) {
+export function CreateGroupModal({
+  open,
+  onOpenChange,
+  onSubmit,
+  members,
+  isSubmitting = false,
+}: CreateGroupModalProps) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [error, setError] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const nameRef = useRef<HTMLInputElement>(null);
+
+  const filteredMembers = useFuzzySearch(members, { keys: ["ownername"] }, searchQuery);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -35,7 +55,11 @@ export function CreateGroupModal({ open, onOpenChange, onSubmit, isSubmitting = 
       nameRef.current?.focus();
       return;
     }
-    onSubmit({ name: name.trim(), description: description.trim() || null });
+    onSubmit({
+      name: name.trim(),
+      description: description.trim() || null,
+      memberIds: Array.from(selectedIds),
+    });
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -44,66 +68,152 @@ export function CreateGroupModal({ open, onOpenChange, onSubmit, isSubmitting = 
       setName("");
       setDescription("");
       setError("");
+      setSearchQuery("");
+      setSelectedIds(new Set());
     }
     onOpenChange(nextOpen);
   };
 
+  const toggleMember = (memberId: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(memberId)) next.delete(memberId);
+      else next.add(memberId);
+      return next;
+    });
+  };
+
+  const handleSelectAll = () => {
+    const allFilteredIds = filteredMembers.map((m) => m.memberId);
+    const allSelected = allFilteredIds.every((id) => selectedIds.has(id));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allSelected) {
+        for (const id of allFilteredIds) next.delete(id);
+      } else {
+        for (const id of allFilteredIds) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const allFilteredSelected = filteredMembers.length > 0 && filteredMembers.every((m) => selectedIds.has(m.memberId));
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-[550px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Create Contact Group</DialogTitle>
+            <DialogTitle className="font-angkor text-2xl font-normal">Create a new group</DialogTitle>
             <DialogDescription className="sr-only">
               Fill in the details below to create a new contact group.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="mt-4">
-            <Label htmlFor="group-name">
-              Group Name <span className="text-prfc-red">*</span>
-            </Label>
-            <Input
-              ref={nameRef}
-              id="group-name"
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                if (error) setError("");
-              }}
-              aria-required="true"
-              aria-invalid={error ? true : undefined}
-              aria-describedby={error ? "group-name-error" : undefined}
-            />
-            {error && (
-              <p id="group-name-error" className="text-sm text-prfc-red mt-1">
-                {error}
-              </p>
-            )}
-          </div>
+          <div className="mt-4 space-y-4">
+            <div>
+              <Input
+                ref={nameRef}
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  if (error) setError("");
+                }}
+                placeholder="Group Name"
+                aria-required="true"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "group-name-error" : undefined}
+              />
+              {error && (
+                <p id="group-name-error" className="mt-1 text-sm text-prfc-red">
+                  {error}
+                </p>
+              )}
+            </div>
 
-          <div className="mt-4">
-            <Label htmlFor="description">Description (Optional)</Label>
-            <Textarea id="description" value={description} onChange={(e) => setDescription(e.target.value)} />
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Description..."
+              rows={3}
+            />
+
+            <div className="rounded-lg border border-prfc-border/30">
+              <div className="border-b border-prfc-border/30 px-3 py-2">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search or select members"
+                    className="border-none pl-9 shadow-none focus-visible:ring-0"
+                    aria-label="Search members"
+                    aria-controls="member-list"
+                  />
+                </div>
+              </div>
+              <div className="px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold">Members</span>
+                  <button
+                    type="button"
+                    onClick={handleSelectAll}
+                    className="text-sm text-foreground underline hover:text-prfc-brown"
+                  >
+                    {allFilteredSelected ? "Deselect all" : "Select all"}
+                  </button>
+                </div>
+                <div
+                  id="member-list"
+                  className="mt-2 max-h-[min(280px,40vh)] overflow-y-auto pr-1"
+                  style={{ scrollbarGutter: "stable" }}
+                >
+                  {filteredMembers.length === 0 ? (
+                    <p className="py-4 text-center text-sm text-muted-foreground">No members found.</p>
+                  ) : (
+                    <div className="space-y-1">
+                      {filteredMembers.map((member) => (
+                        <label
+                          key={member.memberId}
+                          className="flex cursor-pointer items-center justify-between rounded-md px-2 py-2 hover:bg-paso-grey"
+                        >
+                          <div className="flex items-center gap-3">
+                            <Avatar className="h-9 w-9">
+                              {member.photoUrl && <AvatarImage src={member.photoUrl} alt={member.ownername} />}
+                              <AvatarFallback
+                                style={{ backgroundColor: getAvatarColor(member.ownername) }}
+                                className="text-xs font-semibold text-white"
+                              >
+                                {getInitials(member.ownername)}
+                              </AvatarFallback>
+                            </Avatar>
+                            <span className="text-sm">{member.ownername}</span>
+                          </div>
+                          <Checkbox
+                            checked={selectedIds.has(member.memberId)}
+                            onCheckedChange={() => toggleMember(member.memberId)}
+                            aria-label={`Select ${member.ownername}`}
+                          />
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
 
           <DialogFooter className="mt-6">
-            <Button
-              type="button"
-              onClick={() => handleOpenChange(false)}
-              variant="outline"
-              className="border-prfc-red text-prfc-red hover:bg-red-100"
-            >
+            <Button type="button" onClick={() => handleOpenChange(false)} variant="outline" disabled={isSubmitting}>
               Cancel
             </Button>
-
             <Button
               type="submit"
               disabled={!name.trim() || isSubmitting}
               className="bg-prfc-brown text-white hover:bg-prfc-dark-brown"
             >
-              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
-              {isSubmitting ? "Creating..." : "Create Group"}
+              {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {isSubmitting ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </form>

--- a/src/hooks/use-groups-modal.ts
+++ b/src/hooks/use-groups-modal.ts
@@ -227,9 +227,13 @@ export function useGroupsModal(ownerId: number) {
     });
   }, [modal]);
 
-  const handleCreateSubmit = useCallback((data: { name: string; description: string | null }) => {
+  const handleCreateSubmit = useCallback((data: { name: string; description: string | null; memberIds: number[] }) => {
     startTransition(async () => {
-      const result = await createContactGroup(buildGroupFormData(data));
+      const result = await createContactGroup({
+        name: data.name,
+        description: data.description,
+        memberIds: data.memberIds.length > 0 ? data.memberIds : undefined,
+      });
       if (result.success) {
         toast.success("Group created successfully");
         setModal({ type: "closed" });

--- a/src/schema/contact-group.ts
+++ b/src/schema/contact-group.ts
@@ -16,6 +16,7 @@ export const CreateContactGroupSchema = ContactGroupSchema.omit({
   ownerid: true,
 }).extend({
   description: z.string().max(500).nullish(),
+  memberIds: z.array(z.number().int().positive()).optional(),
 });
 
 export const UpdateContactGroupSchema = CreateContactGroupSchema.partial();

--- a/test/actions/contact-group.test.ts
+++ b/test/actions/contact-group.test.ts
@@ -73,8 +73,7 @@ describe("createContactGroup", () => {
       updatedAt: new Date(),
     });
 
-    const formData = createFormData({ name: "Neighbors", description: "Local list" });
-    const result = await createContactGroup(formData);
+    const result = await createContactGroup({ name: "Neighbors", description: "Local list" });
 
     expect(result.success).toBe(true);
     expect(result.data?.id).toBe(55);
@@ -83,11 +82,51 @@ describe("createContactGroup", () => {
     expect(mockRevalidatePath).toHaveBeenCalledWith("/groups");
   });
 
+  it("creates group and adds members when memberIds are provided", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockCreateGroup.mockResolvedValue({
+      id: 55,
+      name: "Neighbors",
+      description: null,
+      ownerid: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockAddMembersToGroup.mockResolvedValue({ count: 2 });
+
+    const result = await createContactGroup({ name: "Neighbors", description: null, memberIds: [100001, 100002] });
+
+    expect(result.success).toBe(true);
+    expect(mockAddMembersToGroup).toHaveBeenCalledWith(
+      55,
+      [
+        { memberId: 100001, notifyEmail: true, notifySms: false },
+        { memberId: 100002, notifyEmail: true, notifySms: false },
+      ],
+      10,
+    );
+  });
+
+  it("skips addMembersToGroup when memberIds is empty", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockCreateGroup.mockResolvedValue({
+      id: 55,
+      name: "Solo",
+      description: null,
+      ownerid: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await createContactGroup({ name: "Solo", description: null, memberIds: [] });
+
+    expect(mockAddMembersToGroup).not.toHaveBeenCalled();
+  });
+
   it("returns validation error when data is invalid", async () => {
     mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
 
-    const formData = createFormData({ name: "", description: "Local list" });
-    const result = await createContactGroup(formData);
+    const result = await createContactGroup({ name: "", description: "Local list" });
 
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
@@ -97,8 +136,7 @@ describe("createContactGroup", () => {
   it("returns error when session verification fails", async () => {
     mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
 
-    const formData = createFormData({ name: "Neighbors", description: "Local list" });
-    const result = await createContactGroup(formData);
+    const result = await createContactGroup({ name: "Neighbors", description: "Local list" });
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("Authentication required");


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #119

## What changed?

I rewrote the create group modal to match the hi-fi design. The modal now has inline member selection with fuzzy search, avatar rows with checkboxes, and a select all toggle. The action accepts memberIds and adds members to the group in a single create flow instead of requiring a separate add-members step.

- `src/components/groups/create-group-modal.tsx` - rewrote with Angkor heading, placeholder-only inputs, search input + member list in a shared bordered container (Gestalt common region), scrollbar-gutter for checkbox spacing, useFuzzySearch for local filtering
- `src/schema/contact-group.ts` - added optional memberIds array to CreateContactGroupSchema
- `src/actions/contact-group.ts` - changed createContactGroup from FormData to typed object, calls addMembersToGroup after group creation when memberIds present
- `src/hooks/use-groups-modal.ts` - updated handleCreateSubmit signature to pass memberIds
- `src/app/(protected)/groups/page.tsx` - fetches getAllMembers in parallel, passes to GroupsContent
- `src/app/(protected)/groups/groups-content.tsx` - accepts members prop, maps to CreateGroupModal
- `src/app/team/ma/page.tsx` - updated to pass members prop
- `test/actions/contact-group.test.ts` - updated from FormData to typed objects, added 2 tests for memberIds fan-out

## How to test

1. Run `npm run dev`
2. Visit `localhost:3000/team/rutledge`, click "Open Create Group Modal"
3. Verify Angkor heading, placeholder inputs, search with magnifying glass icon
4. Type in search to filter members
5. Check individual members and verify checkboxes toggle
6. Click "Select all" and verify all visible members are selected
7. Click "Save" without a name to see validation error
8. Visit `localhost:3000/groups`, click the + card or "New Group" top bar button
9. Create a group with members selected, verify the group is created with the members added

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers