### PR TITLE
feat: add profile page

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { getSessionWithName } from "@/lib/dal";
+import { getMemberProfile } from "@/services/profile";
+import { getProfilePhotoUrl } from "@/services/user-preference";
+import { ProfileContent } from "./profile-content";
+
+export const metadata: Metadata = {
+  title: "Profile | PRFC Connect",
+};
+
+export default async function ProfilePage() {
+  const session = await getSessionWithName();
+  const [profile, photoUrl] = await Promise.all([
+    getMemberProfile(session.ownerid, session.isAdmin),
+    getProfilePhotoUrl(session.ownerid),
+  ]);
+
+  return (
+    <ProfileContent profile={profile} photoUrl={photoUrl} userName={session.ownername} isAdmin={session.isAdmin} />
+  );
+}

--- a/src/app/(protected)/profile/profile-content.tsx
+++ b/src/app/(protected)/profile/profile-content.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { ProfilePhotoUpload } from "@/components/profile/profile-photo-upload";
+import { PersonalInformationCard } from "@/components/profile/personal-information-card";
+import { uploadPhotoAction } from "@/actions/settings";
+import type { MemberProfile } from "@/services/profile";
+
+type Props = {
+  profile: MemberProfile;
+  photoUrl: string | null;
+  userName: string;
+  isAdmin: boolean;
+};
+
+export function ProfileContent({ profile, photoUrl, userName, isAdmin }: Props) {
+  const [currentPhotoUrl, setCurrentPhotoUrl] = useState(photoUrl);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleUpload = async (file: File) => {
+    setIsUploading(true);
+    const formData = new FormData();
+    formData.set("file", file);
+    const result = await uploadPhotoAction(formData);
+    setIsUploading(false);
+    if (result.success && result.data) {
+      setCurrentPhotoUrl(result.data.url);
+      toast.success("Photo updated");
+    } else {
+      toast.error(result.error ?? "Failed to upload photo");
+    }
+  };
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="font-angkor text-3xl text-prfc-brown">My Profile</h1>
+      <p className="mt-1 text-muted-foreground">{isAdmin ? "Admin" : "Member"}</p>
+
+      <div className="mt-6">
+        <ProfilePhotoUpload
+          name={userName}
+          photoUrl={currentPhotoUrl}
+          onUpload={handleUpload}
+          isUploading={isUploading}
+        />
+      </div>
+
+      <div className="mt-8">
+        <PersonalInformationCard
+          firstName={profile.firstName}
+          lastName={profile.lastName}
+          email={profile.email}
+          phone={profile.phone}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #139

## What changed?

Added the profile page at /profile. The server component fetches the member profile and photo URL in parallel. The client component renders the existing ProfilePhotoUpload and PersonalInformationCard components with photo upload handling and toast feedback.

- `src/app/(protected)/profile/page.tsx` - server component fetches profile and photo URL
- `src/app/(protected)/profile/profile-content.tsx` - client component with Angkor heading, role subtitle, photo upload with optimistic URL update, read-only personal info card

## How to test

1. Visit `/profile`
2. Verify "My Profile" heading with "Admin" or "Member" subtitle
3. Verify profile photo section with upload button
4. Verify personal info card with first name, last name, email, phone

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers