### PR TITLE
feat: add settings page with notification preferences and sms consent

### DIFF
--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,17 +1,29 @@
 import type { Metadata } from "next";
-import { Settings } from "lucide-react";
-import { ComingSoonPage } from "@/components/layout/coming-soon-page";
+import { verifySession } from "@/lib/dal";
+import { getUserPreferences } from "@/services/user-preference";
+import { getMemberSmsConsent } from "@/services/sms-consent";
+import { getMemberProfile } from "@/services/profile";
+import { env } from "@/env";
+import { SettingsContent } from "./settings-content";
 
 export const metadata: Metadata = {
   title: "Settings | PRFC Connect",
 };
 
-export default function SettingsPage() {
+export default async function SettingsPage() {
+  const session = await verifySession();
+  const [preferences, smsConsent, profile] = await Promise.all([
+    getUserPreferences(session.ownerid),
+    env.SMS_ENABLED ? getMemberSmsConsent(session.ownerid) : null,
+    getMemberProfile(session.ownerid, session.isAdmin),
+  ]);
+
   return (
-    <ComingSoonPage
-      icon={Settings}
-      title="Settings"
-      description="Coming soon. Account settings will be available here."
+    <SettingsContent
+      preferences={preferences}
+      smsConsent={smsConsent}
+      phone={profile.phone}
+      smsFeatureEnabled={env.SMS_ENABLED}
     />
   );
 }

--- a/src/app/(protected)/settings/settings-content.tsx
+++ b/src/app/(protected)/settings/settings-content.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { NotificationPreferencesCard } from "@/components/settings/notification-preferences-card";
+import { SmsConsentCard } from "@/components/settings/sms-consent-card";
+import { updateUserPreferencesAction, revokeSmsConsentAction } from "@/actions/settings";
+import type { UserPreferenceData } from "@/services/user-preference";
+import type { SmsConsentRecord } from "@/services/sms-consent";
+
+type Props = {
+  preferences: UserPreferenceData;
+  smsConsent: SmsConsentRecord | null;
+  phone: string;
+  smsFeatureEnabled: boolean;
+};
+
+export function SettingsContent({ preferences, smsConsent, phone, smsFeatureEnabled }: Props) {
+  const [emailEnabled, setEmailEnabled] = useState(preferences.notifyEmailDefault);
+  const [smsEnabled, setSmsEnabled] = useState(preferences.notifySmsDefault);
+  const [hasConsent, setHasConsent] = useState(!!smsConsent);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const handleToggle = async (key: "notifyEmailDefault" | "notifySmsDefault", value: boolean) => {
+    if (key === "notifyEmailDefault") setEmailEnabled(value);
+    else setSmsEnabled(value);
+
+    const result = await updateUserPreferencesAction({ [key]: value });
+    if (result.success) {
+      toast.success("Preferences updated");
+    } else {
+      if (key === "notifyEmailDefault") setEmailEnabled(!value);
+      else setSmsEnabled(!value);
+      toast.error(result.error ?? "Failed to update preferences");
+    }
+  };
+
+  const handleRevoke = async () => {
+    setIsRevoking(true);
+    const result = await revokeSmsConsentAction({ method: "web_settings", message: null });
+    setIsRevoking(false);
+    if (result.success) {
+      setHasConsent(false);
+      toast.success("SMS consent revoked");
+    } else {
+      toast.error(result.error ?? "Failed to revoke consent");
+    }
+  };
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="font-angkor text-3xl text-prfc-brown">Settings</h1>
+
+      <div className="mt-6 space-y-6">
+        <NotificationPreferencesCard
+          emailEnabled={emailEnabled}
+          smsEnabled={smsEnabled}
+          smsFeatureEnabled={smsFeatureEnabled}
+          onToggle={handleToggle}
+        />
+
+        {smsFeatureEnabled && (
+          <SmsConsentCard phone={phone} hasConsent={hasConsent} onRevoke={handleRevoke} isRevoking={isRevoking} />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #142

## What changed?

I replaced the settings placeholder with the full settings page. The server component fetches user preferences, SMS consent status, and profile data in parallel. The client component renders the notification preferences card with optimistic toggle updates and the SMS consent card (gated by SMS_ENABLED feature flag).

- `src/app/(protected)/settings/page.tsx` - server component fetches preferences, consent, profile, reads SMS_ENABLED env
- `src/app/(protected)/settings/settings-content.tsx` - client component with optimistic toggle updates, toast feedback, SMS consent revoke with loading state

## How to test

1. Visit `/settings`
2. Verify "Settings" heading
3. Toggle email notification - verify toast and persistence
4. SMS toggle visible only if SMS_ENABLED=true
5. SMS Consent card visible only if SMS_ENABLED=true

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers