### PR TITLE
feat: add upcoming events card component

### DIFF
--- a/src/app/team/rutledge/rutledge-content.tsx
+++ b/src/app/team/rutledge/rutledge-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageSentConfirmation } from "@/components/messages/message-sent-confirmation";
+import { UpcomingEventsCard } from "@/components/dashboard/upcoming-events-card";
 
 export function RutledgeContent() {
   return (
@@ -8,28 +8,44 @@ export function RutledgeContent() {
       <div className="mx-auto max-w-2xl">
         <h1 className="text-3xl font-bold text-foreground">Kevin Rutledge</h1>
         <p className="mt-2 text-lg text-muted-foreground">Tech Lead</p>
-        <div className="mt-10">
-          <h2 className="text-xl font-semibold">Message Sent Confirmation Preview</h2>
-          <div className="mt-4 space-y-6">
-            <MessageSentConfirmation
-              recipientCount={120}
-              channels={{ email: true, sms: true }}
-              onTrackRsvps={() => console.log("Track RSVPs")}
-              onDeliveryStatus={() => console.log("Delivery Status")}
-            />
-            <MessageSentConfirmation
-              recipientCount={45}
-              channels={{ email: true, sms: false }}
-              onTrackRsvps={() => console.log("Track RSVPs")}
-              onDeliveryStatus={() => console.log("Delivery Status")}
-            />
-            <MessageSentConfirmation
-              recipientCount={30}
-              channels={{ email: false, sms: true }}
-              onTrackRsvps={() => console.log("Track RSVPs")}
-              onDeliveryStatus={() => console.log("Delivery Status")}
-            />
-          </div>
+        <div className="mt-10 space-y-6">
+          <UpcomingEventsCard
+            events={[
+              {
+                id: 1,
+                title: "Local Bites @ Winery",
+                startDate: new Date("2026-04-30T01:00:00Z"),
+                eventType: "social",
+                groupName: "Food Lovers",
+                rsvpCount: 25,
+              },
+              {
+                id: 2,
+                title: "Co-Op Info Session",
+                startDate: new Date("2026-05-05T19:00:00Z"),
+                eventType: "networking",
+                groupName: "New Members",
+                rsvpCount: 18,
+              },
+              {
+                id: 3,
+                title: "Member Town Hall",
+                startDate: new Date("2026-05-08T01:00:00Z"),
+                eventType: "meeting",
+                groupName: "PRFC Members",
+                rsvpCount: 20,
+              },
+              {
+                id: 4,
+                title: "Chamber Networking",
+                startDate: new Date("2026-05-12T00:30:00Z"),
+                eventType: "volunteer",
+                groupName: "PRFC Members",
+                rsvpCount: 12,
+              },
+            ]}
+          />
+          <UpcomingEventsCard events={[]} />
         </div>
       </div>
     </div>

--- a/src/components/dashboard/upcoming-events-card.tsx
+++ b/src/components/dashboard/upcoming-events-card.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { coopFormatTimed } from "@/utils/time";
+import type { EventType } from "@/generated/prisma/client";
+
+interface UpcomingEventsCardProps {
+  events: Array<{
+    id: number;
+    title: string;
+    startDate: Date;
+    eventType: EventType;
+    groupName: string | null;
+    rsvpCount: number;
+  }>;
+}
+
+const EVENT_EMOJI: Record<EventType, string> = {
+  social: "\u{1F354}",
+  networking: "\u{1F3DB}\u{FE0F}",
+  volunteer: "\u{1F308}",
+  meeting: "\u{2B50}",
+};
+
+const EVENT_BG: Record<EventType, string> = {
+  social: "bg-amber-100",
+  networking: "bg-blue-100",
+  volunteer: "bg-green-100",
+  meeting: "bg-yellow-100",
+};
+
+export function UpcomingEventsCard({ events }: UpcomingEventsCardProps) {
+  return (
+    <Card className="flex flex-col">
+      <CardContent className="flex flex-1 flex-col pt-6">
+        <h2 className="font-angkor text-xl">Upcoming Events</h2>
+        <div className="mt-4 flex-1 space-y-3">
+          {events.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No upcoming events. Create one to engage members.</p>
+          ) : (
+            events.map((event) => (
+              <div key={event.id} className="flex items-center gap-3 rounded-lg bg-paso-grey px-4 py-3">
+                <div
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${EVENT_BG[event.eventType]}`}
+                >
+                  <span className="text-lg">{EVENT_EMOJI[event.eventType]}</span>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold">{event.title}</p>
+                  {event.groupName && <p className="truncate text-xs text-muted-foreground">{event.groupName}</p>}
+                </div>
+                <div className="shrink-0 text-right">
+                  <p className="text-sm">
+                    {coopFormatTimed(event.startDate, "MMM d")} &middot; {coopFormatTimed(event.startDate, "h:mm a")}
+                  </p>
+                  <p className="text-xs text-muted-foreground">RSVPs: {event.rsvpCount}</p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+        <hr className="mt-3 border-prfc-border/30" />
+        <Link
+          href="/events"
+          className="mt-3 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          View all <ChevronRight className="h-4 w-4" />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #114

## What changed?

Added the upcoming events card for the dashboard. Each event row shows an emoji avatar mapped to event type, title with group name, formatted date/time with middle dot separator, and RSVP count. Uses the same flex-col pinned footer pattern as the other dashboard cards.

- `src/components/dashboard/upcoming-events-card.tsx` - new component with emoji type mapping, coopFormatTimed for Pacific dates, flex pinned "View all" footer linking to /events, empty state
- `src/app/team/rutledge/rutledge-content.tsx` - preview with 4 events and empty state

## How to test

1. Visit `/team/rutledge`
2. Verify populated card shows 4 events with emoji avatars, titles, group names, dates, RSVP counts
3. Verify empty card shows "No upcoming events. Create one to engage members."
4. Verify "View all" links to /events

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers