### PR TITLE
feat: add message history table component

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,13 +1,43 @@
 "use client";
 
-import { GroupMemberTable } from "@/components/groups/group-member-table";
+import { MessageHistoryTable } from "@/components/messages/message-history-table";
 
-const MOCK_MEMBERS = [
-  { memberId: 100001, ownername: "Angelica Allison", owneremail: "angelica.allison@email.com" },
-  { memberId: 100002, ownername: "Aya Gallagher", owneremail: "aya.gallagher@email.com" },
-  { memberId: 100003, ownername: "Brandon Schwartz", owneremail: "brandon.schwartz@email.com" },
-  { memberId: 100004, ownername: "Sarah Chen", owneremail: "sarah.chen@email.com" },
-  { memberId: 100005, ownername: "Derek Phan", owneremail: "derek.phan@email.com" },
+const MOCK_MESSAGES = [
+  {
+    id: 1,
+    subject: "Meeting tonight at 6 PM - please confirm attendance",
+    sentAt: new Date("2026-01-06T19:57:01Z"),
+    groupName: "PRFC Members",
+    isBlast: false,
+  },
+  {
+    id: 2,
+    subject: "Volunteer signup for Saturday market",
+    sentAt: new Date("2025-12-31T18:43:11Z"),
+    groupName: "Volunteers",
+    isBlast: false,
+  },
+  {
+    id: 3,
+    subject: "November newsletter update",
+    sentAt: new Date("2025-11-06T19:57:20Z"),
+    groupName: null,
+    isBlast: true,
+  },
+  {
+    id: 4,
+    subject: "Board meeting rescheduled",
+    sentAt: new Date("2025-10-06T19:57:59Z"),
+    groupName: "Board",
+    isBlast: false,
+  },
+  {
+    id: 5,
+    subject: "Fall harvest event details",
+    sentAt: new Date("2025-09-06T19:57:09Z"),
+    groupName: "Garden Committee",
+    isBlast: false,
+  },
 ];
 
 export function RutledgeContent() {
@@ -17,15 +47,9 @@ export function RutledgeContent() {
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
-          <h2 className="text-xl font-semibold">Group Member Table - View Mode</h2>
+          <h2 className="text-xl font-semibold">Message History Table Preview</h2>
           <div className="mt-4">
-            <GroupMemberTable members={MOCK_MEMBERS} mode="view" />
-          </div>
-        </div>
-        <div className="mt-10">
-          <h2 className="text-xl font-semibold">Group Member Table - Edit Mode</h2>
-          <div className="mt-4">
-            <GroupMemberTable members={MOCK_MEMBERS} mode="edit" onRemove={(id) => console.log("Remove:", id)} />
+            <MessageHistoryTable messages={MOCK_MESSAGES} onView={(id) => console.log("View:", id)} />
           </div>
         </div>
       </div>

--- a/src/components/messages/message-history-table.tsx
+++ b/src/components/messages/message-history-table.tsx
@@ -1,0 +1,59 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { coopFormatTimed } from "@/lib/time";
+
+interface MessageHistoryTableProps {
+  messages: Array<{
+    id: number;
+    subject: string;
+    sentAt: Date;
+    groupName: string | null;
+    isBlast: boolean;
+  }>;
+  onView: (messageId: number) => void;
+}
+
+function formatDeliveredAt(date: Date): string {
+  return coopFormatTimed(date, "M/d/yyyy h:mm:ss a zzz");
+}
+
+export function MessageHistoryTable({ messages, onView }: MessageHistoryTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="font-bold text-foreground">Message Preview</TableHead>
+          <TableHead className="font-bold text-foreground">Delivered at</TableHead>
+          <TableHead className="w-[80px]">
+            <span className="sr-only">Actions</span>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {messages.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={3} className="py-8 text-center text-muted-foreground">
+              No messages yet.
+            </TableCell>
+          </TableRow>
+        ) : (
+          messages.map((message) => (
+            <TableRow key={message.id}>
+              <TableCell className="max-w-[300px] truncate text-sm">{message.subject}</TableCell>
+              <TableCell className="text-sm">{formatDeliveredAt(message.sentAt)}</TableCell>
+              <TableCell>
+                <button
+                  type="button"
+                  onClick={() => onView(message.id)}
+                  aria-label={`View message: ${message.subject}`}
+                  className="text-sm underline hover:text-prfc-brown"
+                >
+                  View
+                </button>
+              </TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  );
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #130

## What changed?

Added a presentational table that displays sent messages with truncated subject preview, Pacific timezone timestamp, and a "View" link per row. The table receives filtered data from the parent and fires an onView callback. Timestamps use coopFormatTimed for consistent Pacific timezone formatting. The "View" link will open the ViewMessageModal when wired on the message history page (#134).

- `src/components/messages/message-history-table.tsx` - new component with shadcn Table primitives, truncated subjects, coopFormatTimed timestamps, aria-labeled View buttons, empty state
- `src/app/team/rutledge/rutledge-content.tsx` - preview with 5 mock messages

## How to test

1. Run `npm run dev`
2. Visit `localhost:3000/team/rutledge`
3. Verify table shows "Message Preview" and "Delivered at" bold headers
4. Verify message subjects truncate with ellipsis
5. Verify timestamps show Pacific timezone (PDT/PST)
6. Verify "View" links are underlined

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers