### PR TITLE
feat: add collapsible sidebar with localStorage persistence

### DIFF
--- a/src/app/(protected)/groups/[id]/group-detail-content.tsx
+++ b/src/app/(protected)/groups/[id]/group-detail-content.tsx
@@ -11,6 +11,7 @@ import { GroupMemberTable } from "@/components/groups/group-member-table";
 import { AddMembersModal, type MemberRow } from "@/components/groups/add-members-modal";
 import { addMembers, removeMember } from "@/actions/contact-group";
 import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import { useSidebar } from "@/components/layout/sidebar-context";
 import type { MemberSummary } from "@/types/member";
 
 type Props = {
@@ -32,6 +33,7 @@ type Props = {
 
 export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAdmin }: Props) {
   const router = useRouter();
+  const { width: sidebarWidth } = useSidebar();
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [searchQuery, setSearchQuery] = useState("");
   const [addMembersOpen, setAddMembersOpen] = useState(false);
@@ -176,7 +178,10 @@ export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAd
       </div>
 
       {mode === "edit" && (
-        <div className="fixed bottom-0 left-0 right-0 z-10 flex justify-end border-t border-prfc-border/30 bg-background px-8 py-4 md:pl-[calc(220px+2rem)]">
+        <div
+          style={{ paddingLeft: sidebarWidth + 32 }}
+          className="fixed bottom-0 left-0 right-0 z-10 flex justify-end border-t border-prfc-border/30 bg-background px-8 py-4 transition-[padding-left] duration-200 ease-in-out"
+        >
           <Button
             onClick={handleSave}
             disabled={isPending}

--- a/src/app/(protected)/layout-content.tsx
+++ b/src/app/(protected)/layout-content.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useSidebar } from "@/components/layout/sidebar-context";
+
+export function LayoutContent({ children }: { children: React.ReactNode }) {
+  const { width } = useSidebar();
+
+  return (
+    <main
+      style={{ paddingLeft: width + 32 }}
+      className="min-h-screen p-8 pt-[calc(var(--header-height)+2rem)] transition-[padding-left] duration-200 ease-in-out"
+    >
+      {children}
+    </main>
+  );
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,22 +1,24 @@
 import { getSessionWithName } from "@/lib/dal";
 import { TopBarActionProvider } from "@/components/layout/top-bar-action-context";
 import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
+import { SidebarProvider } from "@/components/layout/sidebar-context";
 import { TopBar } from "@/components/layout/top-bar";
 import { Sidebar } from "@/components/layout/sidebar";
+import { LayoutContent } from "./layout-content";
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
   const session = await getSessionWithName();
   const userRole = session.isAdmin ? "Admin Manager" : "Member";
 
   return (
-    <TopBarActionProvider>
-      <TopBarSearchProvider>
-        <Sidebar />
-        <TopBar userName={session.ownername} userRole={userRole} />
-        <main className="min-h-screen p-8 pt-[calc(var(--header-height)+2rem)] md:pl-[calc(220px+2rem)]">
-          {children}
-        </main>
-      </TopBarSearchProvider>
-    </TopBarActionProvider>
+    <SidebarProvider>
+      <TopBarActionProvider>
+        <TopBarSearchProvider>
+          <Sidebar />
+          <TopBar userName={session.ownername} userRole={userRole} />
+          <LayoutContent>{children}</LayoutContent>
+        </TopBarSearchProvider>
+      </TopBarActionProvider>
+    </SidebarProvider>
   );
 }

--- a/src/app/team/suman/page.tsx
+++ b/src/app/team/suman/page.tsx
@@ -5,31 +5,33 @@ import { TopBar } from "@/components/layout/top-bar";
 import { QuickActionsCard } from "@/components/dashboard/quick-actions-card";
 import { TopBarActionProvider } from "@/components/layout/top-bar-action-context";
 import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
+import { SidebarProvider } from "@/components/layout/sidebar-context";
+import { LayoutContent } from "@/app/(protected)/layout-content";
 
 export default function SumanPage() {
   return (
     <div className="min-h-screen bg-background">
-      <TopBarActionProvider>
-        <TopBarSearchProvider>
-          <Sidebar />
-          <TopBar userName="Saurish Suman" userRole="Admin Manager" />
-
-          <main className="min-h-screen p-8 pt-[calc(var(--header-height)+2rem)] md:pl-[calc(220px+2rem)]">
-            <h1 className="text-2xl font-bold mb-4">Sidebar + Toolbar Preview</h1>
-            <p className="text-muted-foreground">
-              Sidebar spans full height with logo and user menu. Toolbar sits to the right of sidebar.
-            </p>
-
-            <div className="mt-6 w-1/3">
-              <QuickActionsCard
-                onCreateEvent={() => alert("Create Event clicked")}
-                onCreateGroup={() => alert("Create Group clicked")}
-                onSendMessage={() => alert("Send Message clicked")}
-              />
-            </div>
-          </main>
-        </TopBarSearchProvider>
-      </TopBarActionProvider>
+      <SidebarProvider>
+        <TopBarActionProvider>
+          <TopBarSearchProvider>
+            <Sidebar />
+            <TopBar userName="Saurish Suman" userRole="Admin Manager" />
+            <LayoutContent>
+              <h1 className="text-2xl font-bold mb-4">Sidebar + Toolbar Preview</h1>
+              <p className="text-muted-foreground">
+                Sidebar collapses to icon-only mode. Click the collapse button at the bottom.
+              </p>
+              <div className="mt-6 w-1/3">
+                <QuickActionsCard
+                  onCreateEvent={() => alert("Create Event clicked")}
+                  onCreateGroup={() => alert("Create Group clicked")}
+                  onSendMessage={() => alert("Send Message clicked")}
+                />
+              </div>
+            </LayoutContent>
+          </TopBarSearchProvider>
+        </TopBarActionProvider>
+      </SidebarProvider>
     </div>
   );
 }

--- a/src/components/layout/sidebar-context.tsx
+++ b/src/components/layout/sidebar-context.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "sidebar-collapsed";
+const SIDEBAR_WIDTH = 220;
+const SIDEBAR_COLLAPSED_WIDTH = 64;
+
+interface SidebarContextValue {
+  collapsed: boolean;
+  toggle: () => void;
+  width: number;
+}
+
+const SidebarContext = createContext<SidebarContextValue>({
+  collapsed: false,
+  toggle: () => {},
+  width: SIDEBAR_WIDTH,
+});
+
+function getSnapshot(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+export function SidebarProvider({ children }: { children: React.ReactNode }) {
+  const collapsed = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const toggle = useCallback(() => {
+    const next = !getSnapshot();
+    localStorage.setItem(STORAGE_KEY, String(next));
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+  }, []);
+
+  const width = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
+
+  return <SidebarContext.Provider value={{ collapsed, toggle, width }}>{children}</SidebarContext.Provider>;
+}
+
+export function useSidebar() {
+  return useContext(SidebarContext);
+}
+
+export { SIDEBAR_WIDTH, SIDEBAR_COLLAPSED_WIDTH };

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
@@ -16,10 +15,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { logout } from "@/actions/auth";
-
-interface SidebarProps {
-  className?: string;
-}
+import { useSidebar } from "@/components/layout/sidebar-context";
 
 interface SidebarNavItem {
   label: string;
@@ -43,15 +39,16 @@ function isItemActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-function NavItem({ item, active }: { item: SidebarNavItem; active: boolean }) {
+function NavItem({ item, active, collapsed }: { item: SidebarNavItem; active: boolean; collapsed: boolean }) {
   const Icon = item.icon;
   return (
     <li>
       <Link
         href={item.href}
         aria-current={active ? "page" : undefined}
+        title={collapsed ? item.label : undefined}
         className={cn(
-          "relative flex items-center gap-3 overflow-hidden rounded-md px-4 py-3 text-base transition-colors",
+          "relative flex h-11 items-center gap-3 overflow-hidden rounded-md px-4 py-3 text-base transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           active
             ? "bg-paso-light-brown font-semibold text-foreground"
@@ -60,37 +57,26 @@ function NavItem({ item, active }: { item: SidebarNavItem; active: boolean }) {
       >
         {active ? <span className="absolute left-0 top-0 h-full w-[3px] bg-prfc-brown" aria-hidden="true" /> : null}
         <Icon className={cn("h-5 w-5 shrink-0", active ? "text-foreground" : "text-muted-foreground")} />
-        <span>{item.label}</span>
+        {!collapsed && <span className="truncate">{item.label}</span>}
       </Link>
     </li>
   );
 }
 
-export function Sidebar({ className }: SidebarProps) {
+export function Sidebar() {
   const pathname = usePathname();
+  const { collapsed, width } = useSidebar();
   const [isPending, startTransition] = useTransition();
 
   return (
     <aside
-      className={cn("fixed left-0 top-0 z-30 hidden h-screen w-[220px] bg-paso-grey md:flex md:flex-col", className)}
+      style={{ width }}
+      className="fixed left-0 top-[var(--header-height)] z-30 hidden h-[calc(100vh-var(--header-height))] border-r border-border bg-paso-grey transition-[width] duration-200 ease-in-out md:flex md:flex-col"
     >
-      <div className="flex h-[var(--header-height)] shrink-0 items-center px-5">
-        <Link href="/home" aria-label="Go to dashboard">
-          <Image
-            src="/assets/logo.png"
-            alt="Paso Food Co-op logo"
-            width={140}
-            height={48}
-            priority
-            className="h-12 w-auto"
-          />
-        </Link>
-      </div>
-
       <nav aria-label="Main navigation" className="flex-1 overflow-y-auto px-2 py-2">
         <ul role="list" className="flex flex-col gap-1">
           {SIDEBAR_ITEMS.map((item) => (
-            <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} />
+            <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} collapsed={collapsed} />
           ))}
         </ul>
       </nav>
@@ -98,17 +84,18 @@ export function Sidebar({ className }: SidebarProps) {
       <div className="px-2 py-2">
         <ul role="list" className="flex flex-col gap-1">
           {SIDEBAR_UTILITY.map((item) => (
-            <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} />
+            <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} collapsed={collapsed} />
           ))}
         </ul>
         <button
           type="button"
           disabled={isPending}
           onClick={() => startTransition(() => logout())}
-          className="mt-2 flex w-full items-center gap-3 rounded-md px-4 py-3 text-base text-muted-foreground hover:bg-prfc-brown/[0.08]"
+          title={collapsed ? "Back to Portal" : undefined}
+          className="mt-2 flex h-11 w-full items-center gap-3 overflow-hidden rounded-md px-4 py-3 text-base text-muted-foreground hover:bg-prfc-brown/[0.08]"
         >
           <ExternalLink className="h-5 w-5 shrink-0" />
-          <span>{isPending ? "Redirecting..." : "Back to Portal"}</span>
+          {!collapsed && <span>{isPending ? "Redirecting..." : "Back to Portal"}</span>}
         </button>
       </div>
     </aside>

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Bell, Plus } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { Bell, Menu, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useTopBarAction } from "@/components/layout/top-bar-action-context";
 import { UserMenu } from "@/components/layout/user-menu";
+import { useSidebar } from "@/components/layout/sidebar-context";
 
 interface TopBarProps {
   userName: string;
@@ -13,30 +16,53 @@ interface TopBarProps {
 
 export function TopBar({ userName, userRole }: TopBarProps) {
   const action = useTopBarAction();
+  const { toggle } = useSidebar();
 
   return (
-    <header className="fixed top-0 right-0 z-20 flex h-[var(--header-height)] items-center border-b border-border bg-paso-grey px-4 md:left-[220px] md:px-6">
-      <div className="flex w-full items-center justify-end gap-2 md:gap-3">
-        {action ? (
-          <Button
-            type="button"
-            onClick={action.onClick}
-            className="mr-auto h-10 bg-prfc-red px-4 text-white hover:bg-prfc-red/90"
-          >
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            <span>{action.label}</span>
-          </Button>
-        ) : null}
-
+    <header className="fixed top-0 left-0 right-0 z-40 flex h-[var(--header-height)] items-center border-b border-border bg-paso-grey px-3.5">
+      <div className="flex w-full items-center gap-3">
         <button
           type="button"
-          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          aria-label="Notifications"
+          onClick={toggle}
+          aria-label="Toggle sidebar"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:bg-prfc-brown/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
-          <Bell className="h-6 w-6" aria-hidden="true" />
+          <Menu className="h-6 w-6" />
         </button>
 
-        <UserMenu userName={userName} userRole={userRole} />
+        <Link href="/home" aria-label="Go to dashboard" className="shrink-0">
+          <Image
+            src="/assets/logo.png"
+            alt="Paso Food Co-op logo"
+            width={140}
+            height={48}
+            priority
+            className="h-10 w-auto"
+          />
+        </Link>
+
+        <div className="ml-auto flex shrink-0 items-center gap-2 md:gap-3">
+          {action ? (
+            <Button
+              type="button"
+              onClick={action.onClick}
+              className="h-10 bg-prfc-red px-4 text-white hover:bg-prfc-red/90"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span>{action.label}</span>
+            </Button>
+          ) : null}
+
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Notifications"
+          >
+            <Bell className="h-6 w-6" aria-hidden="true" />
+          </button>
+
+          <UserMenu userName={userName} userRole={userRole} />
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Added collapsible sidebar following the Gmail pattern. The hamburger toggle + logo live in the full-width header. The sidebar sits below the header and collapses from 220px to 64px icon-only mode. Sidebar width is centralized in a React context using useSyncExternalStore for localStorage persistence without hydration mismatch. All width consumers (sidebar, header, main content, fixed save bar) read from the context.

- `src/components/layout/sidebar-context.tsx` - new context with useSyncExternalStore for localStorage, exports collapsed state, toggle, and width
- `src/components/layout/sidebar.tsx` - reads collapsed state, shows icon-only with tooltips when collapsed, nav-only (no logo/hamburger)
- `src/components/layout/top-bar.tsx` - full-width header with hamburger toggle + logo on left, action/bell/user on right
- `src/app/(protected)/layout.tsx` - wraps in SidebarProvider
- `src/app/(protected)/layout-content.tsx` - client wrapper that reads sidebar width for dynamic padding
- `src/app/(protected)/groups/[id]/group-detail-content.tsx` - fixed save bar reads sidebar width from context

## How to test

1. Visit any page - click hamburger to collapse sidebar
2. Sidebar shrinks to 64px icon-only with tooltips on hover
3. Click hamburger again to expand
4. Refresh page - collapsed state persists
5. Test on groups detail page edit mode - save bar adjusts with sidebar

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers