### PR TITLE
feat: add message sent confirmation component

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import { ComposeMessageForm } from "@/components/messages/compose-message-form";
-
-const MOCK_GROUPS = [
-  { id: 1, name: "PRFC Members" },
-  { id: 2, name: "Volunteers" },
-  { id: 3, name: "Board of Directors" },
-  { id: 4, name: "Garden Committee" },
-];
+import { MessageSentConfirmation } from "@/components/messages/message-sent-confirmation";
 
 export function RutledgeContent() {
   return (
@@ -16,12 +9,27 @@ export function RutledgeContent() {
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
         <div className="mt-10">
-          <ComposeMessageForm
-            groups={MOCK_GROUPS}
-            currentUser={{ name: "Kevin Rutledge" }}
-            smsConsent={{ eligible: 95, total: 120 }}
-            onSend={(data) => console.log("Send:", data)}
-          />
+          <h2 className="text-xl font-semibold">Message Sent Confirmation Preview</h2>
+          <div className="mt-4 space-y-6">
+            <MessageSentConfirmation
+              recipientCount={120}
+              channels={{ email: true, sms: true }}
+              onTrackRsvps={() => console.log("Track RSVPs")}
+              onDeliveryStatus={() => console.log("Delivery Status")}
+            />
+            <MessageSentConfirmation
+              recipientCount={45}
+              channels={{ email: true, sms: false }}
+              onTrackRsvps={() => console.log("Track RSVPs")}
+              onDeliveryStatus={() => console.log("Delivery Status")}
+            />
+            <MessageSentConfirmation
+              recipientCount={30}
+              channels={{ email: false, sms: true }}
+              onTrackRsvps={() => console.log("Track RSVPs")}
+              onDeliveryStatus={() => console.log("Delivery Status")}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/messages/message-sent-confirmation.tsx
+++ b/src/components/messages/message-sent-confirmation.tsx
@@ -1,0 +1,42 @@
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MessageSentConfirmationProps {
+  recipientCount: number;
+  channels: { email: boolean; sms: boolean };
+  onTrackRsvps: () => void;
+  onDeliveryStatus: () => void;
+}
+
+function channelLabel(channels: { email: boolean; sms: boolean }): string {
+  if (channels.email && channels.sms) return "Text/Email";
+  if (channels.sms) return "Text";
+  return "Email";
+}
+
+export function MessageSentConfirmation({
+  recipientCount,
+  channels,
+  onTrackRsvps,
+  onDeliveryStatus,
+}: MessageSentConfirmationProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-lg border border-prfc-border/30 py-16">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-400">
+        <Check className="h-8 w-8 text-white" strokeWidth={3} />
+      </div>
+      <h2 className="font-angkor text-2xl">Message Sent!</h2>
+      <p className="text-sm text-muted-foreground">
+        {channelLabel(channels)} sent to {recipientCount} members
+      </p>
+      <div className="flex flex-col gap-2">
+        <Button onClick={onTrackRsvps} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
+          Track RSVPs
+        </Button>
+        <Button onClick={onDeliveryStatus} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
+          Delivery Status
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #133

## What changed?

Added a confirmation component that renders after a message is sent. It shows a green checkmark circle, "Message Sent!" heading in Angkor font, a channel-aware summary line ("Text/Email sent to N members"), and two brown action buttons for Track RSVPs and Delivery Status. The channel label adjusts based on which channels were used.

- `src/components/messages/message-sent-confirmation.tsx` - new component with green checkmark, Angkor heading, dynamic channel label, two action buttons
- `src/app/team/rutledge/rutledge-content.tsx` - preview showing all three channel combinations (both, email only, SMS only)

## How to test

1. Run `npm run dev`
2. Visit `localhost:3000/team/rutledge`
3. Verify three confirmation cards showing "Text/Email", "Email", and "Text" variants
4. Verify green checkmark, heading, recipient counts, and button labels

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers