### PR TITLE
feat: add group detail page with view and edit modes

### DIFF
--- a/src/app/(protected)/groups/[id]/group-detail-content.tsx
+++ b/src/app/(protected)/groups/[id]/group-detail-content.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, Search, UserPlus } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { GroupMemberTable } from "@/components/groups/group-member-table";
+import { AddMembersModal, type MemberRow } from "@/components/groups/add-members-modal";
+import { addMembers, removeMember } from "@/actions/contact-group";
+import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import type { MemberSummary } from "@/types/member";
+
+type Props = {
+  group: {
+    id: number;
+    name: string;
+    description: string | null;
+    ownerid: number;
+    members: Array<{
+      memberId: number;
+      ownername: string;
+      owneremail: string;
+    }>;
+  };
+  allMembers: MemberSummary[];
+  currentUserOwnerid: number;
+  isAdmin: boolean;
+};
+
+export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAdmin }: Props) {
+  const router = useRouter();
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [addMembersOpen, setAddMembersOpen] = useState(false);
+  const [removedIds, setRemovedIds] = useState<Set<number>>(new Set());
+  const [isPending, startTransition] = useTransition();
+
+  const filteredMembers = useFuzzySearch(group.members, { keys: ["ownername", "owneremail"] }, searchQuery);
+
+  const memberRows: MemberRow[] = useMemo(() => {
+    const currentMemberIds = new Set(group.members.map((m) => m.memberId));
+    return allMembers.map((m) => ({
+      memberId: m.ownerid,
+      ownername: m.ownername,
+      isOwner: m.ownerid === group.ownerid,
+      isSelected: currentMemberIds.has(m.ownerid),
+    }));
+  }, [allMembers, group.members, group.ownerid]);
+
+  const [modalMembers, setModalMembers] = useState<MemberRow[]>([]);
+
+  const handleEdit = () => {
+    setMode("edit");
+    setRemovedIds(new Set());
+  };
+
+  const handleRemove = (memberId: number) => {
+    setRemovedIds((prev) => new Set(prev).add(memberId));
+  };
+
+  const handleRestore = (memberId: number) => {
+    setRemovedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(memberId);
+      return next;
+    });
+  };
+
+  const handleOpenAddMembers = () => {
+    setModalMembers(memberRows);
+    setAddMembersOpen(true);
+  };
+
+  const handleSelectionChange = (memberId: number, selected: boolean) => {
+    setModalMembers((prev) => prev.map((m) => (m.memberId === memberId ? { ...m, isSelected: selected } : m)));
+  };
+
+  const handleConfirmAddMembers = () => {
+    const currentMemberIds = new Set(group.members.map((m) => m.memberId));
+    const newMemberIds = modalMembers
+      .filter((m) => m.isSelected && !currentMemberIds.has(m.memberId))
+      .map((m) => m.memberId);
+
+    if (newMemberIds.length === 0) {
+      setAddMembersOpen(false);
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await addMembers({
+        groupId: group.id,
+        members: newMemberIds.map((id) => ({ memberId: id })),
+      });
+      if (result.success) {
+        toast.success(`Added ${result.data?.count ?? newMemberIds.length} member(s)`);
+        setAddMembersOpen(false);
+        router.refresh();
+      } else {
+        toast.error(result.error ?? "Failed to add members");
+      }
+    });
+  };
+
+  const handleSave = () => {
+    if (removedIds.size === 0) {
+      setMode("view");
+      return;
+    }
+
+    startTransition(async () => {
+      const results = await Promise.all(Array.from(removedIds).map((memberId) => removeMember(group.id, memberId)));
+      const failures = results.filter((r) => !r.success);
+      if (failures.length > 0) {
+        toast.error(`Failed to remove ${failures.length} member(s)`);
+      } else {
+        toast.success(`Removed ${removedIds.size} member(s)`);
+      }
+      setMode("view");
+      setRemovedIds(new Set());
+      router.refresh();
+    });
+  };
+
+  const canEdit = isAdmin || currentUserOwnerid === group.ownerid;
+
+  return (
+    <div className={mode === "edit" ? "pb-20" : ""}>
+      <Link
+        href="/groups"
+        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Go Back
+      </Link>
+
+      <h1 className="font-angkor text-3xl text-prfc-brown">{group.name}</h1>
+      {group.description && <p className="mt-2 text-muted-foreground">{group.description}</p>}
+
+      <div className="mt-6 flex items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search"
+            className="pl-9"
+            aria-label="Search members"
+          />
+        </div>
+        <div className="ml-auto">
+          {mode === "view" && canEdit && (
+            <Button onClick={handleEdit} className="bg-prfc-brown text-white hover:bg-prfc-dark-brown">
+              Edit
+            </Button>
+          )}
+          {mode === "edit" && (
+            <Button variant="outline" onClick={handleOpenAddMembers} disabled={isPending}>
+              <UserPlus className="mr-2 h-4 w-4" />
+              Add Member
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <GroupMemberTable
+          members={filteredMembers}
+          mode={mode}
+          removedIds={removedIds}
+          onRemove={handleRemove}
+          onRestore={handleRestore}
+        />
+      </div>
+
+      {mode === "edit" && (
+        <div className="fixed bottom-0 left-0 right-0 z-10 flex justify-end border-t border-prfc-border/30 bg-background px-8 py-4 md:pl-[calc(220px+2rem)]">
+          <Button
+            onClick={handleSave}
+            disabled={isPending}
+            className="bg-prfc-brown text-white hover:bg-prfc-dark-brown"
+          >
+            {isPending ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      )}
+
+      <AddMembersModal
+        open={addMembersOpen}
+        onOpenChange={setAddMembersOpen}
+        members={modalMembers}
+        onSelectionChange={handleSelectionChange}
+        onConfirm={handleConfirmAddMembers}
+        isSubmitting={isPending}
+      />
+    </div>
+  );
+}

--- a/src/app/(protected)/groups/[id]/page.tsx
+++ b/src/app/(protected)/groups/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from "next/navigation";
+import { verifySession } from "@/lib/dal";
+import { getGroupById, enrichGroupMembers, isGroupOwner } from "@/services/contact-group";
+import { getAllMembers } from "@/lib/api/member-api";
+import { AppError } from "@/utils/errors";
+import { GroupDetailContent } from "./group-detail-content";
+
+async function loadGroup(groupId: number) {
+  try {
+    const group = await getGroupById(groupId);
+    return await enrichGroupMembers(group);
+  } catch (error) {
+    if (error instanceof AppError && error.code === "NOT_FOUND") notFound();
+    throw error;
+  }
+}
+
+export default async function GroupDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const groupId = parseInt(id, 10);
+  if (isNaN(groupId) || groupId <= 0) notFound();
+
+  const session = await verifySession();
+  if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) notFound();
+
+  const [enriched, allMembers] = await Promise.all([loadGroup(groupId), getAllMembers()]);
+
+  return (
+    <GroupDetailContent
+      group={{
+        id: enriched.id,
+        name: enriched.name,
+        description: enriched.description,
+        ownerid: enriched.ownerid,
+        members: enriched.members.map((m) => ({
+          memberId: m.memberId,
+          ownername: m.ownername,
+          owneremail: m.owneremail,
+        })),
+      }}
+      allMembers={allMembers}
+      currentUserOwnerid={session.ownerid}
+      isAdmin={session.isAdmin}
+    />
+  );
+}

--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { EntityCard } from "@/components/groups/entity-card";
-import { GroupDetailViewModal } from "@/components/groups/group-detail-view-modal";
 import { GroupEditModal } from "@/components/groups/group-edit-modal";
 import { CreateGroupModal } from "@/components/groups/create-group-modal";
 import { DeleteGroupModal } from "@/components/groups/delete-group-modal";
@@ -19,14 +19,13 @@ interface GroupsContentProps {
 }
 
 export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsContentProps) {
+  const router = useRouter();
   const {
     modal,
     isPending,
     loadingGroupId,
     openCreateModal,
     closeModal,
-    handleCardClick,
-    handleEdit,
     handleQuickEdit,
     handleQuickDelete,
     handleSave,
@@ -56,7 +55,7 @@ export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsConte
                 variant="group"
                 name={group.name}
                 memberCount={group.memberCount}
-                onViewGroup={() => handleCardClick(group.id)}
+                onViewGroup={() => router.push(`/groups/${group.id}`)}
                 onQuickEdit={() => handleQuickEdit(group.id)}
                 onDelete={() => handleQuickDelete(group.id)}
               />
@@ -70,15 +69,6 @@ export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsConte
           {!isSearchActive ? <EntityCard variant="add" onClick={openCreateModal} /> : null}
         </div>
       )}
-
-      <GroupDetailViewModal
-        open={modal.type === "detail"}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-        group={modal.type === "detail" ? modal.group : EMPTY_GROUP}
-        onEdit={handleEdit}
-      />
 
       <GroupEditModal
         key={modal.type === "edit" ? modal.group.id : "closed"}

--- a/src/components/groups/group-member-table.tsx
+++ b/src/components/groups/group-member-table.tsx
@@ -1,6 +1,7 @@
-import { Lock, UserMinus } from "lucide-react";
+import { Lock, Undo2, UserMinus } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 import { getAvatarColor, getInitials } from "@/utils/avatar";
 
 interface GroupMemberTableProps {
@@ -11,10 +12,12 @@ interface GroupMemberTableProps {
     photoUrl?: string | null;
   }>;
   mode: "view" | "edit";
+  removedIds?: Set<number>;
   onRemove?: (memberId: number) => void;
+  onRestore?: (memberId: number) => void;
 }
 
-export function GroupMemberTable({ members, mode, onRemove }: GroupMemberTableProps) {
+export function GroupMemberTable({ members, mode, removedIds, onRemove, onRestore }: GroupMemberTableProps) {
   return (
     <Table>
       <TableHeader>
@@ -28,41 +31,54 @@ export function GroupMemberTable({ members, mode, onRemove }: GroupMemberTablePr
         </TableRow>
       </TableHeader>
       <TableBody>
-        {members.map((member) => (
-          <TableRow key={member.memberId}>
-            <TableCell>
-              <div className="flex items-center gap-3">
-                <Avatar className="h-9 w-9">
-                  {member.photoUrl && <AvatarImage src={member.photoUrl} alt={member.ownername} />}
-                  <AvatarFallback
-                    style={{ backgroundColor: getAvatarColor(member.ownername) }}
-                    className="text-xs font-semibold text-white"
+        {members.map((member) => {
+          const isRemoved = removedIds?.has(member.memberId) ?? false;
+          return (
+            <TableRow key={member.memberId} className={cn(isRemoved && "opacity-40")}>
+              <TableCell>
+                <div className="flex items-center gap-3">
+                  <Avatar className="h-9 w-9">
+                    {member.photoUrl && <AvatarImage src={member.photoUrl} alt={member.ownername} />}
+                    <AvatarFallback
+                      style={{ backgroundColor: getAvatarColor(member.ownername) }}
+                      className="text-xs font-semibold text-white"
+                    >
+                      {getInitials(member.ownername)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className={cn("text-sm", isRemoved && "line-through")}>{member.ownername}</span>
+                </div>
+              </TableCell>
+              <TableCell className={cn("text-sm", isRemoved && "line-through")}>{member.owneremail}</TableCell>
+              <TableCell className="text-sm">Member</TableCell>
+              <TableCell>
+                {mode === "view" ? (
+                  <Lock className="h-4 w-4 text-muted-foreground" />
+                ) : isRemoved ? (
+                  <button
+                    type="button"
+                    onClick={() => onRestore?.(member.memberId)}
+                    aria-label={`Restore ${member.ownername}`}
+                    className="flex items-center gap-2 text-sm font-semibold text-prfc-brown hover:text-prfc-brown/80"
                   >
-                    {getInitials(member.ownername)}
-                  </AvatarFallback>
-                </Avatar>
-                <span className="text-sm">{member.ownername}</span>
-              </div>
-            </TableCell>
-            <TableCell className="text-sm">{member.owneremail}</TableCell>
-            <TableCell className="text-sm">Member</TableCell>
-            <TableCell>
-              {mode === "view" ? (
-                <Lock className="h-4 w-4 text-muted-foreground" />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => onRemove?.(member.memberId)}
-                  aria-label={`Remove ${member.ownername}`}
-                  className="flex items-center gap-2 text-sm font-semibold text-prfc-red hover:text-prfc-red/80"
-                >
-                  <UserMinus className="h-4 w-4" />
-                  Remove
-                </button>
-              )}
-            </TableCell>
-          </TableRow>
-        ))}
+                    <Undo2 className="h-4 w-4" />
+                    Restore
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onRemove?.(member.memberId)}
+                    aria-label={`Remove ${member.ownername}`}
+                    className="flex items-center gap-2 text-sm font-semibold text-prfc-red hover:text-prfc-red/80"
+                  >
+                    <UserMinus className="h-4 w-4" />
+                    Remove
+                  </button>
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
       </TableBody>
     </Table>
   );


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #123

## What changed?

I built the group detail page at `/groups/[id]` that replaces the old detail modal. The page shows group name, description, and a member table with two modes. View mode has lock icons and an Edit button. Edit mode shows Remove buttons with inline undo (dimmed rows + Restore), a sticky Save bar at the bottom, and an Add Member button that opens the existing modal. The groups list page now navigates to this page instead of opening the detail modal.

- `src/app/(protected)/groups/[id]/page.tsx` - server component that fetches enriched group data and all members, handles NOT_FOUND via helper function pattern
- `src/app/(protected)/groups/[id]/group-detail-content.tsx` - client component with view/edit mode toggle, fuzzy search, deferred batch removal with undo, fixed bottom Save bar, Add Members modal integration
- `src/app/(protected)/groups/groups-content.tsx` - "View Group" now navigates to `/groups/[id]` instead of opening detail modal, removed GroupDetailViewModal
- `src/components/groups/group-member-table.tsx` - added removedIds prop for dimmed rows with strikethrough, Restore button with undo icon

## How to test

1. Visit `/groups`, click "View Group" on any card
2. Verify page shows group name in Angkor, description, search bar, member table
3. Search filters members by name and email
4. Click "Edit" to enter edit mode
5. Click "Remove" on a member - row dims with strikethrough, shows "Restore"
6. Click "Restore" - row returns to normal
7. Click "Save" - removed members are persisted, returns to view mode
8. Click "Add Member" in edit mode - modal opens
9. "Go Back" returns to /groups
10. Invalid URLs (/groups/abc, /groups/0) show 404

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers