### PR TITLE
feat: add dashboard page layout with stat cards and widgets

### DIFF
--- a/src/app/(protected)/home/home-content.tsx
+++ b/src/app/(protected)/home/home-content.tsx
@@ -1,36 +1,54 @@
 "use client";
 
-import { EntityCard } from "@/components/groups/entity-card";
-import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
-import type { GroupWithCount } from "@/services/contact-group";
+import { useRouter } from "next/navigation";
+import { TotalMembersCard } from "@/components/dashboard/total-members-card";
+import { EventsThisMonthCard } from "@/components/dashboard/events-this-month-card";
+import { QuickActionsCard } from "@/components/dashboard/quick-actions-card";
+import { UpcomingEventsCard } from "@/components/dashboard/upcoming-events-card";
+import { RecentActivityCard } from "@/components/dashboard/recent-activity-card";
+import { RecentMessagesCard } from "@/components/dashboard/recent-messages-card";
+import type { EventSummary } from "@/types/event";
+import type { ActivityItem } from "@/types/dashboard";
+import type { MessageHistoryItem } from "@/types/message";
 
 interface HomeContentProps {
-  groups: GroupWithCount[];
-  greeting: string;
-  sectionHeading: string;
+  totalMembers: number;
+  eventsThisMonth: number;
+  upcomingEvents: EventSummary[];
+  recentActivity: ActivityItem[];
+  recentMessages: MessageHistoryItem[];
 }
 
-export function HomeContent({ groups, greeting, sectionHeading }: HomeContentProps) {
-  const filteredGroups = useFuzzySearch(groups, {
-    keys: ["name", "description"],
-  });
+export function HomeContent({
+  totalMembers,
+  eventsThisMonth,
+  upcomingEvents,
+  recentActivity,
+  recentMessages,
+}: HomeContentProps) {
+  const router = useRouter();
 
   return (
     <div>
-      <h1 className="font-angkor text-3xl text-prfc-red mb-2">{greeting}</h1>
-      <h2 className="font-khula font-bold text-xl mb-6">{sectionHeading}</h2>
+      <h1 className="font-angkor text-3xl text-prfc-brown">Dashboard</h1>
 
-      {filteredGroups.length === 0 ? (
-        <p className="text-muted-foreground">
-          {groups.length === 0 ? "No groups yet." : "No groups match your search."}
-        </p>
-      ) : (
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-          {filteredGroups.map((group) => (
-            <EntityCard key={group.id} variant="group" name={group.name} memberCount={group.memberCount} />
-          ))}
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <TotalMembersCard count={totalMembers} />
+        <EventsThisMonthCard count={eventsThisMonth} />
+        <QuickActionsCard
+          onCreateEvent={() => router.push("/events")}
+          onCreateGroup={() => router.push("/groups")}
+          onSendMessage={() => router.push("/messages/compose")}
+        />
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
+        <UpcomingEventsCard events={upcomingEvents} />
+        <div className="flex flex-col gap-6">
+          <RecentActivityCard activities={recentActivity} />
+          <RecentMessagesCard messages={recentMessages} />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/app/(protected)/home/page.tsx
+++ b/src/app/(protected)/home/page.tsx
@@ -1,23 +1,30 @@
-import { getSessionWithName } from "@/lib/dal";
-import { getAllGroups, getGroupsByOwner } from "@/services/contact-group";
-import { coopHourOfDay } from "@/utils/time";
+import { verifySession } from "@/lib/dal";
+import { getAllMembers } from "@/lib/api/member-api";
+import { getEventsForMonth, getUpcomingEvents } from "@/services/event";
+import { getRecentActivity } from "@/services/dashboard";
+import { getAllMessageHistory } from "@/services/message";
+import { coopNow } from "@/utils/time";
 import { HomeContent } from "./home-content";
 
-function getGreeting(): string {
-  const hour = coopHourOfDay(new Date());
-  if (hour < 12) return "Good Morning";
-  if (hour < 17) return "Good Afternoon";
-  return "Good Evening";
-}
-
 export default async function HomePage() {
-  const session = await getSessionWithName();
-  const groups = session.isAdmin ? await getAllGroups() : await getGroupsByOwner(session.ownerid);
+  await verifySession();
+  const now = coopNow();
 
-  const greeting = getGreeting();
-  const sectionHeading = session.isAdmin ? "All Groups" : "My Groups";
+  const [memberList, monthEvents, upcomingEvents, recentActivity, recentMessages] = await Promise.all([
+    getAllMembers(),
+    getEventsForMonth(now.year, now.month0 + 1),
+    getUpcomingEvents(4),
+    getRecentActivity(3),
+    getAllMessageHistory({ limit: 3 }),
+  ]);
 
   return (
-    <HomeContent groups={groups} greeting={`${greeting}, ${session.ownername}!`} sectionHeading={sectionHeading} />
+    <HomeContent
+      totalMembers={memberList.length}
+      eventsThisMonth={monthEvents.length}
+      upcomingEvents={upcomingEvents}
+      recentActivity={recentActivity}
+      recentMessages={recentMessages}
+    />
   );
 }

--- a/src/components/dashboard/quick-actions-card.tsx
+++ b/src/components/dashboard/quick-actions-card.tsx
@@ -19,7 +19,7 @@ export function QuickActionsCard({ onCreateEvent, onCreateGroup, onSendMessage }
           variant="ghost"
           size="lg"
           onClick={onCreateEvent}
-          className="w-full justify-start bg-gray-50 text-left hover:bg-gray-100 border border-gray-100 shadow-sm"
+          className="w-full justify-start bg-paso-grey text-left hover:bg-prfc-brown/[0.08] border border-prfc-border/20 shadow-sm"
         >
           <Plus className="mr-2 h-4 w-4" />
           Create Event
@@ -28,7 +28,7 @@ export function QuickActionsCard({ onCreateEvent, onCreateGroup, onSendMessage }
           variant="ghost"
           size="lg"
           onClick={onCreateGroup}
-          className="w-full justify-start bg-gray-50 text-left hover:bg-gray-100 border border-gray-100 shadow-sm"
+          className="w-full justify-start bg-paso-grey text-left hover:bg-prfc-brown/[0.08] border border-prfc-border/20 shadow-sm"
         >
           <UsersRound className="mr-2 h-4 w-4" />
           Create Group
@@ -37,7 +37,7 @@ export function QuickActionsCard({ onCreateEvent, onCreateGroup, onSendMessage }
           variant="ghost"
           size="lg"
           onClick={onSendMessage}
-          className="w-full justify-start bg-gray-50 text-left hover:bg-gray-100 border border-gray-100 shadow-sm"
+          className="w-full justify-start bg-paso-grey text-left hover:bg-prfc-brown/[0.08] border border-prfc-border/20 shadow-sm"
         >
           <SquarePen className="mr-2 h-4 w-4" />
           Send Message

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -17,7 +17,7 @@ interface SidebarNavItem {
 }
 
 const SIDEBAR_ITEMS: SidebarNavItem[] = [
-  { label: "Home", href: "/home", icon: LayoutGrid },
+  { label: "Dashboard", href: "/home", icon: LayoutGrid },
   { label: "Messages", href: "/messages", icon: MessageSquareMore },
   { label: "Groups", href: "/groups", icon: UsersRound },
   { label: "Events", href: "/events", icon: CalendarDays },
@@ -34,7 +34,7 @@ export function Sidebar({ className }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "fixed left-0 top-[var(--header-height)] z-20 hidden h-[calc(100vh-var(--header-height))] w-[220px] bg-white md:block",
+        "fixed left-0 top-[var(--header-height)] z-20 hidden h-[calc(100vh-var(--header-height))] w-[220px] bg-paso-grey md:block",
         "border-r border-border",
         className,
       )}
@@ -55,7 +55,7 @@ export function Sidebar({ className }: SidebarProps) {
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                     active
                       ? "bg-paso-light-brown font-semibold text-foreground"
-                      : "font-normal text-muted-foreground hover:bg-muted/60",
+                      : "font-normal text-muted-foreground hover:bg-prfc-brown/[0.08]",
                   )}
                 >
                   {active ? (


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #117

## What changed?

I rewrote the home page from a group card grid into the dashboard widget layout. The page fetches all dashboard data from services in parallel and renders stat cards, upcoming events, recent activity, and recent messages in a responsive grid. Also updated the sidebar background to paso-grey and standardized hover states across sidebar and quick actions to use Material Design 3 state layer pattern (8% primary brown overlay).

- `src/app/(protected)/home/page.tsx` - server component fetches members, events, activity, messages in parallel from services
- `src/app/(protected)/home/home-content.tsx` - rewrote from group grid to dashboard layout with 3-col top row and 2fr/1fr bottom row
- `src/components/layout/sidebar.tsx` - bg-white to bg-paso-grey, "Home" to "Dashboard", hover to prfc-brown/8% state layer
- `src/components/dashboard/quick-actions-card.tsx` - bg-gray-50 to bg-paso-grey, hover to prfc-brown/8% state layer

## How to test

1. Visit `/home`
2. Verify "Dashboard" heading, sidebar label updated
3. Top row: Total Members, Events This Month, Quick Actions
4. Bottom: Upcoming Events (left), Recent Activity + Recent Messages (right)
5. Hover sidebar items and quick action buttons - subtle warm brown tint
6. Quick Actions navigate to /events, /groups, /messages/compose
7. All cards show empty states when no data

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers