### PR TITLE
refactor: migrate messaging from single-group to multi-group sends

### DIFF
--- a/prisma/migrations/20260427000000_multi_group_messaging/migration.sql
+++ b/prisma/migrations/20260427000000_multi_group_messaging/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE `message_group` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `message_id` INTEGER NOT NULL,
+    `group_id` INTEGER NOT NULL,
+
+    INDEX `message_group_message_id_idx`(`message_id`),
+    INDEX `message_group_group_id_idx`(`group_id`),
+    UNIQUE INDEX `message_group_message_id_group_id_key`(`message_id`, `group_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- MigrateData: copy existing group associations to join table
+INSERT INTO `message_group` (`message_id`, `group_id`)
+SELECT `id`, `group_id` FROM `message` WHERE `group_id` IS NOT NULL;
+
+-- DropForeignKey
+ALTER TABLE `message` DROP FOREIGN KEY `message_group_id_fkey`;
+
+-- DropIndex
+DROP INDEX `message_group_id_idx` ON `message`;
+DROP INDEX `message_group_id_sent_at_idx` ON `message`;
+
+-- AlterTable
+ALTER TABLE `message` DROP COLUMN `group_id`;
+
+-- AddForeignKey
+ALTER TABLE `message_group` ADD CONSTRAINT `message_group_message_id_fkey` FOREIGN KEY (`message_id`) REFERENCES `message`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `message_group` ADD CONSTRAINT `message_group_group_id_fkey` FOREIGN KEY (`group_id`) REFERENCES `contact_group`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,9 +31,9 @@ model ContactGroup {
   description String?  @db.VarChar(500)
   ownerid     Int
 
-  members  ContactGroupMember[]
-  messages Message[]
-  events   Event[]
+  members       ContactGroupMember[]
+  messageGroups MessageGroup[]
+  events        Event[]
 
   @@index([ownerid])
   @@map("contact_group")
@@ -97,7 +97,6 @@ model EmailSuppression {
 
 model Message {
   id          Int      @id @default(autoincrement())
-  groupId     Int?     @map("group_id")
   senderId    Int      @map("sender_id")
   subject     String   @db.VarChar(200)
   body        String   @db.Text
@@ -107,15 +106,27 @@ model Message {
   failedCount Int      @default(0) @map("failed_count")
   isBlast     Boolean  @default(false) @map("is_blast")
 
-  group      ContactGroup?      @relation(fields: [groupId], references: [id], onDelete: SetNull)
+  groups     MessageGroup[]
   recipients MessageRecipient[]
 
-  @@index([groupId])
   @@index([senderId])
   @@index([sentAt])
-  @@index([groupId, sentAt])
   @@index([isBlast, sentAt])
   @@map("message")
+}
+
+model MessageGroup {
+  id        Int @id @default(autoincrement())
+  messageId Int @map("message_id")
+  groupId   Int @map("group_id")
+
+  message Message      @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  group   ContactGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  @@unique([messageId, groupId])
+  @@index([messageId])
+  @@index([groupId])
+  @@map("message_group")
 }
 
 model MessageRecipient {

--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -229,7 +229,7 @@ export async function updateNotifications(input: {
 }
 
 export async function sendMessage(input: {
-  groupId: number;
+  groupIds: number[];
   subject: string;
   body: string;
   sendEmail?: boolean;
@@ -238,8 +238,11 @@ export async function sendMessage(input: {
   try {
     const session = await verifySession();
 
-    if (!session.isAdmin && !(await isGroupOwner(input.groupId, session.ownerid))) {
-      return { success: false, error: "You do not have permission to send messages to this group" };
+    if (!session.isAdmin) {
+      const ownerChecks = await Promise.all(input.groupIds.map((gid) => isGroupOwner(gid, session.ownerid)));
+      if (ownerChecks.some((isOwner) => !isOwner)) {
+        return { success: false, error: "You do not have permission to send messages to one or more selected groups" };
+      }
     }
 
     const validated = ComposeMessageSchema.parse(input);

--- a/src/app/(protected)/messages/compose/compose-content.tsx
+++ b/src/app/(protected)/messages/compose/compose-content.tsx
@@ -22,7 +22,7 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
   const [isPending, startTransition] = useTransition();
 
   const handleSend = (data: {
-    groupId: number | null;
+    groupIds: number[];
     isBlast: boolean;
     subject: string;
     body: string;
@@ -52,12 +52,12 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
           toast.error(result.error ?? "Failed to send message");
         }
       } else {
-        if (!data.groupId) {
-          toast.error("Please select a group");
+        if (data.groupIds.length === 0) {
+          toast.error("Please select at least one group");
           return;
         }
         const result = await sendMessage({
-          groupId: data.groupId,
+          groupIds: data.groupIds,
           subject: data.subject,
           body: data.body,
           sendEmail: data.sendEmail,

--- a/src/app/(protected)/messages/messages-content.tsx
+++ b/src/app/(protected)/messages/messages-content.tsx
@@ -110,7 +110,7 @@ export function MessagesContent({ initialMessages }: Props) {
             subject: viewModal.message.subject,
             body: viewModal.message.body,
             sentAt: viewModal.message.sentAt,
-            groupName: viewModal.message.groupName,
+            groupNames: viewModal.message.groupNames,
             isBlast: viewModal.message.isBlast,
           }}
           recipients={viewModal.recipients.map((r) => ({

--- a/src/app/team/kakani/page.tsx
+++ b/src/app/team/kakani/page.tsx
@@ -21,7 +21,7 @@ const mockMessage = {
   subject: "Garden Party Reminder",
   body: "Garden party at 4pm. Be there or be square.",
   sentAt: new Date("2024-01-06T19:57:01Z"),
-  groupName: "Garden Club",
+  groupNames: ["Garden Club"],
   isBlast: false,
 };
 
@@ -41,7 +41,7 @@ const mockBlastMessage = {
   subject: "All Hands Update",
   body: "Monthly meeting this Friday at noon. Attendance is mandatory.",
   sentAt: new Date("2024-01-06T19:57:01Z"),
-  groupName: null,
+  groupNames: [],
   isBlast: true,
 };
 

--- a/src/components/dashboard/recent-messages-card.tsx
+++ b/src/components/dashboard/recent-messages-card.tsx
@@ -6,7 +6,7 @@ interface RecentMessagesCardProps {
   messages: Array<{
     id: number;
     subject: string;
-    groupName: string | null;
+    groupNames: string[];
     isBlast: boolean;
     sentAt: Date;
   }>;
@@ -29,7 +29,12 @@ export function RecentMessagesCard({ messages }: RecentMessagesCardProps) {
                 <div className="mt-0.5 h-8 w-[3px] shrink-0 rounded-full bg-green-600" />
                 <div>
                   <p className="text-sm font-semibold">
-                    To: {message.isBlast ? "All Members" : (message.groupName ?? "Unknown Group")}
+                    To:{" "}
+                    {message.isBlast
+                      ? "All Members"
+                      : message.groupNames.length > 0
+                        ? message.groupNames.join(", ")
+                        : "Unknown Group"}
                   </p>
                   <p className="text-sm italic text-muted-foreground">&ldquo;{message.subject}&rdquo;</p>
                 </div>

--- a/src/components/messages/compose-message-form.tsx
+++ b/src/components/messages/compose-message-form.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { AlertCircle, Loader2, Mail, MessageCircle } from "lucide-react";
+import { AlertCircle, Check, ChevronDown, Loader2, Mail, MessageCircle } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import { getAvatarColor, getInitials } from "@/utils/avatar";
 
 const SMS_CHAR_LIMIT = 160;
@@ -17,7 +18,7 @@ interface ComposeMessageFormProps {
   currentUser: { name: string; photoUrl?: string | null };
   smsConsent?: { eligible: number; total: number };
   onSend: (data: {
-    groupId: number | null;
+    groupIds: number[];
     isBlast: boolean;
     subject: string;
     body: string;
@@ -35,7 +36,9 @@ export function ComposeMessageForm({
   onSend,
   isSending = false,
 }: ComposeMessageFormProps) {
-  const [groupId, setGroupId] = useState<string>("");
+  const [isBlast, setIsBlast] = useState(false);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<number>>(new Set());
+  const [groupPickerOpen, setGroupPickerOpen] = useState(false);
   const [sendSms, setSendSms] = useState(false);
   const [sendEmail, setSendEmail] = useState(false);
   const [smsBody, setSmsBody] = useState("");
@@ -43,15 +46,35 @@ export function ComposeMessageForm({
   const [emailBody, setEmailBody] = useState("");
   const [error, setError] = useState("");
 
-  const isBlast = groupId === "all";
-  const selectedGroupId = isBlast ? null : groupId ? Number(groupId) : null;
+  const toggleGroup = (id: number) => {
+    setSelectedGroupIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    setIsBlast(false);
+  };
+
+  const handleBlastToggle = () => {
+    setIsBlast(true);
+    setSelectedGroupIds(new Set());
+  };
+
+  const recipientLabel = isBlast
+    ? "All Members"
+    : selectedGroupIds.size === 0
+      ? "Select Groups"
+      : selectedGroupIds.size === 1
+        ? (groups.find((g) => selectedGroupIds.has(g.id))?.name ?? "1 group")
+        : `${selectedGroupIds.size} groups`;
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
 
-    if (!groupId) {
-      setError("Please select a recipient group.");
+    if (!isBlast && selectedGroupIds.size === 0) {
+      setError("Please select at least one recipient group.");
       return;
     }
     if (!sendSms && !sendEmail) {
@@ -76,7 +99,7 @@ export function ComposeMessageForm({
     }
 
     onSend({
-      groupId: selectedGroupId,
+      groupIds: Array.from(selectedGroupIds),
       isBlast,
       subject: emailSubject.trim() || smsBody.trim().slice(0, 200),
       body: emailBody.trim() || smsBody.trim(),
@@ -92,21 +115,43 @@ export function ComposeMessageForm({
 
       <div>
         <p className="mb-2 text-sm font-semibold">To:</p>
-        <div className="flex gap-3">
-          <Select value={groupId} onValueChange={setGroupId}>
-            <SelectTrigger className="w-48">
-              <SelectValue placeholder="Select Groups" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All</SelectItem>
-              {groups.map((g) => (
-                <SelectItem key={g.id} value={String(g.id)}>
-                  {g.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+        <Popover open={groupPickerOpen} onOpenChange={setGroupPickerOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="outline" role="combobox" aria-expanded={groupPickerOpen} className="w-64 justify-between">
+              {recipientLabel}
+              <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-64 p-0">
+            <Command>
+              <CommandInput placeholder="Search groups..." />
+              <CommandList>
+                <CommandEmpty>No groups found.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="all-members-blast"
+                    onSelect={handleBlastToggle}
+                    className="flex items-center gap-2"
+                  >
+                    <Check className={cn("h-4 w-4", isBlast ? "opacity-100" : "opacity-0")} />
+                    All Members
+                  </CommandItem>
+                  {groups.map((g) => (
+                    <CommandItem
+                      key={g.id}
+                      value={g.name}
+                      onSelect={() => toggleGroup(g.id)}
+                      className="flex items-center gap-2"
+                    >
+                      <Check className={cn("h-4 w-4", selectedGroupIds.has(g.id) ? "opacity-100" : "opacity-0")} />
+                      {g.name}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       </div>
 
       <div>
@@ -162,15 +207,16 @@ export function ComposeMessageForm({
       {sendEmail && (
         <div>
           <p className="mb-2 text-sm font-semibold">Compose Email</p>
-          <div className="rounded-lg border border-prfc-border/30 p-4 space-y-3">
+          <div className="space-y-3 rounded-lg border border-prfc-border/30 p-4">
             <div>
               <p className="text-sm font-semibold">Subject Line</p>
-              <Input
+              <input
+                type="text"
                 value={emailSubject}
                 onChange={(e) => setEmailSubject(e.target.value)}
                 placeholder="Subject"
                 maxLength={200}
-                className="mt-1 border-none p-0 shadow-none focus-visible:ring-0"
+                className="mt-1 w-full border-none bg-transparent p-0 text-sm outline-none placeholder:text-muted-foreground"
               />
             </div>
             <hr className="border-prfc-border/30" />

--- a/src/components/messages/message-history-table.tsx
+++ b/src/components/messages/message-history-table.tsx
@@ -7,7 +7,7 @@ interface MessageHistoryTableProps {
     subject: string;
     body?: string;
     sentAt: Date;
-    groupName: string | null;
+    groupNames: string[];
     isBlast: boolean;
   }>;
   onView: (messageId: number) => void;
@@ -27,8 +27,15 @@ function formatSmartTimestamp(date: Date): string {
   return coopFormatTimed(date, "MMM d, yyyy");
 }
 
-function RecipientLabel({ message }: { message: { isBlast: boolean; groupName: string | null } }) {
-  return <>{message.isBlast ? "All Members" : (message.groupName ?? "Unknown")}</>;
+function RecipientLabel({ message }: { message: { isBlast: boolean; groupNames: string[] } }) {
+  if (message.isBlast) return <>All Members</>;
+  if (message.groupNames.length === 0) return <>Unknown</>;
+  if (message.groupNames.length <= 2) return <>{message.groupNames.join(", ")}</>;
+  return (
+    <>
+      {message.groupNames.slice(0, 2).join(", ")} +{message.groupNames.length - 2} more
+    </>
+  );
 }
 
 function MessagePreview({ message }: { message: { subject: string; body?: string } }) {

--- a/src/components/messages/view-message-modal.tsx
+++ b/src/components/messages/view-message-modal.tsx
@@ -23,7 +23,7 @@ export interface ViewMessageModalProps {
     subject: string;
     body: string;
     sentAt: Date;
-    groupName: string | null;
+    groupNames: string[];
     isBlast: boolean;
   };
   recipients: Array<{
@@ -48,7 +48,11 @@ export function ViewMessageModal({ open, onOpenChange, message, recipients }: Vi
     onOpenChange(next);
   };
 
-  const groupLabel = message.isBlast ? "All Members" : (message.groupName ?? "Unknown Group");
+  const groupLabel = message.isBlast
+    ? "All Members"
+    : message.groupNames.length > 0
+      ? message.groupNames.join(", ")
+      : "Unknown Group";
   const visibleAvatars = recipients.slice(0, MAX_VISIBLE_AVATARS);
   const overflowCount = recipients.length - MAX_VISIBLE_AVATARS;
 

--- a/src/schema/contact-group.ts
+++ b/src/schema/contact-group.ts
@@ -56,7 +56,7 @@ export const BaseMessageSchema = z
   });
 
 export const ComposeMessageSchema = BaseMessageSchema.extend({
-  groupId: z.number().int().positive(),
+  groupIds: z.array(z.number().int().positive()).min(1),
 });
 
 export const BlastMessageSchema = BaseMessageSchema.extend({

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -36,7 +36,7 @@ export async function getGroupMessageHistory(
     const effectiveLimit = Math.min(Math.max(1, limit), MAX_MESSAGE_HISTORY_LIMIT);
 
     const messages = await prisma.message.findMany({
-      where: { groupId },
+      where: { groups: { some: { groupId } } },
       select: {
         id: true,
         subject: true,
@@ -80,7 +80,7 @@ async function sendEmailsForMessage(
   recipients: MockMember[],
   subject: string,
   body: string,
-  groupId: number | null,
+  groupIds: number[] | null,
 ): Promise<{ sent: number; failed: number }> {
   try {
     const emailResult = await sendGroupEmails({
@@ -93,7 +93,7 @@ async function sendEmailsForMessage(
       body,
       senderName: "Paso Robles Food Co-op",
       replyTo: env.FROM_EMAIL ?? "",
-      groupId: groupId ?? 0,
+      groupId: groupIds?.[0] ?? 0,
     });
 
     if (emailResult.failed === 0) {
@@ -131,7 +131,7 @@ async function sendEmailsForMessage(
 
 export async function sendGroupMessage(input: ComposeMessage, senderId: number): Promise<MessageResult> {
   try {
-    const { groupId, subject, body, sendEmail, sendSms } = input;
+    const { groupIds, subject, body, sendEmail, sendSms } = input;
 
     if (!sendEmail && !sendSms) {
       throw new AppError("VALIDATION_ERROR", "At least one delivery method (email or SMS) must be selected");
@@ -145,9 +145,11 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
       validateSmsAllowed();
     }
 
-    const emailRecipientIds = sendEmail ? await getGroupRecipients(groupId, "email") : [];
-    const smsRecipientIds = sendSms ? await getGroupRecipients(groupId, "sms") : [];
+    const emailSets = sendEmail ? await Promise.all(groupIds.map((gid) => getGroupRecipients(gid, "email"))) : [];
+    const smsSets = sendSms ? await Promise.all(groupIds.map((gid) => getGroupRecipients(gid, "sms"))) : [];
 
+    const emailRecipientIds = Array.from(new Set(emailSets.flat()));
+    const smsRecipientIds = Array.from(new Set(smsSets.flat()));
     const allRecipientIds = Array.from(new Set([...emailRecipientIds, ...smsRecipientIds]));
 
     if (allRecipientIds.length === 0) {
@@ -159,7 +161,6 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
     const result = await prisma.$transaction(async (tx) => {
       const message = await tx.message.create({
         data: {
-          groupId,
           senderId,
           subject,
           body,
@@ -168,6 +169,10 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
           failedCount: 0,
           isBlast: false,
         },
+      });
+
+      await tx.messageGroup.createMany({
+        data: groupIds.map((groupId) => ({ messageId: message.id, groupId })),
       });
 
       if (sendEmail && emailRecipientIds.length > 0) {
@@ -200,7 +205,7 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
 
     if (sendEmail && emailRecipientIds.length > 0) {
       const emailRecipients = members.filter((m) => emailRecipientIds.includes(m.ownerid));
-      const emailResult = await sendEmailsForMessage(result.id, emailRecipients, subject, body, groupId);
+      const emailResult = await sendEmailsForMessage(result.id, emailRecipients, subject, body, groupIds);
       emailsSent = emailResult.sent;
       emailsFailed = emailResult.failed;
     }
@@ -255,7 +260,6 @@ export async function sendBlastMessage(input: BlastMessage, senderId: number): P
     const result = await prisma.$transaction(async (tx) => {
       const message = await tx.message.create({
         data: {
-          groupId: null,
           senderId,
           subject,
           body,
@@ -347,7 +351,7 @@ export async function getAllMessageHistory(options: {
         smsCount: true,
         failedCount: true,
         isBlast: true,
-        group: { select: { name: true } },
+        groups: { select: { group: { select: { name: true } } } },
       },
       orderBy: { sentAt: "desc" },
       take: effectiveLimit,
@@ -363,7 +367,7 @@ export async function getAllMessageHistory(options: {
       smsCount: m.smsCount,
       failedCount: m.failedCount,
       isBlast: m.isBlast,
-      groupName: m.group?.name ?? null,
+      groupNames: m.groups.map((mg) => mg.group.name),
     }));
   } catch (error) {
     throw transformError(error);
@@ -384,7 +388,7 @@ export async function getMessageById(messageId: number): Promise<MessageDetail> 
         smsCount: true,
         failedCount: true,
         isBlast: true,
-        group: { select: { name: true } },
+        groups: { select: { group: { select: { name: true } } } },
       },
     });
 
@@ -394,7 +398,7 @@ export async function getMessageById(messageId: number): Promise<MessageDetail> 
 
     return {
       ...message,
-      groupName: message.group?.name ?? null,
+      groupNames: message.groups.map((mg) => mg.group.name),
     };
   } catch (error) {
     throw transformError(error);

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -25,12 +25,12 @@ export interface MessageHistoryItem {
   smsCount: number;
   failedCount: number;
   isBlast: boolean;
-  groupName: string | null;
+  groupNames: string[];
 }
 
 export interface MessageDetail extends MessageSummary {
   isBlast: boolean;
-  groupName: string | null;
+  groupNames: string[];
 }
 
 export interface RecipientStatus {

--- a/test/actions/contact-group.test.ts
+++ b/test/actions/contact-group.test.ts
@@ -341,7 +341,7 @@ describe("sendMessage", () => {
     mockSendGroupMessage.mockResolvedValue(messageResult);
 
     const result = await sendMessage({
-      groupId: 3,
+      groupIds: [3],
       subject: "Hello",
       body: "Body text",
       sendEmail: true,
@@ -352,7 +352,7 @@ describe("sendMessage", () => {
     expect(result.data).toEqual(messageResult);
     expect(mockSendGroupMessage).toHaveBeenCalledWith(
       {
-        groupId: 3,
+        groupIds: [3],
         subject: "Hello",
         body: "Body text",
         sendEmail: true,
@@ -367,7 +367,7 @@ describe("sendMessage", () => {
     mockSendGroupMessage.mockResolvedValue(messageResult);
 
     const result = await sendMessage({
-      groupId: 3,
+      groupIds: [3],
       subject: "Admin",
       body: "Admin body",
       sendEmail: true,
@@ -383,7 +383,7 @@ describe("sendMessage", () => {
     mockIsGroupOwner.mockResolvedValue(false);
 
     const result = await sendMessage({
-      groupId: 3,
+      groupIds: [3],
       subject: "Nope",
       body: "Body text",
       sendEmail: true,
@@ -400,7 +400,7 @@ describe("sendMessage", () => {
     mockIsGroupOwner.mockResolvedValue(true);
 
     const result = await sendMessage({
-      groupId: 3,
+      groupIds: [3],
       subject: "",
       body: "Body text",
       sendEmail: true,
@@ -418,7 +418,7 @@ describe("sendMessage", () => {
     mockSendGroupMessage.mockRejectedValue(new AppError("MESSAGE_SEND_FAILED", "Email delivery failed"));
 
     const result = await sendMessage({
-      groupId: 3,
+      groupIds: [3],
       subject: "Hello",
       body: "Body text",
       sendEmail: true,

--- a/test/actions/message-query.test.ts
+++ b/test/actions/message-query.test.ts
@@ -45,7 +45,7 @@ describe("fetchMessageHistory", () => {
         smsCount: 0,
         failedCount: 0,
         isBlast: false,
-        groupName: "Garden Club",
+        groupNames: ["Garden Club"],
       },
     ];
     mockGetAllMessageHistory.mockResolvedValue(messages);
@@ -99,7 +99,7 @@ describe("fetchMessageDetail", () => {
     smsCount: 0,
     failedCount: 0,
     isBlast: false,
-    groupName: "Garden Club",
+    groupNames: ["Garden Club"],
   };
 
   const recipients = [

--- a/test/services/message-history.test.ts
+++ b/test/services/message-history.test.ts
@@ -73,7 +73,7 @@ describe("getGroupMessageHistory", () => {
     await getGroupMessageHistory(5);
 
     expect(mockPrisma.message.findMany).toHaveBeenCalledWith({
-      where: { groupId: 5 },
+      where: { groups: { some: { groupId: 5 } } },
       select: {
         id: true,
         subject: true,

--- a/test/services/message-query.test.ts
+++ b/test/services/message-query.test.ts
@@ -29,12 +29,13 @@ describe("getAllMessageHistory", () => {
       {
         id: 1,
         subject: "Hello",
+        body: "Hello body",
         sentAt: new Date("2026-04-01"),
         emailCount: 5,
         smsCount: 0,
         failedCount: 0,
         isBlast: false,
-        group: { name: "Garden Club" },
+        groups: [{ group: { name: "Garden Club" } }],
       },
     ] as never);
 
@@ -44,33 +45,35 @@ describe("getAllMessageHistory", () => {
       {
         id: 1,
         subject: "Hello",
+        body: "Hello body",
         sentAt: new Date("2026-04-01"),
         emailCount: 5,
         smsCount: 0,
         failedCount: 0,
         isBlast: false,
-        groupName: "Garden Club",
+        groupNames: ["Garden Club"],
       },
     ]);
   });
 
-  it("returns null groupName for blast messages", async () => {
+  it("returns empty groupNames for blast messages", async () => {
     mockPrisma.message.findMany.mockResolvedValue([
       {
         id: 2,
         subject: "Blast",
+        body: "Blast body",
         sentAt: new Date("2026-04-01"),
         emailCount: 100,
         smsCount: 0,
         failedCount: 0,
         isBlast: true,
-        group: null,
+        groups: [],
       },
     ] as never);
 
     const result = await getAllMessageHistory({});
 
-    expect(result[0].groupName).toBeNull();
+    expect(result[0].groupNames).toEqual([]);
     expect(result[0].isBlast).toBe(true);
   });
 
@@ -122,7 +125,7 @@ describe("getAllMessageHistory", () => {
 });
 
 describe("getMessageById", () => {
-  it("returns message with group name", async () => {
+  it("returns message with group names", async () => {
     mockPrisma.message.findUnique.mockResolvedValue({
       id: 1,
       subject: "Hello",
@@ -133,12 +136,12 @@ describe("getMessageById", () => {
       smsCount: 0,
       failedCount: 0,
       isBlast: false,
-      group: { name: "Garden Club" },
+      groups: [{ group: { name: "Garden Club" } }],
     } as never);
 
     const result = await getMessageById(1);
 
-    expect(result).toHaveProperty("groupName", "Garden Club");
+    expect(result).toHaveProperty("groupNames", ["Garden Club"]);
     expect(result).toHaveProperty("body", "Body text");
     expect(result).toHaveProperty("senderId", 100001);
   });

--- a/test/services/message.test.ts
+++ b/test/services/message.test.ts
@@ -8,7 +8,6 @@ import type { Message } from "@/generated/prisma/client";
 // Test fixtures
 const testMessage: Message = {
   id: 1,
-  groupId: 5,
   senderId: 100001,
   subject: "Test Group Message",
   body: "This is a test message for the group.",
@@ -21,7 +20,6 @@ const testMessage: Message = {
 
 const testBlastMessage: Message = {
   id: 2,
-  groupId: null,
   senderId: 100001,
   subject: "Test Blast Message",
   body: "This is a blast message to all members.",
@@ -154,7 +152,7 @@ describe("validateSmsAllowed", () => {
 describe("sendGroupMessage", () => {
   const testRecipients = [mockMembers[1], mockMembers[2], mockMembers[3]];
   const defaultInput = {
-    groupId: 5,
+    groupIds: [5],
     subject: "Test Subject",
     body: "Test Body",
     sendEmail: true,
@@ -182,7 +180,6 @@ describe("sendGroupMessage", () => {
     expect(result.messageId).toBe(1);
     expect(mockPrisma.message.create).toHaveBeenCalledWith({
       data: {
-        groupId: 5,
         senderId: 100001,
         subject: "Test Subject",
         body: "Test Body",
@@ -267,7 +264,7 @@ describe("sendBlastMessage", () => {
     mockInteractiveTransaction();
   });
 
-  it("creates Message with isBlast=true and groupId=null", async () => {
+  it("creates Message with isBlast=true and no groupId", async () => {
     vi.mocked(getAllActiveMemberIds).mockResolvedValue(allMemberIds);
     vi.mocked(getMemberDetails).mockResolvedValue([...mockMembers]);
     vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 389, failed: 0, suppressed: 0 });
@@ -282,9 +279,10 @@ describe("sendBlastMessage", () => {
     expect(mockPrisma.message.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         isBlast: true,
-        groupId: null,
       }),
     });
+    const createCall = mockPrisma.message.create.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createCall.data).not.toHaveProperty("groupId");
   });
 
   it("sends to all active members", async () => {


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I migrated the messaging system from single-group to multi-group sends. Messages now associate with groups through a `message_group` join table instead of a `group_id` FK on the message table. The compose form uses a multi-select dropdown, and all display components show comma-separated group names. Existing messages were migrated to the join table.

- `prisma/schema.prisma` - added MessageGroup join table, removed groupId from Message
- `prisma/migrations/20260427000000_multi_group_messaging/migration.sql` - creates join table, migrates existing data, drops old column
- `src/types/message.ts` - changed groupName to groupNames array on MessageHistoryItem and MessageDetail
- `src/schema/contact-group.ts` - changed ComposeMessageSchema from groupId to groupIds array
- `src/services/message.ts` - sendGroupMessage accepts groupIds array with cross-group deduplication, queries use join table includes
- `src/actions/contact-group.ts` - sendMessage checks ownership of all groups
- `src/components/messages/compose-message-form.tsx` - replaced Select with Popover+Command multi-select, "All" mutually exclusive with group selections
- `src/components/messages/message-history-table.tsx` - RecipientLabel shows comma-separated names with +N truncation
- `src/components/messages/view-message-modal.tsx` - groupNames join for display
- `src/components/dashboard/recent-messages-card.tsx` - groupNames join for display

## How to test

1. Run `npx prisma migrate dev` or apply migration SQL directly
2. Visit `/messages/compose`, select multiple groups, send
3. Verify `/messages` shows comma-separated group names
4. Verify blast messages still work with "All Members"
5. Click a row to verify modal shows group names

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers