### PR TITLE
feat: update groups list page to match hi-fi design

### DIFF
--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -1,11 +1,15 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Plus, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { EntityCard } from "@/components/groups/entity-card";
 import { GroupEditModal } from "@/components/groups/group-edit-modal";
 import { CreateGroupModal } from "@/components/groups/create-group-modal";
 import { DeleteGroupModal } from "@/components/groups/delete-group-modal";
-import { useSetTopBarAction } from "@/components/layout/top-bar-action-context";
 import { useGroupsModal, EMPTY_GROUP } from "@/components/groups/use-groups-modal";
 import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
 import type { GroupWithCount } from "@/services/contact-group";
@@ -18,8 +22,10 @@ interface GroupsContentProps {
   members: MemberSummary[];
 }
 
-export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsContentProps) {
+export function GroupsContent({ groups, ownerId, members }: GroupsContentProps) {
   const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState("all");
   const {
     modal,
     isPending,
@@ -34,41 +40,75 @@ export function GroupsContent({ groups, isAdmin, ownerId, members }: GroupsConte
     handleDeleteCancel,
   } = useGroupsModal(ownerId);
 
-  useSetTopBarAction("New Group", openCreateModal);
+  const filteredGroups = useFuzzySearch(groups, { keys: ["name", "description"] }, searchQuery);
 
-  const filteredGroups = useFuzzySearch(groups, {
-    keys: ["name", "description"],
+  const sortedGroups = [...filteredGroups].sort((a, b) => {
+    if (sortBy === "name") return a.name.localeCompare(b.name);
+    if (sortBy === "members") return b.memberCount - a.memberCount;
+    if (sortBy === "date") return b.createdAt.getTime() - a.createdAt.getTime();
+    return 0;
   });
-  const isSearchActive = filteredGroups.length !== groups.length;
 
   return (
     <div>
-      <h1 className="font-angkor text-2xl text-prfc-brown mb-6">{isAdmin ? "Groups" : "My Groups"}</h1>
+      <h1 className="font-angkor text-3xl text-prfc-brown">Groups</h1>
 
-      {filteredGroups.length === 0 && groups.length > 0 ? (
-        <p className="text-muted-foreground">No groups match your search.</p>
-      ) : (
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-          {filteredGroups.map((group) => (
-            <div key={group.id} className="relative">
-              <EntityCard
-                variant="group"
-                name={group.name}
-                memberCount={group.memberCount}
-                onViewGroup={() => router.push(`/groups/${group.id}`)}
-                onQuickEdit={() => handleQuickEdit(group.id)}
-                onDelete={() => handleQuickDelete(group.id)}
-              />
-              {loadingGroupId === group.id ? (
-                <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-white/60">
-                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-prfc-brown border-t-transparent" />
-                </div>
-              ) : null}
-            </div>
-          ))}
-          {!isSearchActive ? <EntityCard variant="add" onClick={openCreateModal} /> : null}
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search"
+            className="pl-9"
+            aria-label="Search groups"
+          />
         </div>
-      )}
+        <Select value={sortBy} onValueChange={setSortBy}>
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="Filter" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="date">Date</SelectItem>
+            <SelectItem value="name">Name</SelectItem>
+            <SelectItem value="members">Members</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button onClick={openCreateModal} className="ml-auto bg-prfc-red text-white hover:bg-prfc-red/90">
+          <Plus className="mr-2 h-4 w-4" />
+          Create Group
+        </Button>
+      </div>
+
+      <div className="mt-6">
+        {groups.length === 0 ? (
+          <p className="py-20 text-center text-muted-foreground">No groups have been created yet.</p>
+        ) : sortedGroups.length === 0 ? (
+          <p className="text-muted-foreground">No groups match your search.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+            {sortedGroups.map((group) => (
+              <div key={group.id} className="relative">
+                <EntityCard
+                  variant="group"
+                  name={group.name}
+                  memberCount={group.memberCount}
+                  createdAt={group.createdAt}
+                  onViewGroup={() => router.push(`/groups/${group.id}`)}
+                  onQuickEdit={() => handleQuickEdit(group.id)}
+                  onDelete={() => handleQuickDelete(group.id)}
+                />
+                {loadingGroupId === group.id ? (
+                  <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-white/60">
+                    <div className="h-6 w-6 animate-spin rounded-full border-2 border-prfc-brown border-t-transparent" />
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       <GroupEditModal
         key={modal.type === "edit" ? modal.group.id : "closed"}

--- a/src/components/groups/create-group-modal.tsx
+++ b/src/components/groups/create-group-modal.tsx
@@ -165,7 +165,7 @@ export function CreateGroupModal({
                 </div>
                 <div
                   id="member-list"
-                  className="mt-2 max-h-[min(280px,40vh)] overflow-y-auto pr-1"
+                  className="mt-2 max-h-[min(280px,40vh)] overflow-y-auto pr-3"
                   style={{ scrollbarGutter: "stable" }}
                 >
                   {filteredMembers.length === 0 ? (

--- a/src/components/groups/entity-card.tsx
+++ b/src/components/groups/entity-card.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, Plus, Users, UsersRound, MoreVertical } from "lucide-react";
+import { coopFormatTimed } from "@/utils/time";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +13,7 @@ interface EntityCardProps {
   variant?: "group" | "add";
   name?: string;
   memberCount?: number;
+  createdAt?: Date;
   onClick?: () => void;
   onViewGroup?: () => void;
   onQuickEdit?: () => void;
@@ -22,6 +24,7 @@ export function EntityCard({
   variant = "group",
   name = "",
   memberCount = 0,
+  createdAt,
   onClick,
   onViewGroup,
   onQuickEdit,
@@ -35,20 +38,20 @@ export function EntityCard({
       <Users className="h-32 w-32 text-prfc-brown" />
     </div>
   ) : (
-    <div>
-      <div className="flex flex-col gap-2 p-6">
-        <div className="self-end">
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col p-6">
+        <div className="flex items-start justify-between gap-2">
+          <div className="font-bold text-xl line-clamp-2">{name}</div>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="outline"
-                className="p-0 h-6 w-6 rounded-full hover:bg-prfc-border border-transparent bg-transparent drop-shadow-none shadow-none"
+                className="shrink-0 p-0 h-6 w-6 rounded-full hover:bg-prfc-border border-transparent bg-transparent drop-shadow-none shadow-none"
                 onClick={(e) => e.stopPropagation()}
               >
                 <MoreVertical />
               </Button>
             </DropdownMenuTrigger>
-
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 onClick={(e) => {
@@ -69,11 +72,15 @@ export function EntityCard({
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        <div className="font-bold text-xl">{name}</div>
-        <div className="inline-flex items-center gap-2 bg-transparent text-prfc-border rounded-full text-md">
+        <div className="mt-2 inline-flex items-center gap-2 text-prfc-border text-md">
           <UsersRound className="h-5 w-5" />
           {memberCount} {memberCount === 1 ? "member" : "members"}
         </div>
+        {createdAt && (
+          <p className="mt-auto pt-3 text-xs text-muted-foreground">
+            Created {coopFormatTimed(createdAt, "MMM d, yyyy")}
+          </p>
+        )}
       </div>
       <hr className="bg-zinc-300 h-0.5" />
       <div className="flex flex-col gap-4 px-6 py-2">
@@ -96,7 +103,7 @@ export function EntityCard({
       {...(isClickable ? { type: "button" as const, onClick } : {})}
       aria-label={isAdd ? "Add new group" : undefined}
       className={cn(
-        "relative w-full rounded-2xl border bg-white text-left shadow-sm p-0 min-h-[160px]",
+        "relative h-full w-full rounded-2xl border bg-white text-left shadow-sm p-0 min-h-[160px]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isClickable && "cursor-pointer hover:shadow-md",
       )}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #124

## What changed?

I updated the groups list page to match the hi-fi design. Search and filter moved from the top bar to the page itself. The "+ Create Group" red button replaces the top bar action and the add card. Cards now show a created date and have the title on the same row as the kebab menu.

- `src/app/(protected)/groups/groups-content.tsx` - added page-level search input, sort dropdown (All/Date/Name/Members), red Create Group button, removed useSetTopBarAction and add card, added empty state
- `src/components/groups/entity-card.tsx` - title and kebab on same row, line-clamp-2 on name, created date with mt-auto spacing, h-full for grid height matching
- `src/components/groups/create-group-modal.tsx` - increased scrollbar padding from pr-1 to pr-3

## How to test

1. Visit `/groups`
2. Verify "Groups" heading, search input, filter dropdown, red "+ Create Group" button
3. Search filters cards by name
4. Sort by Date, Name, or Members
5. Cards show title + kebab on same row, member count, created date
6. Long names truncate after 2 lines, cards in a row match height
7. "View Group" navigates to `/groups/[id]`
8. Kebab Quick Edit and Delete still work
9. Create Group opens the modal

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers