### PR TITLE
feat: add group member table component

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,55 +1,34 @@
 "use client";
 
-import { useState } from "react";
-import { AddMembersModal, type MemberRow } from "@/components/groups/add-members-modal";
-import { Button } from "@/components/ui/button";
+import { GroupMemberTable } from "@/components/groups/group-member-table";
 
-const INITIAL_MEMBERS: MemberRow[] = [
-  { memberId: 100001, ownername: "Kevin Rutledge", isOwner: true, isSelected: true },
-  { memberId: 100002, ownername: "Mary Jones", isOwner: false, isSelected: true },
-  { memberId: 100003, ownername: "Tom Wilson", isOwner: false, isSelected: false },
-  { memberId: 100004, ownername: "Sarah Chen", isOwner: false, isSelected: false },
-  { memberId: 100005, ownername: "Derek Phan", isOwner: false, isSelected: true },
-  { memberId: 100006, ownername: "Amy Lin", isOwner: false, isSelected: false },
-  { memberId: 100007, ownername: "Jordan Ma", isOwner: false, isSelected: false },
-  { memberId: 100008, ownername: "Priya Kakani", isOwner: false, isSelected: false },
+const MOCK_MEMBERS = [
+  { memberId: 100001, ownername: "Angelica Allison", owneremail: "angelica.allison@email.com" },
+  { memberId: 100002, ownername: "Aya Gallagher", owneremail: "aya.gallagher@email.com" },
+  { memberId: 100003, ownername: "Brandon Schwartz", owneremail: "brandon.schwartz@email.com" },
+  { memberId: 100004, ownername: "Sarah Chen", owneremail: "sarah.chen@email.com" },
+  { memberId: 100005, ownername: "Derek Phan", owneremail: "derek.phan@email.com" },
 ];
 
 export function RutledgeContent() {
-  const [open, setOpen] = useState(false);
-  const [members, setMembers] = useState(INITIAL_MEMBERS);
-
-  const handleSelectionChange = (memberId: number, selected: boolean) => {
-    setMembers((prev) => prev.map((m) => (m.memberId === memberId ? { ...m, isSelected: selected } : m)));
-  };
-
   return (
     <div className="min-h-screen bg-background p-8">
-      <div className="mx-auto max-w-3xl">
+      <div className="mx-auto max-w-4xl">
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
-          <h2 className="text-xl font-semibold">Add Members Modal Preview</h2>
+          <h2 className="text-xl font-semibold">Group Member Table - View Mode</h2>
           <div className="mt-4">
-            <Button onClick={() => setOpen(true)} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
-              Open Add Members Modal
-            </Button>
+            <GroupMemberTable members={MOCK_MEMBERS} mode="view" />
+          </div>
+        </div>
+        <div className="mt-10">
+          <h2 className="text-xl font-semibold">Group Member Table - Edit Mode</h2>
+          <div className="mt-4">
+            <GroupMemberTable members={MOCK_MEMBERS} mode="edit" onRemove={(id) => console.log("Remove:", id)} />
           </div>
         </div>
       </div>
-      <AddMembersModal
-        open={open}
-        onOpenChange={setOpen}
-        members={members}
-        onSelectionChange={handleSelectionChange}
-        onConfirm={() => {
-          console.log(
-            "Confirm:",
-            members.filter((m) => m.isSelected).map((m) => m.ownername),
-          );
-          setOpen(false);
-        }}
-      />
     </div>
   );
 }

--- a/src/components/groups/group-member-table.tsx
+++ b/src/components/groups/group-member-table.tsx
@@ -1,0 +1,69 @@
+import { Lock, UserMinus } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { getAvatarColor, getInitials } from "@/utils/avatar";
+
+interface GroupMemberTableProps {
+  members: Array<{
+    memberId: number;
+    ownername: string;
+    owneremail: string;
+    photoUrl?: string | null;
+  }>;
+  mode: "view" | "edit";
+  onRemove?: (memberId: number) => void;
+}
+
+export function GroupMemberTable({ members, mode, onRemove }: GroupMemberTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead className="w-[100px]">
+            <span className="sr-only">Actions</span>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {members.map((member) => (
+          <TableRow key={member.memberId}>
+            <TableCell>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-9 w-9">
+                  {member.photoUrl && <AvatarImage src={member.photoUrl} alt={member.ownername} />}
+                  <AvatarFallback
+                    style={{ backgroundColor: getAvatarColor(member.ownername) }}
+                    className="text-xs font-semibold text-white"
+                  >
+                    {getInitials(member.ownername)}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-sm">{member.ownername}</span>
+              </div>
+            </TableCell>
+            <TableCell className="text-sm">{member.owneremail}</TableCell>
+            <TableCell className="text-sm">Member</TableCell>
+            <TableCell>
+              {mode === "view" ? (
+                <Lock className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onRemove?.(member.memberId)}
+                  aria-label={`Remove ${member.ownername}`}
+                  className="flex items-center gap-2 text-sm font-semibold text-prfc-red hover:text-prfc-red/80"
+                >
+                  <UserMinus className="h-4 w-4" />
+                  Remove
+                </button>
+              )}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #122

## What changed?

Added a presentational table component that displays group members with avatar, name, email, and role columns. The table supports two modes: view mode shows lock icons in the action column, edit mode shows red "Remove" buttons with UserMinus icons. The table receives already-filtered data from the parent - search filtering will be added at the page level when the group detail page (#123) is built.

- `src/components/groups/group-member-table.tsx` - new component with shadcn Table primitives, avatar fallback, view/edit mode toggle, aria-label on remove buttons
- `src/app/team/rutledge/rutledge-content.tsx` - preview showing both view and edit modes with 5 members

## How to test

1. Run `npm run dev`
2. Visit `localhost:3000/team/rutledge`
3. Verify view mode table shows Name (avatar + name), Email, Role, and lock icons
4. Verify edit mode table shows red "Remove" buttons with icons instead of locks

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers