### PR TITLE
feat: add message history page with responsive layout

### DIFF
--- a/src/app/(protected)/messages/messages-content.tsx
+++ b/src/app/(protected)/messages/messages-content.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { Plus, Search } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { MessageHistoryTable } from "@/components/messages/message-history-table";
+import { ViewMessageModal } from "@/components/messages/view-message-modal";
+import { fetchMessageDetail } from "@/actions/contact-group";
+import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import { cn } from "@/lib/utils";
+import type { MessageHistoryItem } from "@/types/message";
+import type { MessageDetail, RecipientStatus } from "@/types/message";
+
+type Props = {
+  initialMessages: MessageHistoryItem[];
+  isAdmin: boolean;
+};
+
+export function MessagesContent({ initialMessages }: Props) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [channelFilter, setChannelFilter] = useState("all");
+  const [sortOrder, setSortOrder] = useState("recent");
+  const [viewModal, setViewModal] = useState<{ message: MessageDetail; recipients: RecipientStatus[] } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const channelFiltered = useMemo(() => {
+    if (channelFilter === "all") return initialMessages;
+    if (channelFilter === "email") return initialMessages.filter((m) => m.emailCount > 0);
+    return initialMessages.filter((m) => m.smsCount > 0);
+  }, [initialMessages, channelFilter]);
+
+  const searched = useFuzzySearch(channelFiltered, { keys: ["subject"] }, searchQuery);
+
+  const sorted = useMemo(() => {
+    const copy = [...searched];
+    if (sortOrder === "oldest") copy.sort((a, b) => a.sentAt.getTime() - b.sentAt.getTime());
+    else copy.sort((a, b) => b.sentAt.getTime() - a.sentAt.getTime());
+    return copy;
+  }, [searched, sortOrder]);
+
+  const handleView = (messageId: number) => {
+    startTransition(async () => {
+      const result = await fetchMessageDetail(messageId);
+      if (result.success && result.data) {
+        setViewModal({ message: result.data.message, recipients: result.data.recipients });
+      } else {
+        toast.error(result.error ?? "Failed to load message details");
+      }
+    });
+  };
+
+  return (
+    <div>
+      <h1 className="font-angkor text-3xl text-prfc-brown">Message History</h1>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search"
+            className="pl-9"
+            aria-label="Search messages"
+          />
+        </div>
+        <Select value={channelFilter} onValueChange={setChannelFilter}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Message Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="email">Email</SelectItem>
+            <SelectItem value="sms">SMS</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={sortOrder} onValueChange={setSortOrder}>
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="Date" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recent">Recent</SelectItem>
+            <SelectItem value="oldest">Oldest</SelectItem>
+          </SelectContent>
+        </Select>
+        <Link href="/messages/compose" className="ml-auto">
+          <Button className="bg-prfc-red text-white hover:bg-prfc-red/90">
+            <Plus className="mr-2 h-4 w-4" />
+            New Message
+          </Button>
+        </Link>
+      </div>
+
+      <div className={cn("mt-6 transition-opacity", isPending && "pointer-events-none opacity-60")}>
+        <MessageHistoryTable messages={sorted} onView={handleView} />
+      </div>
+
+      {viewModal && (
+        <ViewMessageModal
+          open={!!viewModal}
+          onOpenChange={(open) => {
+            if (!open) setViewModal(null);
+          }}
+          message={{
+            id: viewModal.message.id,
+            subject: viewModal.message.subject,
+            body: viewModal.message.body,
+            sentAt: viewModal.message.sentAt,
+            groupName: viewModal.message.groupName,
+            isBlast: viewModal.message.isBlast,
+          }}
+          recipients={viewModal.recipients.map((r) => ({
+            memberId: r.memberId,
+            memberName: r.memberName,
+            status: r.status === "sent" ? "sent" : r.status === "failed" ? "failed" : "pending",
+          }))}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/messages/page.tsx
+++ b/src/app/(protected)/messages/page.tsx
@@ -1,17 +1,16 @@
 import type { Metadata } from "next";
-import { MessageSquareMore } from "lucide-react";
-import { ComingSoonPage } from "@/components/layout/coming-soon-page";
+import { verifySession } from "@/lib/dal";
+import { getAllMessageHistory } from "@/services/message";
+import { MessagesContent } from "./messages-content";
 
 export const metadata: Metadata = {
   title: "Messages | PRFC Connect",
 };
 
-export default function MessagesPage() {
-  return (
-    <ComingSoonPage
-      icon={MessageSquareMore}
-      title="Messages"
-      description="Coming soon. You'll be able to send messages to your groups here."
-    />
-  );
+export default async function MessagesPage() {
+  const session = await verifySession();
+  const senderId = session.isAdmin ? undefined : session.ownerid;
+  const messages = await getAllMessageHistory({ senderId });
+
+  return <MessagesContent initialMessages={messages} isAdmin={session.isAdmin} />;
 }

--- a/src/components/messages/message-history-table.tsx
+++ b/src/components/messages/message-history-table.tsx
@@ -1,10 +1,11 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { coopFormatTimed } from "@/utils/time";
+import { coopDateParts, coopFormatTimed } from "@/utils/time";
 
 interface MessageHistoryTableProps {
   messages: Array<{
     id: number;
     subject: string;
+    body?: string;
     sentAt: Date;
     groupName: string | null;
     isBlast: boolean;
@@ -12,48 +13,85 @@ interface MessageHistoryTableProps {
   onView: (messageId: number) => void;
 }
 
-function formatDeliveredAt(date: Date): string {
-  return coopFormatTimed(date, "M/d/yyyy h:mm:ss a zzz");
+function formatSmartTimestamp(date: Date): string {
+  const now = new Date();
+  const nowParts = coopDateParts(now);
+  const dateParts = coopDateParts(date);
+
+  if (nowParts.year === dateParts.year && nowParts.month0 === dateParts.month0 && nowParts.day === dateParts.day) {
+    return coopFormatTimed(date, "h:mm a");
+  }
+  if (nowParts.year === dateParts.year) {
+    return coopFormatTimed(date, "MMM d");
+  }
+  return coopFormatTimed(date, "MMM d, yyyy");
+}
+
+function RecipientLabel({ message }: { message: { isBlast: boolean; groupName: string | null } }) {
+  return <>{message.isBlast ? "All Members" : (message.groupName ?? "Unknown")}</>;
+}
+
+function MessagePreview({ message }: { message: { subject: string; body?: string } }) {
+  return (
+    <>
+      <span className="font-medium">{message.subject}</span>
+      {message.body && <span className="text-muted-foreground"> - {message.body}</span>}
+    </>
+  );
 }
 
 export function MessageHistoryTable({ messages, onView }: MessageHistoryTableProps) {
+  if (messages.length === 0) {
+    return <p className="py-8 text-center text-muted-foreground">No messages yet.</p>;
+  }
+
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="font-bold text-foreground">Message Preview</TableHead>
-          <TableHead className="font-bold text-foreground">Delivered at</TableHead>
-          <TableHead className="w-[80px]">
-            <span className="sr-only">Actions</span>
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {messages.length === 0 ? (
+    <>
+      <Table className="hidden sm:table">
+        <TableHeader>
           <TableRow>
-            <TableCell colSpan={3} className="py-8 text-center text-muted-foreground">
-              No messages yet.
-            </TableCell>
+            <TableHead className="font-bold text-foreground">To</TableHead>
+            <TableHead className="w-full font-bold text-foreground">Message</TableHead>
+            <TableHead className="font-bold text-foreground">Delivered</TableHead>
           </TableRow>
-        ) : (
-          messages.map((message) => (
-            <TableRow key={message.id}>
-              <TableCell className="max-w-[300px] truncate text-sm">{message.subject}</TableCell>
-              <TableCell className="text-sm">{formatDeliveredAt(message.sentAt)}</TableCell>
-              <TableCell>
-                <button
-                  type="button"
-                  onClick={() => onView(message.id)}
-                  aria-label={`View message: ${message.subject}`}
-                  className="text-sm underline hover:text-prfc-brown"
-                >
-                  View
-                </button>
+        </TableHeader>
+        <TableBody>
+          {messages.map((message) => (
+            <TableRow key={message.id} onClick={() => onView(message.id)} className="cursor-pointer hover:bg-muted/50">
+              <TableCell className="whitespace-nowrap text-sm">
+                <RecipientLabel message={message} />
+              </TableCell>
+              <TableCell className="truncate text-sm">
+                <MessagePreview message={message} />
+              </TableCell>
+              <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                {formatSmartTimestamp(message.sentAt)}
               </TableCell>
             </TableRow>
-          ))
-        )}
-      </TableBody>
-    </Table>
+          ))}
+        </TableBody>
+      </Table>
+
+      <div className="divide-y sm:hidden">
+        {messages.map((message) => (
+          <button
+            key={message.id}
+            type="button"
+            onClick={() => onView(message.id)}
+            className="w-full px-3 py-3 text-left hover:bg-muted/50"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-medium">
+                <RecipientLabel message={message} />
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground">{formatSmartTimestamp(message.sentAt)}</span>
+            </div>
+            <p className="mt-1 truncate text-sm">
+              <MessagePreview message={message} />
+            </p>
+          </button>
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -341,6 +341,7 @@ export async function getAllMessageHistory(options: {
       select: {
         id: true,
         subject: true,
+        body: true,
         sentAt: true,
         emailCount: true,
         smsCount: true,
@@ -356,6 +357,7 @@ export async function getAllMessageHistory(options: {
     return messages.map((m) => ({
       id: m.id,
       subject: m.subject,
+      body: m.body,
       sentAt: m.sentAt,
       emailCount: m.emailCount,
       smsCount: m.smsCount,

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -19,6 +19,7 @@ export interface MessageSummary {
 export interface MessageHistoryItem {
   id: number;
   subject: string;
+  body: string;
   sentAt: Date;
   emailCount: number;
   smsCount: number;

--- a/test/actions/message-query.test.ts
+++ b/test/actions/message-query.test.ts
@@ -39,6 +39,7 @@ describe("fetchMessageHistory", () => {
       {
         id: 1,
         subject: "Test",
+        body: "Test body content",
         sentAt: new Date(),
         emailCount: 5,
         smsCount: 0,


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #134

## What changed?

I replaced the messages placeholder with a message history page. The table uses Gmail-inspired patterns: recipient column, subject + body snippet with dash separator, smart relative timestamps (today = time, this year = month/day, older = full date). Clicking a row fetches message detail and opens the ViewMessageModal. At narrow viewports, the table switches to a stacked card layout with recipient + timestamp on the first line and message preview on the second.

- `src/app/(protected)/messages/page.tsx` - server component fetches message history including body
- `src/app/(protected)/messages/messages-content.tsx` - client component with search, channel filter (All/Email/SMS), date sort (Recent/Oldest), red New Message button linking to /messages/compose, loading opacity during detail fetch
- `src/components/messages/message-history-table.tsx` - responsive table with `hidden sm:table` desktop layout and `sm:hidden` stacked mobile layout, clickable rows, smart timestamps, truncated previews
- `src/types/message.ts` - added body field to MessageHistoryItem
- `src/services/message.ts` - added body to getAllMessageHistory select and return mapping
- `test/actions/message-query.test.ts` - added body to test fixture

## How to test

1. Visit `/messages`
2. Verify "Message History" heading, search, channel filter, date sort, New Message button
3. Click a row to open ViewMessageModal
4. Search filters by subject
5. Filter by Email/SMS
6. Sort Recent/Oldest
7. Resize to narrow viewport to see stacked layout

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers