### PR TITLE
fix: viewport-fill layouts, message pagination, events UI polish

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -26,15 +26,19 @@ import {
   sendGroupMessage,
   sendBlastMessage,
   getAllMessageHistory,
+  getMessageHistoryPage,
   getMessageById,
   getMessageRecipients,
   previewRecipientCounts,
 } from "@/services/message";
+import { MessageHistoryQuerySchema } from "@/schema/message";
 import { transformError } from "@/utils/errors";
 import type { ActionResult } from "@/types/action";
+import type { MessageHistoryQueryInput } from "@/schema/message";
 import type {
   MessageResult,
   MessageHistoryItem,
+  MessageHistoryPage,
   MessageDetail,
   RecipientStatus,
   RecipientCounts,
@@ -289,6 +293,21 @@ export async function fetchMessageHistory(options: {
     const senderId = session.isAdmin ? undefined : session.ownerid;
     const messages = await getAllMessageHistory({ ...options, senderId });
     return { success: true, data: messages };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function fetchMessageHistoryPage(
+  input: MessageHistoryQueryInput,
+): Promise<ActionResult<MessageHistoryPage>> {
+  try {
+    const session = await verifySession();
+    const validated = MessageHistoryQuerySchema.parse(input);
+    const senderId = session.isAdmin ? undefined : session.ownerid;
+    const page = await getMessageHistoryPage({ ...validated, senderId });
+    return { success: true, data: page };
   } catch (error) {
     const appError = transformError(error);
     return { success: false, error: appError.message };

--- a/src/app/(protected)/events/events-content.tsx
+++ b/src/app/(protected)/events/events-content.tsx
@@ -251,30 +251,65 @@ export function EventsContent({
   const canEditCurrent = editingEvent ? isAdmin || editingEvent.ownerid === currentUserOwnerid : true;
 
   return (
-    <div>
-      <div className="mb-6 flex flex-wrap items-center gap-3">
-        {view === "week" && (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <h1 className="font-angkor text-3xl text-prfc-brown">Events</h1>
+      <div className="mt-4 mb-6 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={goPrev}
+          aria-label={view === "week" ? "Previous week" : "Previous month"}
+          className="rounded-md p-2 hover:bg-paso-light-brown"
+        >
+          <ChevronLeft className="h-5 w-5 text-prfc-brown" />
+        </button>
+        <h2 className="flex items-baseline gap-2">
+          {view === "week" ? (
+            <>
+              <span className="font-angkor text-2xl text-prfc-red">{weekHeading.rangeLabel}</span>
+              <span className="text-2xl text-prfc-brown">{weekHeading.year}</span>
+            </>
+          ) : (
+            <>
+              <span className="font-angkor text-2xl text-prfc-red">{coopFormatTimed(currentDate, "MMMM")}</span>
+              <span className="text-2xl text-prfc-brown">{coopFormatTimed(currentDate, "yyyy")}</span>
+            </>
+          )}
+        </h2>
+        <button
+          type="button"
+          onClick={goNext}
+          aria-label={view === "week" ? "Next week" : "Next month"}
+          className="rounded-md p-2 hover:bg-paso-light-brown"
+        >
+          <ChevronRight className="h-5 w-5 text-prfc-brown" />
+        </button>
+        {view === "month" && (
           <>
-            <button
-              type="button"
-              onClick={goPrev}
-              aria-label="Previous week"
-              className="rounded-md p-2 hover:bg-paso-light-brown"
-            >
-              <ChevronLeft className="h-5 w-5 text-prfc-brown" />
-            </button>
-            <h1 className="flex items-baseline gap-2">
-              <span className="font-angkor text-3xl text-prfc-red">{weekHeading.rangeLabel}</span>
-              <span className="text-3xl text-prfc-brown">{weekHeading.year}</span>
-            </h1>
-            <button
-              type="button"
-              onClick={goNext}
-              aria-label="Next week"
-              className="rounded-md p-2 hover:bg-paso-light-brown"
-            >
-              <ChevronRight className="h-5 w-5 text-prfc-brown" />
-            </button>
+            <Select value={groupFilter} onValueChange={setGroupFilter}>
+              <SelectTrigger className="w-48">
+                <SelectValue placeholder="Group" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Groups</SelectItem>
+                {groups.map((g) => (
+                  <SelectItem key={g.id} value={String(g.id)}>
+                    {g.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <SelectTrigger className="w-48">
+                <SelectValue placeholder="Event Type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Events</SelectItem>
+                <SelectItem value="social">Social</SelectItem>
+                <SelectItem value="networking">Networking</SelectItem>
+                <SelectItem value="meeting">Meeting</SelectItem>
+                <SelectItem value="volunteer">Volunteer</SelectItem>
+              </SelectContent>
+            </Select>
           </>
         )}
         <div className="ml-auto flex items-center gap-3">
@@ -294,9 +329,14 @@ export function EventsContent({
         </div>
       </div>
 
-      <div className={cn("isolate transition-opacity", isPending && "pointer-events-none opacity-60")}>
+      <div
+        className={cn(
+          "isolate flex min-h-0 flex-1 flex-col transition-opacity",
+          isPending && "pointer-events-none opacity-60",
+        )}
+      >
         {view === "week" ? (
-          <div className="h-[700px]">
+          <div className="min-h-0 flex-1">
             <WeekCalendar
               events={weekEvents}
               selectedDate={currentDate}
@@ -305,35 +345,8 @@ export function EventsContent({
             />
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_300px]">
-            <div>
-              <div className="mb-4 flex flex-wrap gap-3">
-                <Select value={groupFilter} onValueChange={setGroupFilter}>
-                  <SelectTrigger className="w-48">
-                    <SelectValue placeholder="Group" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Groups</SelectItem>
-                    {groups.map((g) => (
-                      <SelectItem key={g.id} value={String(g.id)}>
-                        {g.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Select value={typeFilter} onValueChange={setTypeFilter}>
-                  <SelectTrigger className="w-48">
-                    <SelectValue placeholder="Event Type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Events</SelectItem>
-                    <SelectItem value="social">Social</SelectItem>
-                    <SelectItem value="networking">Networking</SelectItem>
-                    <SelectItem value="meeting">Meeting</SelectItem>
-                    <SelectItem value="volunteer">Volunteer</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_300px]">
+            <div className="flex min-h-0 flex-col">
               <MonthCalendar
                 currentMonth={currentDate}
                 onMonthChange={(d) => setCurrentDate(coopWallClockToUtc(d.getFullYear(), d.getMonth(), 1, 12, 0))}

--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -87,7 +87,7 @@ export function GroupsContent({ groups, ownerId, members }: GroupsContentProps) 
         ) : sortedGroups.length === 0 ? (
           <p className="text-muted-foreground">No groups match your search.</p>
         ) : (
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 min-[1920px]:grid-cols-5">
             {sortedGroups.map((group) => (
               <div key={group.id} className="relative">
                 <EntityCard

--- a/src/app/(protected)/home/home-content.tsx
+++ b/src/app/(protected)/home/home-content.tsx
@@ -29,7 +29,7 @@ export function HomeContent({
   const router = useRouter();
 
   return (
-    <div>
+    <div className="flex flex-1 flex-col">
       <h1 className="font-angkor text-3xl text-prfc-brown">Dashboard</h1>
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -42,7 +42,7 @@ export function HomeContent({
         />
       </div>
 
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
+      <div className="mt-6 grid flex-1 grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
         <UpcomingEventsCard events={upcomingEvents} />
         <div className="flex flex-col gap-4">
           <RecentActivityCard activities={recentActivity} />

--- a/src/app/(protected)/layout-content.tsx
+++ b/src/app/(protected)/layout-content.tsx
@@ -8,7 +8,7 @@ export function LayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <main
       style={{ paddingLeft: width + 32 }}
-      className="min-h-screen p-8 pt-[calc(var(--header-height)+2rem)] transition-[padding-left] duration-200 ease-in-out"
+      className="flex h-dvh flex-col overflow-y-auto p-8 pt-[calc(var(--header-height)+2rem)] transition-[padding-left] duration-200 ease-in-out"
     >
       {children}
     </main>

--- a/src/app/(protected)/messages/messages-content.tsx
+++ b/src/app/(protected)/messages/messages-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { Plus, Search } from "lucide-react";
 import { toast } from "sonner";
@@ -9,41 +9,124 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { MessageHistoryTable } from "@/components/messages/message-history-table";
 import { ViewMessageModal } from "@/components/messages/view-message-modal";
-import { fetchMessageDetail } from "@/actions/contact-group";
-import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import { fetchMessageDetail, fetchMessageHistoryPage } from "@/actions/contact-group";
+import { useDebounce } from "@/hooks/use-debounce";
 import { cn } from "@/lib/utils";
-import type { MessageHistoryItem } from "@/types/message";
+import type { MessageHistoryPage } from "@/types/message";
 import type { MessageDetail, RecipientStatus } from "@/types/message";
 
 type Props = {
-  initialMessages: MessageHistoryItem[];
+  initialPage: MessageHistoryPage;
   isAdmin: boolean;
 };
 
-export function MessagesContent({ initialMessages }: Props) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [channelFilter, setChannelFilter] = useState("all");
-  const [sortOrder, setSortOrder] = useState("recent");
-  const [viewModal, setViewModal] = useState<{ message: MessageDetail; recipients: RecipientStatus[] } | null>(null);
+function useMessagePagination(initialPage: MessageHistoryPage) {
+  const [page, setPage] = useState(initialPage);
+  const [startIndex, setStartIndex] = useState(1);
   const [isPending, startTransition] = useTransition();
 
-  const channelFiltered = useMemo(() => {
-    if (channelFilter === "all") return initialMessages;
-    if (channelFilter === "email") return initialMessages.filter((m) => m.emailCount > 0);
-    return initialMessages.filter((m) => m.smsCount > 0);
-  }, [initialMessages, channelFilter]);
+  const refetch = (params: {
+    search?: string;
+    channel?: "email" | "sms";
+    sort: "recent" | "oldest";
+    pageSize: 10 | 25 | 50;
+    cursor?: number;
+    direction?: "forward" | "backward";
+  }) => {
+    if (!params.cursor) setStartIndex(1);
+    startTransition(async () => {
+      const result = await fetchMessageHistoryPage({
+        search: params.search || undefined,
+        channel: params.channel,
+        sort: params.sort,
+        cursor: params.cursor,
+        direction: params.direction,
+        pageSize: params.pageSize,
+      });
+      if (result.success && result.data) {
+        setPage(result.data);
+      } else {
+        toast.error(result.error ?? "Failed to load messages");
+      }
+    });
+  };
 
-  const searched = useFuzzySearch(channelFiltered, { keys: ["subject"] }, searchQuery);
+  const goNext = () => {
+    setStartIndex((prev) => prev + page.items.length);
+  };
 
-  const sorted = useMemo(() => {
-    const copy = [...searched];
-    if (sortOrder === "oldest") copy.sort((a, b) => a.sentAt.getTime() - b.sentAt.getTime());
-    else copy.sort((a, b) => b.sentAt.getTime() - a.sentAt.getTime());
-    return copy;
-  }, [searched, sortOrder]);
+  const goPrev = (currentPageSize: number) => {
+    setStartIndex((prev) => Math.max(1, prev - currentPageSize));
+  };
+
+  return { page, startIndex, isPending, refetch, goNext, goPrev };
+}
+
+export function MessagesContent({ initialPage }: Props) {
+  const { page, startIndex, isPending, refetch, goNext, goPrev } = useMessagePagination(initialPage);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [channelFilter, setChannelFilter] = useState<string>("all");
+  const [sortOrder, setSortOrder] = useState<"recent" | "oldest">("recent");
+  const [pageSize, setPageSize] = useState<10 | 25 | 50>(25);
+  const [viewModal, setViewModal] = useState<{ message: MessageDetail; recipients: RecipientStatus[] } | null>(null);
+
+  const debouncedSearch = useDebounce(searchQuery, 300);
+  const isInitialMount = useRef(true);
+
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    fetchFirstPage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
+
+  const fetchFirstPage = (overrides?: { channel?: string; sort?: "recent" | "oldest"; pageSize?: 10 | 25 | 50 }) => {
+    const ch = overrides?.channel ?? channelFilter;
+    const channel = ch === "all" ? undefined : (ch as "email" | "sms");
+    refetch({
+      search: debouncedSearch,
+      channel,
+      sort: overrides?.sort ?? sortOrder,
+      pageSize: overrides?.pageSize ?? pageSize,
+    });
+  };
+
+  const handleNextPage = () => {
+    if (page.nextCursor) {
+      goNext();
+      const channel = channelFilter === "all" ? undefined : (channelFilter as "email" | "sms");
+      refetch({
+        search: debouncedSearch,
+        channel,
+        sort: sortOrder,
+        pageSize,
+        cursor: page.nextCursor,
+        direction: "forward",
+      });
+    }
+  };
+
+  const handlePrevPage = () => {
+    if (page.prevCursor) {
+      goPrev(pageSize);
+      const channel = channelFilter === "all" ? undefined : (channelFilter as "email" | "sms");
+      refetch({
+        search: debouncedSearch,
+        channel,
+        sort: sortOrder,
+        pageSize,
+        cursor: page.prevCursor,
+        direction: "backward",
+      });
+    }
+  };
+
+  const [isViewPending, startViewTransition] = useTransition();
 
   const handleView = (messageId: number) => {
-    startTransition(async () => {
+    startViewTransition(async () => {
       const result = await fetchMessageDetail(messageId);
       if (result.success && result.data) {
         setViewModal({ message: result.data.message, recipients: result.data.recipients });
@@ -53,12 +136,14 @@ export function MessagesContent({ initialMessages }: Props) {
     });
   };
 
+  const endIndex = Math.min(startIndex + page.items.length - 1, page.totalCount);
+
   return (
     <div>
       <h1 className="font-angkor text-3xl text-prfc-brown">Message History</h1>
 
       <div className="mt-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 max-w-md">
+        <div className="relative max-w-md flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             value={searchQuery}
@@ -68,7 +153,13 @@ export function MessagesContent({ initialMessages }: Props) {
             aria-label="Search messages"
           />
         </div>
-        <Select value={channelFilter} onValueChange={setChannelFilter}>
+        <Select
+          value={channelFilter}
+          onValueChange={(v) => {
+            setChannelFilter(v);
+            fetchFirstPage({ channel: v });
+          }}
+        >
           <SelectTrigger className="w-40">
             <SelectValue placeholder="Message Type" />
           </SelectTrigger>
@@ -78,7 +169,14 @@ export function MessagesContent({ initialMessages }: Props) {
             <SelectItem value="sms">SMS</SelectItem>
           </SelectContent>
         </Select>
-        <Select value={sortOrder} onValueChange={setSortOrder}>
+        <Select
+          value={sortOrder}
+          onValueChange={(v) => {
+            const sort = v as "recent" | "oldest";
+            setSortOrder(sort);
+            fetchFirstPage({ sort });
+          }}
+        >
           <SelectTrigger className="w-32">
             <SelectValue placeholder="Date" />
           </SelectTrigger>
@@ -95,8 +193,56 @@ export function MessagesContent({ initialMessages }: Props) {
         </Link>
       </div>
 
-      <div className={cn("mt-6 transition-opacity", isPending && "pointer-events-none opacity-60")}>
-        <MessageHistoryTable messages={sorted} onView={handleView} />
+      <div className={cn("mt-6 transition-opacity", (isPending || isViewPending) && "pointer-events-none opacity-60")}>
+        <MessageHistoryTable messages={page.items} onView={handleView} />
+      </div>
+
+      <div className="mt-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Rows per page</span>
+          <Select
+            value={String(pageSize)}
+            onValueChange={(v) => {
+              const size = Number(v) as 10 | 25 | 50;
+              setPageSize(size);
+              fetchFirstPage({ pageSize: size });
+            }}
+          >
+            <SelectTrigger className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="10">10</SelectItem>
+              <SelectItem value="25">25</SelectItem>
+              <SelectItem value="50">50</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <span className="text-sm text-muted-foreground">
+          {page.totalCount === 0 ? "No messages" : `Showing ${startIndex}-${endIndex} of ${page.totalCount}`}
+        </span>
+
+        <nav className="flex items-center gap-2" aria-label="Pagination">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handlePrevPage}
+            disabled={!page.prevCursor || isPending}
+            aria-disabled={!page.prevCursor || isPending}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleNextPage}
+            disabled={!page.nextCursor || isPending}
+            aria-disabled={!page.nextCursor || isPending}
+          >
+            Next
+          </Button>
+        </nav>
       </div>
 
       {viewModal && (

--- a/src/app/(protected)/messages/page.tsx
+++ b/src/app/(protected)/messages/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { verifySession } from "@/lib/dal";
-import { getAllMessageHistory } from "@/services/message";
+import { getMessageHistoryPage } from "@/services/message";
 import { MessagesContent } from "./messages-content";
 
 export const metadata: Metadata = {
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default async function MessagesPage() {
   const session = await verifySession();
   const senderId = session.isAdmin ? undefined : session.ownerid;
-  const messages = await getAllMessageHistory({ senderId });
+  const initialPage = await getMessageHistoryPage({ senderId });
 
-  return <MessagesContent initialMessages={messages} isAdmin={session.isAdmin} />;
+  return <MessagesContent initialPage={initialPage} isAdmin={session.isAdmin} />;
 }

--- a/src/components/dashboard/recent-activity-card.tsx
+++ b/src/components/dashboard/recent-activity-card.tsx
@@ -11,7 +11,7 @@ interface RecentActivityCardProps {
 
 export function RecentActivityCard({ activities }: RecentActivityCardProps) {
   return (
-    <Card className="flex flex-col">
+    <Card className="flex flex-1 flex-col">
       <CardHeader>
         <CardTitle>Recent Activity</CardTitle>
       </CardHeader>

--- a/src/components/dashboard/recent-messages-card.tsx
+++ b/src/components/dashboard/recent-messages-card.tsx
@@ -14,7 +14,7 @@ interface RecentMessagesCardProps {
 
 export function RecentMessagesCard({ messages }: RecentMessagesCardProps) {
   return (
-    <Card className="flex flex-col">
+    <Card className="flex flex-1 flex-col">
       <CardHeader>
         <CardTitle>Recent Messages</CardTitle>
       </CardHeader>

--- a/src/components/dashboard/upcoming-events-card.tsx
+++ b/src/components/dashboard/upcoming-events-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, UtensilsCrossed, Handshake, HeartHandshake, Presentation, type LucideIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { coopFormatTimed } from "@/utils/time";
 import type { EventType } from "@/generated/prisma/client";
@@ -15,18 +15,18 @@ interface UpcomingEventsCardProps {
   }>;
 }
 
-const EVENT_EMOJI: Record<EventType, string> = {
-  social: "\u{1F354}",
-  networking: "\u{1F3DB}\u{FE0F}",
-  volunteer: "\u{1F308}",
-  meeting: "\u{2B50}",
+const EVENT_ICON: Record<EventType, LucideIcon> = {
+  social: UtensilsCrossed,
+  networking: Handshake,
+  volunteer: HeartHandshake,
+  meeting: Presentation,
 };
 
 const EVENT_BG: Record<EventType, string> = {
-  social: "bg-amber-100",
-  networking: "bg-blue-100",
-  volunteer: "bg-green-100",
-  meeting: "bg-yellow-100",
+  social: "bg-amber-100 text-amber-700",
+  networking: "bg-blue-100 text-blue-700",
+  volunteer: "bg-green-100 text-green-700",
+  meeting: "bg-yellow-100 text-yellow-700",
 };
 
 export function UpcomingEventsCard({ events }: UpcomingEventsCardProps) {
@@ -43,7 +43,10 @@ export function UpcomingEventsCard({ events }: UpcomingEventsCardProps) {
                 <div
                   className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${EVENT_BG[event.eventType]}`}
                 >
-                  <span className="text-lg">{EVENT_EMOJI[event.eventType]}</span>
+                  {(() => {
+                    const Icon = EVENT_ICON[event.eventType];
+                    return <Icon className="h-5 w-5" aria-hidden="true" />;
+                  })()}
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-semibold">{event.title}</p>

--- a/src/components/events/month-calendar.tsx
+++ b/src/components/events/month-calendar.tsx
@@ -2,9 +2,7 @@
 
 import { useMemo } from "react";
 import { DayPicker, type DayButtonProps } from "react-day-picker";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { addMonths, subMonths } from "date-fns";
-import { coopDateParts, coopFormatTimed, localDayKey } from "@/utils/time";
+import { coopDateParts, localDayKey } from "@/utils/time";
 import { cn } from "@/lib/utils";
 
 export type DayMarker = { allDayCount: number; timedCount: number };
@@ -74,31 +72,7 @@ export function MonthCalendar({ currentMonth, onMonthChange, eventsByDate, onDay
   );
 
   return (
-    <div>
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="flex items-baseline gap-2">
-          <span className="font-angkor text-3xl text-prfc-red">{coopFormatTimed(currentMonth, "MMMM")}</span>
-          <span className="text-3xl text-prfc-brown">{coopFormatTimed(currentMonth, "yyyy")}</span>
-        </h2>
-        <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={() => onMonthChange(subMonths(localMonth, 1))}
-            aria-label="Previous month"
-            className="rounded-md p-2 hover:bg-paso-light-brown"
-          >
-            <ChevronLeft className="h-5 w-5 text-prfc-brown" />
-          </button>
-          <button
-            type="button"
-            onClick={() => onMonthChange(addMonths(localMonth, 1))}
-            aria-label="Next month"
-            className="rounded-md p-2 hover:bg-paso-light-brown"
-          >
-            <ChevronRight className="h-5 w-5 text-prfc-brown" />
-          </button>
-        </div>
-      </div>
+    <div className="flex min-h-0 flex-1 flex-col">
       <DayPicker
         mode="single"
         month={localMonth}
@@ -109,12 +83,18 @@ export function MonthCalendar({ currentMonth, onMonthChange, eventsByDate, onDay
         fixedWeeks
         hideNavigation
         components={components}
+        formatters={{ formatWeekdayName: (date) => date.toLocaleDateString("en-US", { weekday: "short" }) }}
         classNames={{
-          month_grid: "w-full border-collapse",
+          root: "flex min-h-0 flex-1 flex-col",
+          month_caption: "hidden",
+          months: "flex min-h-0 flex-1 flex-col",
+          month: "flex min-h-0 flex-1 flex-col",
+          month_grid: "flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border-t border-l border-border",
+          weeks: "flex min-h-0 flex-1 flex-col",
           weekdays: "grid grid-cols-7",
-          weekday: "py-2 text-center text-xs font-bold text-prfc-brown",
-          week: "grid grid-cols-7",
-          day: "h-28 text-center",
+          weekday: "border-r border-border py-2 text-center text-xs font-bold text-prfc-brown",
+          week: "grid min-h-0 flex-1 grid-cols-7",
+          day: "min-h-[112px] border-r border-b border-border text-center",
         }}
       />
     </div>

--- a/src/schema/message.ts
+++ b/src/schema/message.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const MessageHistoryQuerySchema = z.object({
+  search: z.string().max(200).optional(),
+  channel: z.enum(["email", "sms"]).optional(),
+  sort: z.enum(["recent", "oldest"]).optional(),
+  cursor: z.number().int().positive().optional(),
+  direction: z.enum(["forward", "backward"]).optional(),
+  pageSize: z.union([z.literal(10), z.literal(25), z.literal(50)]).optional(),
+});
+
+export type MessageHistoryQueryInput = z.infer<typeof MessageHistoryQuerySchema>;

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -15,6 +15,8 @@ import type {
   MessageDetail,
   RecipientStatus,
   RecipientCounts,
+  MessageHistoryPage,
+  MessageHistoryQuery,
 } from "@/types/message";
 export type {
   MessageResult,
@@ -23,10 +25,13 @@ export type {
   MessageDetail,
   RecipientStatus,
   RecipientCounts,
+  MessageHistoryPage,
+  MessageHistoryQuery,
 } from "@/types/message";
 
 const DEFAULT_MESSAGE_HISTORY_LIMIT = 20;
 const MAX_MESSAGE_HISTORY_LIMIT = 100;
+const DEFAULT_PAGE_SIZE = 25;
 
 export async function getGroupMessageHistory(
   groupId: number,
@@ -369,6 +374,99 @@ export async function getAllMessageHistory(options: {
       isBlast: m.isBlast,
       groupNames: m.groups.map((mg) => mg.group.name),
     }));
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getMessageHistoryPage(query: MessageHistoryQuery): Promise<MessageHistoryPage> {
+  try {
+    const {
+      senderId,
+      search,
+      channel,
+      sort = "recent",
+      cursor,
+      direction = "forward",
+      pageSize = DEFAULT_PAGE_SIZE,
+    } = query;
+
+    const where: Record<string, unknown> = {};
+    if (senderId) where.senderId = senderId;
+    if (channel) where.recipients = { some: { channel } };
+    if (search) where.subject = { contains: search };
+
+    const isBackward = direction === "backward";
+    const orderDirection = sort === "oldest" ? ("asc" as const) : ("desc" as const);
+    const take = isBackward ? -(pageSize + 1) : pageSize + 1;
+
+    const select = {
+      id: true,
+      subject: true,
+      body: true,
+      sentAt: true,
+      emailCount: true,
+      smsCount: true,
+      failedCount: true,
+      isBlast: true,
+      groups: { select: { group: { select: { name: true } } } },
+    } as const;
+
+    const [rawMessages, totalCount] = await Promise.all([
+      cursor
+        ? prisma.message.findMany({
+            where,
+            select,
+            orderBy: { sentAt: orderDirection },
+            take,
+            cursor: { id: cursor },
+            skip: 1,
+          })
+        : prisma.message.findMany({ where, select, orderBy: { sentAt: orderDirection }, take }),
+      prisma.message.count({ where }),
+    ]);
+
+    let messages = [...rawMessages];
+    let hasMore = false;
+
+    if (isBackward) {
+      if (messages.length > pageSize) {
+        hasMore = true;
+        messages = messages.slice(1);
+      }
+    } else {
+      if (messages.length > pageSize) {
+        hasMore = true;
+        messages = messages.slice(0, pageSize);
+      }
+    }
+
+    const items: MessageHistoryItem[] = messages.map((m) => ({
+      id: m.id,
+      subject: m.subject,
+      body: m.body,
+      sentAt: m.sentAt,
+      emailCount: m.emailCount,
+      smsCount: m.smsCount,
+      failedCount: m.failedCount,
+      isBlast: m.isBlast,
+      groupNames: m.groups.map((mg) => mg.group.name),
+    }));
+
+    let nextCursor: number | null = null;
+    let prevCursor: number | null = null;
+
+    if (items.length > 0) {
+      if (isBackward) {
+        nextCursor = items[items.length - 1].id;
+        prevCursor = hasMore ? items[0].id : null;
+      } else {
+        nextCursor = hasMore ? items[items.length - 1].id : null;
+        prevCursor = cursor ? items[0].id : null;
+      }
+    }
+
+    return { items, totalCount, nextCursor, prevCursor };
   } catch (error) {
     throw transformError(error);
   }

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -46,3 +46,20 @@ export interface RecipientCounts {
   smsEligible: number;
   smsIneligible: number;
 }
+
+export interface MessageHistoryPage {
+  items: MessageHistoryItem[];
+  totalCount: number;
+  nextCursor: number | null;
+  prevCursor: number | null;
+}
+
+export interface MessageHistoryQuery {
+  senderId?: number;
+  search?: string;
+  channel?: "email" | "sms";
+  sort?: "recent" | "oldest";
+  cursor?: number;
+  direction?: "forward" | "backward";
+  pageSize?: number;
+}

--- a/test/actions/message-query.test.ts
+++ b/test/actions/message-query.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/services/message", () => ({
   sendGroupMessage: vi.fn(),
   sendBlastMessage: vi.fn(),
   getAllMessageHistory: vi.fn(),
+  getMessageHistoryPage: vi.fn(),
   getMessageById: vi.fn(),
   getMessageRecipients: vi.fn(),
   previewRecipientCounts: vi.fn(),
@@ -18,11 +19,23 @@ vi.mock("@/services/contact-group", () => ({
   isGroupOwner: vi.fn(),
 }));
 
-import { getAllMessageHistory, getMessageById, getMessageRecipients, previewRecipientCounts } from "@/services/message";
+import {
+  getAllMessageHistory,
+  getMessageHistoryPage,
+  getMessageById,
+  getMessageRecipients,
+  previewRecipientCounts,
+} from "@/services/message";
 import { isGroupOwner } from "@/services/contact-group";
-import { fetchMessageHistory, fetchMessageDetail, fetchRecipientPreview } from "@/actions/contact-group";
+import {
+  fetchMessageHistory,
+  fetchMessageHistoryPage,
+  fetchMessageDetail,
+  fetchRecipientPreview,
+} from "@/actions/contact-group";
 
 const mockGetAllMessageHistory = getAllMessageHistory as MockedFunction<typeof getAllMessageHistory>;
+const mockGetMessageHistoryPage = getMessageHistoryPage as MockedFunction<typeof getMessageHistoryPage>;
 const mockGetMessageById = getMessageById as MockedFunction<typeof getMessageById>;
 const mockGetMessageRecipients = getMessageRecipients as MockedFunction<typeof getMessageRecipients>;
 const mockPreviewRecipientCounts = previewRecipientCounts as MockedFunction<typeof previewRecipientCounts>;
@@ -182,5 +195,67 @@ describe("fetchRecipientPreview", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("do not have permission");
     expect(mockPreviewRecipientCounts).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchMessageHistoryPage", () => {
+  const mockPage = {
+    items: [
+      {
+        id: 1,
+        subject: "Test",
+        body: "Body",
+        sentAt: new Date(),
+        emailCount: 5,
+        smsCount: 0,
+        failedCount: 0,
+        isBlast: false,
+        groupNames: ["Garden Club"],
+      },
+    ],
+    totalCount: 1,
+    nextCursor: null,
+    prevCursor: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns paginated messages for admin without senderId filter", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
+    mockGetMessageHistoryPage.mockResolvedValue(mockPage);
+
+    const result = await fetchMessageHistoryPage({});
+
+    expect(result).toEqual({ success: true, data: mockPage });
+    expect(mockGetMessageHistoryPage).toHaveBeenCalledWith({ senderId: undefined });
+  });
+
+  it("filters by senderId for non-admin member", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
+    mockGetMessageHistoryPage.mockResolvedValue(mockPage);
+
+    await fetchMessageHistoryPage({});
+
+    expect(mockGetMessageHistoryPage).toHaveBeenCalledWith({ senderId: 100003 });
+  });
+
+  it("rejects invalid pageSize via Zod", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
+
+    const result = await fetchMessageHistoryPage({ pageSize: 30 as never });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns error when not authenticated", async () => {
+    mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
+
+    const result = await fetchMessageHistoryPage({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Authentication required");
   });
 });

--- a/test/schema/message.test.ts
+++ b/test/schema/message.test.ts
@@ -1,4 +1,5 @@
 import { BaseMessageSchema } from "@/schema/contact-group";
+import { MessageHistoryQuerySchema } from "@/schema/message";
 
 describe("BaseMessageSchema SMS body length", () => {
   it("allows long body when sendSms is false", () => {
@@ -43,5 +44,44 @@ describe("BaseMessageSchema SMS body length", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe("MessageHistoryQuerySchema", () => {
+  it("accepts valid full input", () => {
+    const result = MessageHistoryQuerySchema.safeParse({
+      search: "hello",
+      channel: "email",
+      sort: "recent",
+      cursor: 42,
+      direction: "forward",
+      pageSize: 25,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty object", () => {
+    const result = MessageHistoryQuerySchema.safeParse({});
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid pageSize", () => {
+    const result = MessageHistoryQuerySchema.safeParse({ pageSize: 30 });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid channel value", () => {
+    const result = MessageHistoryQuerySchema.safeParse({ channel: "push" });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid sort value", () => {
+    const result = MessageHistoryQuerySchema.safeParse({ sort: "alphabetical" });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/test/services/message-query.test.ts
+++ b/test/services/message-query.test.ts
@@ -19,7 +19,13 @@ vi.mock("@/env", () => ({
 }));
 
 import { getMemberDetails } from "@/lib/api/member-api";
-import { getAllMessageHistory, getMessageById, getMessageRecipients, previewRecipientCounts } from "@/services/message";
+import {
+  getAllMessageHistory,
+  getMessageHistoryPage,
+  getMessageById,
+  getMessageRecipients,
+  previewRecipientCounts,
+} from "@/services/message";
 
 const mockGetMemberDetails = getMemberDetails as MockedFunction<typeof getMemberDetails>;
 
@@ -227,5 +233,113 @@ describe("previewRecipientCounts", () => {
     mockPrisma.contactGroupMember.count.mockRejectedValue(new Error("Connection lost"));
 
     await expect(previewRecipientCounts(1)).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("getMessageHistoryPage", () => {
+  const makeMessages = (count: number, startId: number = 1) =>
+    Array.from({ length: count }, (_, i) => ({
+      id: startId + i,
+      subject: `Message ${startId + i}`,
+      body: `Body ${startId + i}`,
+      sentAt: new Date(`2026-04-${String(startId + i).padStart(2, "0")}`),
+      emailCount: 5,
+      smsCount: 0,
+      failedCount: 0,
+      isBlast: false,
+      groups: [{ group: { name: "Garden Club" } }],
+    }));
+
+  it("returns first page with nextCursor and null prevCursor", async () => {
+    mockPrisma.message.findMany.mockResolvedValue(makeMessages(26) as never);
+    mockPrisma.message.count.mockResolvedValue(50);
+
+    const result = await getMessageHistoryPage({});
+
+    expect(result.items).toHaveLength(25);
+    expect(result.totalCount).toBe(50);
+    expect(result.nextCursor).toBe(25);
+    expect(result.prevCursor).toBeNull();
+  });
+
+  it("returns last page with null nextCursor", async () => {
+    mockPrisma.message.findMany.mockResolvedValue(makeMessages(10) as never);
+    mockPrisma.message.count.mockResolvedValue(35);
+
+    const result = await getMessageHistoryPage({ cursor: 25, direction: "forward" });
+
+    expect(result.items).toHaveLength(10);
+    expect(result.nextCursor).toBeNull();
+    expect(result.prevCursor).toBe(1);
+  });
+
+  it("filters by senderId", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+    mockPrisma.message.count.mockResolvedValue(0);
+
+    await getMessageHistoryPage({ senderId: 100001 });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ senderId: 100001 }) }),
+    );
+  });
+
+  it("filters by channel", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+    mockPrisma.message.count.mockResolvedValue(0);
+
+    await getMessageHistoryPage({ channel: "email" });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ recipients: { some: { channel: "email" } } }) }),
+    );
+  });
+
+  it("filters by search term", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+    mockPrisma.message.count.mockResolvedValue(0);
+
+    await getMessageHistoryPage({ search: "hello" });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ subject: { contains: "hello" } }) }),
+    );
+  });
+
+  it("sorts by oldest when specified", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+    mockPrisma.message.count.mockResolvedValue(0);
+
+    await getMessageHistoryPage({ sort: "oldest" });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { sentAt: "asc" } }));
+  });
+
+  it("respects pageSize parameter", async () => {
+    mockPrisma.message.findMany.mockResolvedValue(makeMessages(11) as never);
+    mockPrisma.message.count.mockResolvedValue(20);
+
+    const result = await getMessageHistoryPage({ pageSize: 10 });
+
+    expect(result.items).toHaveLength(10);
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 11 }));
+  });
+
+  it("returns empty items with totalCount 0 when no matches", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+    mockPrisma.message.count.mockResolvedValue(0);
+
+    const result = await getMessageHistoryPage({ search: "nonexistent" });
+
+    expect(result.items).toEqual([]);
+    expect(result.totalCount).toBe(0);
+    expect(result.nextCursor).toBeNull();
+    expect(result.prevCursor).toBeNull();
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.message.findMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getMessageHistoryPage({})).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
   });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Four pages had layout gaps where content stopped at fixed pixel heights instead of filling the viewport. The main content area now uses h-dvh with flex-col so child pages fill remaining height. The messages page loaded all data client-side and filtered with fuse.js, which does not scale. I added cursor-based pagination with server-side search, channel filter, and sort.

- `src/app/(protected)/layout-content.tsx` - changed main from min-h-screen to h-dvh flex flex-col overflow-y-auto
- `src/app/(protected)/home/home-content.tsx` - outer div and bottom grid use flex-1 to fill viewport
- `src/components/dashboard/recent-activity-card.tsx` - added flex-1 so right column cards split height equally
- `src/components/dashboard/recent-messages-card.tsx` - same flex-1 addition
- `src/components/dashboard/upcoming-events-card.tsx` - replaced emoji with Lucide SVG icons (UtensilsCrossed, Handshake, HeartHandshake, Presentation)
- `src/app/(protected)/events/events-content.tsx` - flex chain with min-h-0 for week and month views to fill viewport, moved month heading and filters into unified toolbar, added "Events" page title
- `src/components/events/month-calendar.tsx` - removed heading and nav (moved to parent), added flex chain through DayPicker internals (root, months, month, month_grid, weeks), grid borders with rounded outer corners, 3-letter weekday names
- `src/app/(protected)/groups/groups-content.tsx` - added min-[1920px]:grid-cols-5 for wide monitors
- `src/types/message.ts` - added MessageHistoryPage and MessageHistoryQuery interfaces
- `src/schema/message.ts` - new Zod schema for pagination input with pageSize restricted to 10/25/50
- `src/services/message.ts` - added getMessageHistoryPage with cursor-based pagination, over-fetch-by-one for hasMore detection, parallel count query
- `src/actions/contact-group.ts` - added fetchMessageHistoryPage action
- `src/app/(protected)/messages/page.tsx` - switched to getMessageHistoryPage for initial load
- `src/app/(protected)/messages/messages-content.tsx` - server-side search/filter/sort, pagination footer with rows-per-page selector and prev/next buttons
- `test/services/message-query.test.ts` - 9 tests for getMessageHistoryPage
- `test/actions/message-query.test.ts` - 4 tests for fetchMessageHistoryPage
- `test/schema/message.test.ts` - 5 tests for MessageHistoryQuerySchema

## How to test

1. Visit /home on a tall viewport - dashboard cards fill to the bottom, right column splits equally
2. Visit /events in week view - calendar fills remaining viewport, scrolls to 7 AM
3. Switch to month view - calendar rows stretch to fill viewport, rounded outer corners, grid lines between days
4. Visit /groups on a 1920px+ monitor - 5 cards per row
5. Visit /messages - table shows 25 rows, use prev/next to paginate, search filters server-side with 300ms debounce, change rows per page with selector

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers