### PR TITLE
refactor: bump font sizes for accessibility across all pages

### DIFF
--- a/src/app/(protected)/events/events-content.tsx
+++ b/src/app/(protected)/events/events-content.tsx
@@ -358,8 +358,8 @@ export function EventsContent({
                       onClick={() => handleEventClick(e.id)}
                       className="w-full rounded-md border border-prfc-border/20 p-2 text-left hover:bg-paso-grey"
                     >
-                      <p className="text-sm font-semibold">{e.title}</p>
-                      <p className="text-xs text-muted-foreground">
+                      <p className="text-base font-semibold">{e.title}</p>
+                      <p className="text-sm text-muted-foreground">
                         {e.isAllDay
                           ? "All day"
                           : `${coopFormatTimed(e.startDate, "h:mm a")} - ${coopFormatTimed(e.endDate, "h:mm a")}`}

--- a/src/components/dashboard/upcoming-events-card.tsx
+++ b/src/components/dashboard/upcoming-events-card.tsx
@@ -47,13 +47,13 @@ export function UpcomingEventsCard({ events }: UpcomingEventsCardProps) {
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-semibold">{event.title}</p>
-                  {event.groupName && <p className="truncate text-xs text-muted-foreground">{event.groupName}</p>}
+                  {event.groupName && <p className="truncate text-sm text-muted-foreground">{event.groupName}</p>}
                 </div>
                 <div className="shrink-0 text-right">
                   <p className="text-sm">
                     {coopFormatTimed(event.startDate, "MMM d")} &middot; {coopFormatTimed(event.startDate, "h:mm a")}
                   </p>
-                  <p className="text-xs text-muted-foreground">RSVPs: {event.rsvpCount}</p>
+                  <p className="text-sm text-muted-foreground">RSVPs: {event.rsvpCount}</p>
                 </div>
               </div>
             ))

--- a/src/components/groups/entity-card.tsx
+++ b/src/components/groups/entity-card.tsx
@@ -77,7 +77,7 @@ export function EntityCard({
           {memberCount} {memberCount === 1 ? "member" : "members"}
         </div>
         {createdAt && (
-          <p className="mt-auto pt-3 text-xs text-muted-foreground">
+          <p className="mt-auto pt-3 text-sm text-muted-foreground">
             Created {coopFormatTimed(createdAt, "MMM d, yyyy")}
           </p>
         )}

--- a/src/components/groups/group-member-table.tsx
+++ b/src/components/groups/group-member-table.tsx
@@ -46,11 +46,11 @@ export function GroupMemberTable({ members, mode, removedIds, onRemove, onRestor
                       {getInitials(member.ownername)}
                     </AvatarFallback>
                   </Avatar>
-                  <span className={cn("text-sm", isRemoved && "line-through")}>{member.ownername}</span>
+                  <span className={cn("text-base", isRemoved && "line-through")}>{member.ownername}</span>
                 </div>
               </TableCell>
-              <TableCell className={cn("text-sm", isRemoved && "line-through")}>{member.owneremail}</TableCell>
-              <TableCell className="text-sm">Member</TableCell>
+              <TableCell className={cn("text-base", isRemoved && "line-through")}>{member.owneremail}</TableCell>
+              <TableCell className="text-base">Member</TableCell>
               <TableCell>
                 {mode === "view" ? (
                   <Lock className="h-4 w-4 text-muted-foreground" />
@@ -59,7 +59,7 @@ export function GroupMemberTable({ members, mode, removedIds, onRemove, onRestor
                     type="button"
                     onClick={() => onRestore?.(member.memberId)}
                     aria-label={`Restore ${member.ownername}`}
-                    className="flex items-center gap-2 text-sm font-semibold text-prfc-brown hover:text-prfc-brown/80"
+                    className="flex items-center gap-2 text-base font-semibold text-prfc-brown hover:text-prfc-brown/80"
                   >
                     <Undo2 className="h-4 w-4" />
                     Restore
@@ -69,7 +69,7 @@ export function GroupMemberTable({ members, mode, removedIds, onRemove, onRestor
                     type="button"
                     onClick={() => onRemove?.(member.memberId)}
                     aria-label={`Remove ${member.ownername}`}
-                    className="flex items-center gap-2 text-sm font-semibold text-prfc-red hover:text-prfc-red/80"
+                    className="flex items-center gap-2 text-base font-semibold text-prfc-red hover:text-prfc-red/80"
                   >
                     <UserMinus className="h-4 w-4" />
                     Remove

--- a/src/components/messages/message-history-table.tsx
+++ b/src/components/messages/message-history-table.tsx
@@ -65,10 +65,10 @@ export function MessageHistoryTable({ messages, onView }: MessageHistoryTablePro
         <TableBody>
           {messages.map((message) => (
             <TableRow key={message.id} onClick={() => onView(message.id)} className="cursor-pointer hover:bg-muted/50">
-              <TableCell className="whitespace-nowrap text-sm">
+              <TableCell className="whitespace-nowrap text-base">
                 <RecipientLabel message={message} />
               </TableCell>
-              <TableCell className="truncate text-sm">
+              <TableCell className="truncate text-base">
                 <MessagePreview message={message} />
               </TableCell>
               <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
@@ -88,12 +88,12 @@ export function MessageHistoryTable({ messages, onView }: MessageHistoryTablePro
             className="w-full px-3 py-3 text-left hover:bg-muted/50"
           >
             <div className="flex items-center justify-between gap-2">
-              <span className="text-sm font-medium">
+              <span className="text-base font-medium">
                 <RecipientLabel message={message} />
               </span>
-              <span className="shrink-0 text-xs text-muted-foreground">{formatSmartTimestamp(message.sentAt)}</span>
+              <span className="shrink-0 text-sm text-muted-foreground">{formatSmartTimestamp(message.sentAt)}</span>
             </div>
-            <p className="mt-1 truncate text-sm">
+            <p className="mt-1 truncate text-base">
               <MessagePreview message={message} />
             </p>
           </button>

--- a/src/components/profile/personal-information-card.tsx
+++ b/src/components/profile/personal-information-card.tsx
@@ -30,7 +30,7 @@ function IconInput({ icon, value, id }: { icon: React.ReactNode; value: string; 
 export function PersonalInformationCard({ firstName, lastName, email, phone }: PersonalInformationCardProps) {
   return (
     <section>
-      <h2 className="font-angkor text-4xl mb-4">Personal Information</h2>
+      <h2 className="font-angkor text-2xl mb-4">Personal Information</h2>
       <Card>
         <CardContent className="p-6 space-y-4 font-khula">
           <div className="grid grid-cols-2 gap-6">

--- a/src/components/settings/sms-consent-card.tsx
+++ b/src/components/settings/sms-consent-card.tsx
@@ -54,7 +54,7 @@ export function SmsConsentCard({ phone, hasConsent, onRevoke, isRevoking = false
             </Button>
           )}
 
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Message &amp; data rates may apply. Reply STOP to any message to unsubscribe.
           </p>
         </CardContent>


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I audited font sizes across all pages against Material Design 3 type scale and WCAG recommendations. Body content in tables bumped from 14px to 16px. Secondary metadata bumped from 12px to 14px. Personal Information section heading scaled down from 36px to 24px to fit the heading hierarchy. shadcn UI primitives (buttons, selects, dropdowns, labels) verified at 14px matching Material Design Label Large - no changes needed.

- `src/components/groups/group-member-table.tsx` - table cells and action buttons: text-sm to text-base
- `src/components/messages/message-history-table.tsx` - table cells and mobile stacked text: text-sm to text-base
- `src/components/dashboard/upcoming-events-card.tsx` - group name and RSVP count: text-xs to text-sm
- `src/components/groups/entity-card.tsx` - created date: text-xs to text-sm
- `src/components/settings/sms-consent-card.tsx` - disclosure text: text-xs to text-sm
- `src/app/(protected)/events/events-content.tsx` - event title: text-sm to text-base, time range: text-xs to text-sm
- `src/components/profile/personal-information-card.tsx` - section heading: text-4xl to text-2xl

## How to test

1. Visit `/groups` - verify table text is larger and readable
2. Visit `/messages` - verify table text and mobile stacked view are larger
3. Visit `/home` - verify dashboard event card metadata is readable
4. Visit `/profile` - verify "Personal Information" heading is proportional
5. Visit `/settings` - verify SMS disclosure text is readable

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers