### PR TITLE
feat: simplify group edit modal to quick edit design

### DIFF
--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -5,7 +5,6 @@ import { GroupDetailViewModal } from "@/components/groups/group-detail-view-moda
 import { GroupEditModal } from "@/components/groups/group-edit-modal";
 import { CreateGroupModal } from "@/components/groups/create-group-modal";
 import { DeleteGroupModal } from "@/components/groups/delete-group-modal";
-import { AddMembersModal } from "@/components/groups/add-members-modal";
 import { useSetTopBarAction } from "@/components/layout/top-bar-action-context";
 import { useGroupsModal, EMPTY_GROUP } from "@/hooks/use-groups-modal";
 import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
@@ -31,14 +30,9 @@ export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsConte
     handleQuickEdit,
     handleQuickDelete,
     handleSave,
-    handleDelete,
     handleConfirmDelete,
-    handleAddMembersOpen,
-    handleSelectionChange,
-    handleConfirmAddMembers,
     handleCreateSubmit,
     handleDeleteCancel,
-    handleAddMembersCancel,
   } = useGroupsModal(ownerId);
 
   useSetTopBarAction("New Group", openCreateModal);
@@ -94,8 +88,6 @@ export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsConte
         }}
         group={modal.type === "edit" ? modal.group : EMPTY_GROUP}
         onSave={handleSave}
-        onDelete={handleDelete}
-        onAddMembers={handleAddMembersOpen}
         isSubmitting={modal.type === "edit" && isPending}
       />
 
@@ -117,18 +109,6 @@ export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsConte
         groupName={modal.type === "delete" ? modal.group.name : ""}
         onConfirm={handleConfirmDelete}
         isDeleting={modal.type === "delete" && isPending}
-      />
-
-      <AddMembersModal
-        open={modal.type === "addMembers"}
-        onOpenChange={(open) => {
-          if (!open) handleAddMembersCancel();
-        }}
-        groupName={modal.type === "addMembers" ? modal.group.name : ""}
-        members={modal.type === "addMembers" ? modal.memberRows : []}
-        onSelectionChange={handleSelectionChange}
-        onConfirm={handleConfirmAddMembers}
-        isSubmitting={modal.type === "addMembers" && isPending}
       />
     </div>
   );

--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,19 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { CreateGroupModal } from "@/components/groups/create-group-modal";
+import { GroupEditModal } from "@/components/groups/group-edit-modal";
 import { Button } from "@/components/ui/button";
-
-const MOCK_MEMBERS = [
-  { memberId: 100001, ownername: "Kevin Rutledge" },
-  { memberId: 100002, ownername: "Mary Jones" },
-  { memberId: 100003, ownername: "Tom Wilson" },
-  { memberId: 100004, ownername: "Sarah Chen" },
-  { memberId: 100005, ownername: "Derek Phan" },
-  { memberId: 100006, ownername: "Amy Lin" },
-  { memberId: 100007, ownername: "Jordan Ma" },
-  { memberId: 100008, ownername: "Priya Kakani" },
-];
 
 export function RutledgeContent() {
   const [open, setOpen] = useState(false);
@@ -24,22 +13,22 @@ export function RutledgeContent() {
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
-          <h2 className="text-xl font-semibold">Create Group Modal Preview</h2>
+          <h2 className="text-xl font-semibold">Quick Edit Modal Preview</h2>
           <div className="mt-4">
             <Button onClick={() => setOpen(true)} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
-              Open Create Group Modal
+              Open Quick Edit Modal
             </Button>
           </div>
         </div>
       </div>
-      <CreateGroupModal
+      <GroupEditModal
         open={open}
         onOpenChange={setOpen}
-        onSubmit={(data) => {
-          console.log("Create group:", data);
+        group={{ id: 1, name: "Board of Directors", description: "Executive leadership team" }}
+        onSave={(data) => {
+          console.log("Save:", data);
           setOpen(false);
         }}
-        members={MOCK_MEMBERS}
       />
     </div>
   );

--- a/src/components/groups/group-edit-modal.tsx
+++ b/src/components/groups/group-edit-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -13,34 +13,20 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { getAvatarColor, getInitials } from "@/utils/avatar";
 
-interface GroupEditModalProps {
+interface QuickEditModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   group: {
     id: number;
     name: string;
     description: string | null;
-    members: Array<{ memberId: number; ownername: string }>;
-    memberCount: number;
   };
   onSave: (data: { name: string; description: string | null }) => void;
-  onDelete: () => void;
-  onAddMembers: () => void;
   isSubmitting?: boolean;
 }
 
-export function GroupEditModal({
-  open,
-  onOpenChange,
-  group,
-  onSave,
-  onDelete,
-  onAddMembers,
-  isSubmitting = false,
-}: GroupEditModalProps) {
+export function GroupEditModal({ open, onOpenChange, group, onSave, isSubmitting = false }: QuickEditModalProps) {
   const [newName, setNewName] = useState(group.name);
   const [newDescription, setNewDescription] = useState(group.description ?? "");
   const [error, setError] = useState("");
@@ -83,102 +69,55 @@ export function GroupEditModal({
           if (isSubmitting) e.preventDefault();
         }}
       >
-        <DialogHeader className="text-prfc-brown">
-          <DialogTitle className="text-4xl font-black">{group.name}</DialogTitle>
-          <DialogDescription className="sr-only">Edit the details for the {group.name} group.</DialogDescription>
-        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle className="font-angkor text-2xl font-normal">Quick Edit</DialogTitle>
+            <DialogDescription className="sr-only">Edit the name and description for this group.</DialogDescription>
+          </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="grid grid-cols-1 justify-items-stretch gap-4">
-          <Button
-            type="button"
-            onClick={onDelete}
-            disabled={isSubmitting}
-            className="justify-self-end bg-transparent border-none p-0 text-prfc-red hover:underline hover:bg-transparent cursor-pointer shadow-none"
-          >
-            Delete
-          </Button>
+          <div className="mt-4 space-y-4">
+            <div>
+              <Input
+                ref={nameRef}
+                type="text"
+                value={newName}
+                onChange={(e) => {
+                  setNewName(e.target.value);
+                  if (error) setError("");
+                }}
+                placeholder="Group Name"
+                aria-required="true"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "groupName-error" : undefined}
+              />
+              {error && (
+                <p id="groupName-error" className="mt-1 text-sm text-prfc-red">
+                  {error}
+                </p>
+              )}
+            </div>
 
-          <div className="grid grid-cols-1 gap-2">
-            <label htmlFor="groupName" className="font-bold">
-              Group Name
-            </label>
-            <Input
-              ref={nameRef}
-              type="text"
-              id="groupName"
-              value={newName}
-              onChange={(e) => {
-                setNewName(e.target.value);
-                if (error) setError("");
-              }}
-              aria-required="true"
-              aria-invalid={error ? true : undefined}
-              aria-describedby={error ? "groupName-error" : undefined}
-              className="border-2 border-black"
-            />
-            {error && (
-              <p id="groupName-error" className="text-sm text-prfc-red mt-1">
-                {error}
-              </p>
-            )}
-          </div>
-
-          <div className="grid grid-cols-1 gap-2">
-            <label htmlFor="description" className="font-bold">
-              Description (Optional)
-            </label>
             <Textarea
-              id="description"
               value={newDescription}
               onChange={(e) => setNewDescription(e.target.value)}
-              className="border-2 border-black"
+              placeholder="Description..."
+              rows={3}
             />
+
+            <p className="text-sm text-muted-foreground">Add/Remove members in &ldquo;View Group&rdquo; tab.</p>
           </div>
 
-          <div className="flex items-center gap-4">
-            <span className="font-bold">Add Members</span>
-            <Button
-              type="button"
-              onClick={onAddMembers}
-              disabled={isSubmitting}
-              aria-label="Add members to group"
-              className="h-8 w-8 rounded-full bg-gray-200 hover:bg-gray-300 border-none shadow-none p-0"
-            >
-              <Plus className="h-5 w-5 text-gray-700" aria-hidden="true" />
+          <DialogFooter className="mt-6">
+            <Button type="button" onClick={() => handleOpenChange(false)} variant="outline" disabled={isSubmitting}>
+              Cancel
             </Button>
-          </div>
-
-          <div className="flex gap-2" role="group" aria-label="Group members">
-            {group.members.slice(0, 8).map((member) => (
-              <Avatar key={member.memberId} className="h-8 w-8" role="img" aria-label={member.ownername}>
-                <AvatarFallback
-                  style={{ backgroundColor: getAvatarColor(member.ownername) }}
-                  className="text-xs font-semibold text-white"
-                  aria-hidden="true"
-                >
-                  {getInitials(member.ownername)}
-                </AvatarFallback>
-              </Avatar>
-            ))}
-            {group.memberCount > 8 ? (
-              <div
-                className="bg-slate-300 h-8 w-8 rounded-full font-bold text-sm flex justify-center items-center"
-                role="img"
-                aria-label={`${group.memberCount - 8} more members`}
-              >
-                +{group.memberCount - 8}
-              </div>
-            ) : null}
-          </div>
-
-          <DialogFooter className="mt-4">
             <Button
               type="submit"
-              disabled={isSubmitting}
-              className="bg-prfc-brown text-white hover:bg-prfc-dark-brown rounded-full py-6 px-8"
+              disabled={!newName.trim() || isSubmitting}
+              className="bg-prfc-brown text-white hover:bg-prfc-dark-brown"
             >
-              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
-              {isSubmitting ? "Saving..." : "Save Changes"}
+              {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {isSubmitting ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </form>


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #120

## What changed?

I simplified the group edit modal to match the hi-fi "Quick Edit" design. The modal now focuses on name and description editing only. Delete moved to the kebab menu on group cards, and member management moves to the group detail page. Removed the AddMembersModal from the groups list page since it's unreachable without the edit modal's add members button.

- `src/components/groups/group-edit-modal.tsx` - rewrote with Angkor "Quick Edit" heading, placeholder-only inputs, helper text pointing to View Group for member changes, Cancel + Save buttons, removed delete button/member avatars/add members
- `src/app/(protected)/groups/groups-content.tsx` - removed onDelete and onAddMembers props from GroupEditModal, removed AddMembersModal render and its handlers
- `src/app/team/rutledge/rutledge-content.tsx` - preview with pre-filled group data

## How to test

1. Run `npm run dev`
2. Visit `localhost:3000/team/rutledge`, click "Open Quick Edit Modal"
3. Verify "Quick Edit" heading, pre-filled name and description, helper text, Cancel + Save buttons
4. Verify no delete button, no member avatars, no add members button
5. Visit `localhost:3000/groups`, click kebab menu "Quick Edit" on any group card
6. Verify the modal opens with the group's current name and description

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers