### PR TITLE
refactor: restructure app shell with full-height sidebar and streamlined header

### DIFF
--- a/src/app/(protected)/home/home-content.tsx
+++ b/src/app/(protected)/home/home-content.tsx
@@ -44,7 +44,7 @@ export function HomeContent({
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
         <UpcomingEventsCard events={upcomingEvents} />
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
           <RecentActivityCard activities={recentActivity} />
           <RecentMessagesCard messages={recentMessages} />
         </div>

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -11,9 +11,9 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   return (
     <TopBarActionProvider>
       <TopBarSearchProvider>
-        <TopBar userName={session.ownername} userRole={userRole} />
         <Sidebar />
-        <main className="min-h-[calc(100vh-var(--header-height))] p-8 pt-[calc(var(--header-height)+2rem)] md:pl-[calc(220px+2rem)]">
+        <TopBar userName={session.ownername} userRole={userRole} />
+        <main className="min-h-screen p-8 pt-[calc(var(--header-height)+2rem)] md:pl-[calc(220px+2rem)]">
           {children}
         </main>
       </TopBarSearchProvider>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,7 +64,7 @@
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
-    --header-height: 4rem;
+    --header-height: 4.5rem;
   }
 
   .dark {

--- a/src/app/team/suman/page.tsx
+++ b/src/app/team/suman/page.tsx
@@ -4,29 +4,31 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { TopBar } from "@/components/layout/top-bar";
 import { QuickActionsCard } from "@/components/dashboard/quick-actions-card";
 import { TopBarActionProvider } from "@/components/layout/top-bar-action-context";
+import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
 
 export default function SumanPage() {
   return (
     <div className="min-h-screen bg-background">
       <TopBarActionProvider>
-        <TopBar userName="Saurish Suman" userRole="Admin Manager" />
+        <TopBarSearchProvider>
+          <Sidebar />
+          <TopBar userName="Saurish Suman" userRole="Admin Manager" />
 
-        <Sidebar />
+          <main className="min-h-screen p-8 pt-[calc(var(--header-height)+2rem)] md:pl-[calc(220px+2rem)]">
+            <h1 className="text-2xl font-bold mb-4">Sidebar + Toolbar Preview</h1>
+            <p className="text-muted-foreground">
+              Sidebar spans full height with logo and user menu. Toolbar sits to the right of sidebar.
+            </p>
 
-        <main className="min-h-[calc(100vh-var(--header-height))] p-8 md:pl-[calc(220px+2rem)]">
-          <h1 className="text-2xl font-bold mb-4">Top Bar + Sidebar Preview</h1>
-          <p className="text-muted-foreground">
-            Top bar spans full width. Sidebar is fixed on the left below it (hidden on mobile).
-          </p>
-
-          <div className="mt-6 w-1/3">
-            <QuickActionsCard
-              onCreateEvent={() => alert("Create Event clicked")}
-              onCreateGroup={() => alert("Create Group clicked")}
-              onSendMessage={() => alert("Send Message clicked")}
-            />
-          </div>
-        </main>
+            <div className="mt-6 w-1/3">
+              <QuickActionsCard
+                onCreateEvent={() => alert("Create Event clicked")}
+                onCreateGroup={() => alert("Create Group clicked")}
+                onSendMessage={() => alert("Send Message clicked")}
+              />
+            </div>
+          </main>
+        </TopBarSearchProvider>
       </TopBarActionProvider>
     </div>
   );

--- a/src/components/dashboard/stat-card.tsx
+++ b/src/components/dashboard/stat-card.tsx
@@ -14,7 +14,7 @@ type StatCardProps = {
 export function StatCard({ label, value, icon, viewAllHref, className }: StatCardProps) {
   return (
     <Card className={cn("flex flex-col", className)}>
-      <div className="flex items-center justify-between p-6 pb-4">
+      <div className="flex flex-1 items-center justify-between p-6 pb-4">
         <div className="min-w-0 flex-1">
           <p className="font-semibold text-foreground">{label}</p>
           <p className="mt-3 text-4xl font-bold text-foreground">{value}</p>

--- a/src/components/layout/coming-soon-page.tsx
+++ b/src/components/layout/coming-soon-page.tsx
@@ -8,7 +8,7 @@ interface ComingSoonPageProps {
 
 export function ComingSoonPage({ icon: Icon, title, description }: ComingSoonPageProps) {
   return (
-    <div className="flex min-h-[calc(100vh-var(--header-height)-6rem)] flex-col items-center justify-center text-center">
+    <div className="flex min-h-[calc(100vh-var(--header-height)-8rem)] flex-col items-center justify-center text-center">
       <Icon className="mb-4 h-16 w-16 text-muted-foreground" />
       <h1 className="mb-2 font-angkor text-3xl text-prfc-red">{title}</h1>
       <p className="text-muted-foreground">{description}</p>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,10 +1,21 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
-import { CalendarDays, LayoutGrid, MessageSquareMore, Settings, UsersRound } from "lucide-react";
+import { useTransition } from "react";
+import {
+  CalendarDays,
+  ExternalLink,
+  LayoutGrid,
+  MessageSquareMore,
+  Settings,
+  UserRound,
+  UsersRound,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
+import { logout } from "@/actions/auth";
 
 interface SidebarProps {
   className?: string;
@@ -18,9 +29,13 @@ interface SidebarNavItem {
 
 const SIDEBAR_ITEMS: SidebarNavItem[] = [
   { label: "Dashboard", href: "/home", icon: LayoutGrid },
-  { label: "Messages", href: "/messages", icon: MessageSquareMore },
   { label: "Groups", href: "/groups", icon: UsersRound },
   { label: "Events", href: "/events", icon: CalendarDays },
+  { label: "Messages", href: "/messages", icon: MessageSquareMore },
+];
+
+const SIDEBAR_UTILITY: SidebarNavItem[] = [
+  { label: "Profile", href: "/profile", icon: UserRound },
   { label: "Settings", href: "/settings", icon: Settings },
 ];
 
@@ -28,49 +43,74 @@ function isItemActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
+function NavItem({ item, active }: { item: SidebarNavItem; active: boolean }) {
+  const Icon = item.icon;
+  return (
+    <li>
+      <Link
+        href={item.href}
+        aria-current={active ? "page" : undefined}
+        className={cn(
+          "relative flex items-center gap-3 overflow-hidden rounded-md px-4 py-3 text-base transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          active
+            ? "bg-paso-light-brown font-semibold text-foreground"
+            : "font-normal text-muted-foreground hover:bg-prfc-brown/[0.08]",
+        )}
+      >
+        {active ? <span className="absolute left-0 top-0 h-full w-[3px] bg-prfc-brown" aria-hidden="true" /> : null}
+        <Icon className={cn("h-5 w-5 shrink-0", active ? "text-foreground" : "text-muted-foreground")} />
+        <span>{item.label}</span>
+      </Link>
+    </li>
+  );
+}
+
 export function Sidebar({ className }: SidebarProps) {
   const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
 
   return (
     <aside
-      className={cn(
-        "fixed left-0 top-[var(--header-height)] z-20 hidden h-[calc(100vh-var(--header-height))] w-[220px] bg-paso-grey md:block",
-        "border-r border-border",
-        className,
-      )}
+      className={cn("fixed left-0 top-0 z-30 hidden h-screen w-[220px] bg-paso-grey md:flex md:flex-col", className)}
     >
-      <nav aria-label="Main navigation" className="px-2 py-4">
-        <ul role="list" className="flex flex-col gap-1">
-          {SIDEBAR_ITEMS.map((item) => {
-            const active = isItemActive(pathname, item.href);
-            const Icon = item.icon;
+      <div className="flex h-[var(--header-height)] shrink-0 items-center px-5">
+        <Link href="/home" aria-label="Go to dashboard">
+          <Image
+            src="/assets/logo.png"
+            alt="Paso Food Co-op logo"
+            width={140}
+            height={48}
+            priority
+            className="h-12 w-auto"
+          />
+        </Link>
+      </div>
 
-            return (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  aria-current={active ? "page" : undefined}
-                  className={cn(
-                    "relative flex items-center gap-3 overflow-hidden rounded-md px-4 py-3 text-sm transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                    active
-                      ? "bg-paso-light-brown font-semibold text-foreground"
-                      : "font-normal text-muted-foreground hover:bg-prfc-brown/[0.08]",
-                  )}
-                >
-                  {active ? (
-                    <span className="absolute left-0 top-0 h-full w-[3px] bg-prfc-brown" aria-hidden="true" />
-                  ) : null}
-                  <Icon
-                    className={cn("h-[18px] w-[18px] shrink-0", active ? "text-foreground" : "text-muted-foreground")}
-                  />
-                  <span>{item.label}</span>
-                </Link>
-              </li>
-            );
-          })}
+      <nav aria-label="Main navigation" className="flex-1 overflow-y-auto px-2 py-2">
+        <ul role="list" className="flex flex-col gap-1">
+          {SIDEBAR_ITEMS.map((item) => (
+            <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} />
+          ))}
         </ul>
       </nav>
+
+      <div className="px-2 py-2">
+        <ul role="list" className="flex flex-col gap-1">
+          {SIDEBAR_UTILITY.map((item) => (
+            <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} />
+          ))}
+        </ul>
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={() => startTransition(() => logout())}
+          className="mt-2 flex w-full items-center gap-3 rounded-md px-4 py-3 text-base text-muted-foreground hover:bg-prfc-brown/[0.08]"
+        >
+          <ExternalLink className="h-5 w-5 shrink-0" />
+          <span>{isPending ? "Redirecting..." : "Back to Portal"}</span>
+        </button>
+      </div>
     </aside>
   );
 }

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import Image from "next/image";
-import Link from "next/link";
-import { Bell, Plus, Search } from "lucide-react";
+import { Bell, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useTopBarAction } from "@/components/layout/top-bar-action-context";
-import { useSearchQuery, useSetSearchQuery } from "@/components/layout/top-bar-search-context";
 import { UserMenu } from "@/components/layout/user-menu";
 
 interface TopBarProps {
@@ -17,62 +13,30 @@ interface TopBarProps {
 
 export function TopBar({ userName, userRole }: TopBarProps) {
   const action = useTopBarAction();
-  const searchQuery = useSearchQuery();
-  const setSearchQuery = useSetSearchQuery();
 
   return (
-    <header className="fixed top-0 z-30 flex h-[var(--header-height)] w-full items-center border-b border-border bg-background px-4 md:px-6">
-      <div className="flex w-full items-center gap-3 md:gap-4">
-        <Link href="/home" className="shrink-0 md:w-[220px]" aria-label="Go to home">
-          <Image
-            src="/assets/logo.png"
-            alt="Paso Food Co-op logo"
-            width={140}
-            height={48}
-            priority
-            className="h-10 w-auto"
-          />
-        </Link>
+    <header className="fixed top-0 right-0 z-20 flex h-[var(--header-height)] items-center border-b border-border bg-paso-grey px-4 md:left-[220px] md:px-6">
+      <div className="flex w-full items-center justify-end gap-2 md:gap-3">
+        {action ? (
+          <Button
+            type="button"
+            onClick={action.onClick}
+            className="mr-auto h-10 bg-prfc-red px-4 text-white hover:bg-prfc-red/90"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            <span>{action.label}</span>
+          </Button>
+        ) : null}
 
-        <div className="flex min-w-0 flex-1 items-center gap-3 md:gap-4">
-          <div className="relative min-w-0 flex-1">
-            <Search
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <Input
-              type="text"
-              placeholder="Search"
-              className="h-10 bg-white pl-10"
-              aria-label="Search"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-          </div>
+        <button
+          type="button"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label="Notifications"
+        >
+          <Bell className="h-6 w-6" aria-hidden="true" />
+        </button>
 
-          <div className="ml-auto flex shrink-0 items-center gap-2 md:gap-3">
-            {action ? (
-              <Button
-                type="button"
-                onClick={action.onClick}
-                className="h-10 bg-paso-light-brown px-4 text-foreground hover:bg-paso-light-brown/80"
-              >
-                <Plus className="h-4 w-4" aria-hidden="true" />
-                <span>{action.label}</span>
-              </Button>
-            ) : null}
-
-            <button
-              type="button"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="Notifications"
-            >
-              <Bell className="h-5 w-5" aria-hidden="true" />
-            </button>
-
-            <UserMenu userName={userName} userRole={userRole} />
-          </div>
-        </div>
+        <UserMenu userName={userName} userRole={userRole} />
       </div>
     </header>
   );

--- a/src/components/layout/user-menu.tsx
+++ b/src/components/layout/user-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useTransition } from "react";
 import Link from "next/link";
-import { ChevronDown, LogOut, SlidersVertical, UserRound } from "lucide-react";
+import { ChevronDown, ExternalLink, Settings, UserRound } from "lucide-react";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -35,15 +35,15 @@ export function UserMenu({ userName, userRole }: UserMenuProps) {
           id="user-menu-trigger"
           aria-label="User menu"
         >
+          <div className="min-w-0">
+            <p className="truncate text-base font-semibold leading-tight text-foreground">{userName}</p>
+            <p className="truncate text-sm text-muted-foreground">{userRole}</p>
+          </div>
           <Avatar className="h-10 w-10">
             <AvatarFallback className={cn("text-sm font-semibold text-white")} style={{ backgroundColor: avatarColor }}>
               {initials}
             </AvatarFallback>
           </Avatar>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-semibold leading-tight text-foreground">{userName}</p>
-            <p className="truncate text-xs text-muted-foreground">{userRole}</p>
-          </div>
           <ChevronDown
             className="h-4 w-4 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180"
             aria-hidden="true"
@@ -52,7 +52,7 @@ export function UserMenu({ userName, userRole }: UserMenuProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuItem asChild>
-          <Link href="/settings">
+          <Link href="/profile">
             <UserRound />
             Profile
           </Link>
@@ -60,13 +60,12 @@ export function UserMenu({ userName, userRole }: UserMenuProps) {
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link href="/settings">
-            <SlidersVertical />
-            Account Settings
+            <Settings />
+            Settings
           </Link>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          className="text-destructive focus:text-destructive"
           disabled={isPending}
           onSelect={(e) => {
             e.preventDefault();
@@ -75,8 +74,8 @@ export function UserMenu({ userName, userRole }: UserMenuProps) {
             });
           }}
         >
-          <LogOut />
-          {isPending ? "Signing out…" : "Sign out"}
+          <ExternalLink />
+          {isPending ? "Redirecting…" : "Back to Portal"}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I restructured the app shell following the Linear/Notion pattern. The sidebar now spans full viewport height with the logo at top, main nav in the middle, and Profile/Settings/Back to Portal at the bottom. The header sits to the right of the sidebar with the user menu, bell icon, and action button. Removed the dead global search bar. Unified the shell background to paso-grey. Bumped nav text to 16px and icons to 20px for accessibility.

- `src/components/layout/sidebar.tsx` - full height, logo at top, nav items at text-base/20px icons, Profile/Settings/Back to Portal at bottom, bg-paso-grey, no right border
- `src/components/layout/top-bar.tsx` - removed logo and search bar, offset to right of sidebar, kept user menu/bell/action button
- `src/components/layout/user-menu.tsx` - name/role text bumped to text-base/text-sm, "Account Settings" renamed to "Settings", "Sign out" renamed to "Back to Portal", Profile link fixed to /profile, text before avatar
- `src/app/(protected)/layout.tsx` - updated sidebar/topbar props
- `src/app/globals.css` - header height from 4rem to 4.5rem
- `src/components/dashboard/stat-card.tsx` - flex-1 on content to pin View all to bottom
- `src/app/(protected)/home/home-content.tsx` - tighter gap on right column stack

## How to test

1. Visit any page - verify sidebar with logo, nav, utility section
2. Verify header has user menu, bell, action button, no search bar
3. Click "Back to Portal" in sidebar - logs out
4. Click user menu dropdown - Profile, Settings, Back to Portal
5. Verify all cards on dashboard have "View all" pinned to bottom

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers