### PR TITLE
feat: add chip-based group selection to compose form

### DIFF
--- a/src/components/messages/compose-message-form.tsx
+++ b/src/components/messages/compose-message-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { AlertCircle, Check, ChevronDown, Loader2, Mail, MessageCircle } from "lucide-react";
+import { AlertCircle, Check, ChevronDown, Loader2, Mail, MessageCircle, X } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
@@ -61,13 +62,7 @@ export function ComposeMessageForm({
     setSelectedGroupIds(new Set());
   };
 
-  const recipientLabel = isBlast
-    ? "All Members"
-    : selectedGroupIds.size === 0
-      ? "Select Groups"
-      : selectedGroupIds.size === 1
-        ? (groups.find((g) => selectedGroupIds.has(g.id))?.name ?? "1 group")
-        : `${selectedGroupIds.size} groups`;
+  const selectedGroups = groups.filter((g) => selectedGroupIds.has(g.id));
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -115,10 +110,41 @@ export function ComposeMessageForm({
 
       <div>
         <p className="mb-2 text-sm font-semibold">To:</p>
+        {(isBlast || selectedGroups.length > 0) && (
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {isBlast ? (
+              <Badge variant="secondary" className="gap-1 pl-2 pr-1">
+                All Members
+                <button
+                  type="button"
+                  onClick={() => setIsBlast(false)}
+                  className="ml-0.5 rounded-full p-0.5 hover:bg-muted"
+                  aria-label="Remove All Members"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ) : (
+              selectedGroups.map((g) => (
+                <Badge key={g.id} variant="secondary" className="gap-1 pl-2 pr-1">
+                  {g.name}
+                  <button
+                    type="button"
+                    onClick={() => toggleGroup(g.id)}
+                    className="ml-0.5 rounded-full p-0.5 hover:bg-muted"
+                    aria-label={`Remove ${g.name}`}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))
+            )}
+          </div>
+        )}
         <Popover open={groupPickerOpen} onOpenChange={setGroupPickerOpen}>
           <PopoverTrigger asChild>
             <Button variant="outline" role="combobox" aria-expanded={groupPickerOpen} className="w-64 justify-between">
-              {recipientLabel}
+              {isBlast || selectedGroups.length > 0 ? "Add more..." : "Select groups"}
               <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I replaced the label-only dropdown on the compose message form with a chip/badge pattern. Selected groups now display as removable chips above the dropdown trigger, matching Gmail and Material Design multi-select patterns. Users can see exactly which groups are selected without reopening the dropdown.

- `src/components/messages/compose-message-form.tsx` - added Badge chips for selected groups with X remove buttons, "All Members" shows as a single chip, button label changes to "Add more..." when selections exist

## How to test

1. Visit `/messages/compose`
2. Select groups from the dropdown - chips appear above
3. Click X on a chip to remove a group
4. Select "All Members" - clears group chips, shows "All Members" chip
5. Remove "All Members" chip - returns to empty state

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers