### PR TITLE
feat: update add members modal to match hi-fi design

### DIFF
--- a/src/app/team/kakani/page.tsx
+++ b/src/app/team/kakani/page.tsx
@@ -67,7 +67,6 @@ export default function KakaniPage() {
       <AddMembersModal
         open={open}
         onOpenChange={setOpen}
-        groupName="Garden Club"
         members={members}
         onSelectionChange={handleSelectionChange}
         onConfirm={() => {
@@ -79,7 +78,6 @@ export default function KakaniPage() {
       <AddMembersModal
         open={submittingOpen}
         onOpenChange={setSubmittingOpen}
-        groupName="Garden Club"
         members={members}
         onSelectionChange={handleSelectionChange}
         onConfirm={() => {}}

--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,11 +1,27 @@
 "use client";
 
 import { useState } from "react";
-import { GroupEditModal } from "@/components/groups/group-edit-modal";
+import { AddMembersModal, type MemberRow } from "@/components/groups/add-members-modal";
 import { Button } from "@/components/ui/button";
+
+const INITIAL_MEMBERS: MemberRow[] = [
+  { memberId: 100001, ownername: "Kevin Rutledge", isOwner: true, isSelected: true },
+  { memberId: 100002, ownername: "Mary Jones", isOwner: false, isSelected: true },
+  { memberId: 100003, ownername: "Tom Wilson", isOwner: false, isSelected: false },
+  { memberId: 100004, ownername: "Sarah Chen", isOwner: false, isSelected: false },
+  { memberId: 100005, ownername: "Derek Phan", isOwner: false, isSelected: true },
+  { memberId: 100006, ownername: "Amy Lin", isOwner: false, isSelected: false },
+  { memberId: 100007, ownername: "Jordan Ma", isOwner: false, isSelected: false },
+  { memberId: 100008, ownername: "Priya Kakani", isOwner: false, isSelected: false },
+];
 
 export function RutledgeContent() {
   const [open, setOpen] = useState(false);
+  const [members, setMembers] = useState(INITIAL_MEMBERS);
+
+  const handleSelectionChange = (memberId: number, selected: boolean) => {
+    setMembers((prev) => prev.map((m) => (m.memberId === memberId ? { ...m, isSelected: selected } : m)));
+  };
 
   return (
     <div className="min-h-screen bg-background p-8">
@@ -13,20 +29,24 @@ export function RutledgeContent() {
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
-          <h2 className="text-xl font-semibold">Quick Edit Modal Preview</h2>
+          <h2 className="text-xl font-semibold">Add Members Modal Preview</h2>
           <div className="mt-4">
             <Button onClick={() => setOpen(true)} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
-              Open Quick Edit Modal
+              Open Add Members Modal
             </Button>
           </div>
         </div>
       </div>
-      <GroupEditModal
+      <AddMembersModal
         open={open}
         onOpenChange={setOpen}
-        group={{ id: 1, name: "Board of Directors", description: "Executive leadership team" }}
-        onSave={(data) => {
-          console.log("Save:", data);
+        members={members}
+        onSelectionChange={handleSelectionChange}
+        onConfirm={() => {
+          console.log(
+            "Confirm:",
+            members.filter((m) => m.isSelected).map((m) => m.ownername),
+          );
           setOpen(false);
         }}
       />

--- a/src/components/groups/add-members-modal.tsx
+++ b/src/components/groups/add-members-modal.tsx
@@ -3,15 +3,17 @@
 import { useMemo, useState } from "react";
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
 import { getAvatarColor, getInitials } from "@/utils/avatar";
 
 export interface MemberRow {
   memberId: number;
   ownername: string;
+  photoUrl?: string | null;
   isOwner: boolean;
   isSelected: boolean;
 }
@@ -19,7 +21,6 @@ export interface MemberRow {
 export interface AddMembersModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  groupName: string;
   members: MemberRow[];
   onSelectionChange: (memberId: number, selected: boolean) => void;
   onConfirm: () => void;
@@ -29,100 +30,122 @@ export interface AddMembersModalProps {
 export function AddMembersModal({
   open,
   onOpenChange,
-  groupName,
   members,
   onSelectionChange,
   onConfirm,
   isSubmitting = false,
 }: AddMembersModalProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const currentMemberCount = members.filter((member) => member.isOwner || member.isSelected).length;
+
   const orderedMembers = useMemo(() => [...members].sort((a, b) => Number(b.isOwner) - Number(a.isOwner)), [members]);
-  const filteredMembers = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    const ownerMember = orderedMembers.find((member) => member.isOwner);
-    const nonOwnerMembers = orderedMembers.filter((member) => !member.isOwner);
+  const filteredMembers = useFuzzySearch(orderedMembers, { keys: ["ownername"] }, searchQuery);
 
-    const matchedNonOwners =
-      normalizedQuery.length === 0
-        ? nonOwnerMembers
-        : nonOwnerMembers.filter((member) => member.ownername.toLowerCase().includes(normalizedQuery));
+  const nonOwnerFiltered = useMemo(() => filteredMembers.filter((m) => !m.isOwner), [filteredMembers]);
+  const allNonOwnerSelected = nonOwnerFiltered.length > 0 && nonOwnerFiltered.every((m) => m.isSelected);
 
-    return ownerMember ? [ownerMember, ...matchedNonOwners] : matchedNonOwners;
-  }, [orderedMembers, searchQuery]);
+  const handleSelectAll = () => {
+    for (const m of nonOwnerFiltered) {
+      onSelectionChange(m.memberId, !allNonOwnerSelected);
+    }
+  };
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      setSearchQuery("");
-    }
+    if (!nextOpen) setSearchQuery("");
     onOpenChange(nextOpen);
   };
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[700px] p-6">
-        <DialogHeader className="space-y-1">
-          <DialogTitle className="text-4xl font-bold text-black">{groupName}</DialogTitle>
-          <DialogDescription className="text-3xl text-black">members ({currentMemberCount})</DialogDescription>
-        </DialogHeader>
+      <DialogContent className="sm:max-w-[500px] [&>button:last-child]:hidden">
+        <DialogTitle className="sr-only">Add members</DialogTitle>
+        <DialogDescription className="sr-only">Search and select members to add to this group.</DialogDescription>
 
-        <div className="relative">
-          <Search className="absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-prfc-dark-brown" />
-          <Input
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search or add members"
-            aria-label="Search members"
-            className="h-12 rounded-lg border-prfc-border pr-10 text-xl"
-          />
-        </div>
-
-        <div aria-live="polite" className="sr-only">
-          {filteredMembers.length} {filteredMembers.length === 1 ? "member" : "members"} found
-        </div>
-
-        <div className="max-h-[min(400px,50vh)] overflow-y-auto rounded-lg bg-paso-grey p-2">
-          {filteredMembers.length === 0 ? (
-            <p className="py-8 text-center text-lg text-muted-foreground">
-              No members found matching &ldquo;{searchQuery}&rdquo;
-            </p>
-          ) : (
-            <div className="space-y-1" role="group" aria-label="Group members">
-              {filteredMembers.map((member) => (
-                <div key={member.memberId} className="flex items-center justify-between rounded-md px-3 py-2">
-                  <div className="flex items-center gap-3">
-                    <Avatar className="h-10 w-10">
-                      <AvatarFallback style={{ backgroundColor: getAvatarColor(member.ownername), color: "#fff" }}>
-                        {getInitials(member.ownername)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="text-2xl text-black">
-                      {member.ownername}
-                      {member.isOwner ? " (owner)" : ""}
-                    </span>
-                  </div>
-                  <Checkbox
-                    checked={member.isOwner ? true : member.isSelected}
-                    disabled={member.isOwner}
-                    onCheckedChange={(checked) => {
-                      if (member.isOwner) return;
-                      onSelectionChange(member.memberId, checked === true);
-                    }}
-                    aria-label={
-                      member.isOwner ? `${member.ownername} is the group owner` : `Select ${member.ownername}`
-                    }
-                  />
-                </div>
-              ))}
+        <div className="rounded-lg border border-prfc-border/30">
+          <div className="border-b border-prfc-border/30 px-3 py-2">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search or select members"
+                className="border-none pl-9 shadow-none focus-visible:ring-0"
+                aria-label="Search members"
+                aria-controls="add-member-list"
+              />
             </div>
-          )}
+          </div>
+          <div className="px-3 py-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold">Members</span>
+              <button
+                type="button"
+                onClick={handleSelectAll}
+                className="text-sm text-foreground underline hover:text-prfc-brown"
+              >
+                {allNonOwnerSelected ? "Deselect all" : "Select all"}
+              </button>
+            </div>
+            <div
+              id="add-member-list"
+              className="mt-2 max-h-[min(280px,40vh)] overflow-y-auto pr-1"
+              style={{ scrollbarGutter: "stable" }}
+            >
+              {filteredMembers.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">No members found.</p>
+              ) : (
+                <div className="space-y-1">
+                  {filteredMembers.map((member) => (
+                    <label
+                      key={member.memberId}
+                      className="flex cursor-pointer items-center justify-between rounded-md px-2 py-2 hover:bg-paso-grey"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-9 w-9">
+                          {member.photoUrl && <AvatarImage src={member.photoUrl} alt={member.ownername} />}
+                          <AvatarFallback
+                            style={{ backgroundColor: getAvatarColor(member.ownername) }}
+                            className="text-xs font-semibold text-white"
+                          >
+                            {getInitials(member.ownername)}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="text-sm">
+                          {member.ownername}
+                          {member.isOwner ? " (owner)" : ""}
+                        </span>
+                      </div>
+                      <Checkbox
+                        checked={member.isOwner ? true : member.isSelected}
+                        disabled={member.isOwner}
+                        onCheckedChange={(checked) => {
+                          if (member.isOwner) return;
+                          onSelectionChange(member.memberId, checked === true);
+                        }}
+                        aria-label={
+                          member.isOwner ? `${member.ownername} is the group owner` : `Select ${member.ownername}`
+                        }
+                      />
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
 
-        <div className="flex justify-end">
-          <Button type="button" onClick={onConfirm} disabled={isSubmitting} className="bg-prfc-brown px-8">
-            {isSubmitting ? "Saving..." : "Save"}
+        <DialogFooter>
+          <Button type="button" onClick={() => handleOpenChange(false)} variant="outline" disabled={isSubmitting}>
+            Cancel
           </Button>
-        </div>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            className="bg-prfc-brown text-white hover:bg-prfc-dark-brown"
+          >
+            {isSubmitting ? "Adding..." : "Add"}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/groups/create-group-modal.tsx
+++ b/src/components/groups/create-group-modal.tsx
@@ -101,7 +101,7 @@ export function CreateGroupModal({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[550px]">
+      <DialogContent className="sm:max-w-[550px] [&>button:last-child]:hidden">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle className="font-angkor text-2xl font-normal">Create a new group</DialogTitle>

--- a/src/components/groups/group-edit-modal.tsx
+++ b/src/components/groups/group-edit-modal.tsx
@@ -62,6 +62,7 @@ export function GroupEditModal({ open, onOpenChange, group, onSave, isSubmitting
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
+        className="[&>button:last-child]:hidden"
         onEscapeKeyDown={(e) => {
           if (isSubmitting) e.preventDefault();
         }}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #121

## What changed?

I rewrote the add members modal to match the hi-fi design. The modal now uses the same search-in-container pattern as the create group modal, with useFuzzySearch for filtering, "Select all" toggle for non-owner members, and Cancel + Add buttons. Removed the group name header and replaced the single Save button. Also hid the default X close button on all three group modals (create, quick edit, add members) since the hi-fi shows Cancel buttons instead.

- `src/components/groups/add-members-modal.tsx` - rewrote with bordered search container, useFuzzySearch, "Select all" toggle, Cancel + Add footer, removed groupName prop
- `src/components/groups/create-group-modal.tsx` - hid X close button
- `src/components/groups/group-edit-modal.tsx` - hid X close button
- `src/app/team/kakani/page.tsx` - removed groupName prop from preview
- `src/app/team/rutledge/rutledge-content.tsx` - preview with 8 members including owner

## How to test

1. Run `npm run dev`
2. Visit `localhost:3000/team/rutledge`, click "Open Add Members Modal"
3. Verify search filters members with fuzzy matching
4. Verify owner (Kevin Rutledge) is pinned at top, always checked, disabled
5. Verify "Select all" toggles all non-owner members
6. Verify Cancel and Add buttons, no X close button
7. Visit `localhost:3000/team/kakani` to verify their preview still works

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers