### PR TITLE
fix: role-based group visibility, recipient-scoped messages, sms filter gate

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -25,19 +25,18 @@ import {
 import {
   sendGroupMessage,
   sendBlastMessage,
-  getAllMessageHistory,
   getMessageHistoryPage,
   getMessageById,
   getMessageRecipients,
   previewRecipientCounts,
 } from "@/services/message";
 import { MessageHistoryQuerySchema } from "@/schema/message";
+import { getMemberById } from "@/lib/api/member-api";
 import { transformError } from "@/utils/errors";
 import type { ActionResult } from "@/types/action";
 import type { MessageHistoryQueryInput } from "@/schema/message";
 import type {
   MessageResult,
-  MessageHistoryItem,
   MessageHistoryPage,
   MessageDetail,
   RecipientStatus,
@@ -55,7 +54,7 @@ export async function fetchEnrichedGroup(groupId: number): Promise<ActionResult<
     }
 
     const group = await getGroupById(groupId);
-    const enriched = await enrichGroupMembers(group);
+    const [enriched, owner] = await Promise.all([enrichGroupMembers(group), getMemberById(group.ownerid)]);
 
     return {
       success: true,
@@ -68,6 +67,7 @@ export async function fetchEnrichedGroup(groupId: number): Promise<ActionResult<
           ownername: m.ownername,
         })),
         memberCount: enriched.memberCount,
+        ownerName: owner?.ownername ?? null,
       },
     };
   } catch (error) {
@@ -283,30 +283,14 @@ export async function sendBlast(input: {
   }
 }
 
-export async function fetchMessageHistory(options: {
-  limit?: number;
-  offset?: number;
-  channel?: "email" | "sms";
-}): Promise<ActionResult<MessageHistoryItem[]>> {
-  try {
-    const session = await verifySession();
-    const senderId = session.isAdmin ? undefined : session.ownerid;
-    const messages = await getAllMessageHistory({ ...options, senderId });
-    return { success: true, data: messages };
-  } catch (error) {
-    const appError = transformError(error);
-    return { success: false, error: appError.message };
-  }
-}
-
 export async function fetchMessageHistoryPage(
   input: MessageHistoryQueryInput,
 ): Promise<ActionResult<MessageHistoryPage>> {
   try {
     const session = await verifySession();
     const validated = MessageHistoryQuerySchema.parse(input);
-    const senderId = session.isAdmin ? undefined : session.ownerid;
-    const page = await getMessageHistoryPage({ ...validated, senderId });
+    const roleFilter = session.isAdmin ? {} : { recipientId: session.ownerid };
+    const page = await getMessageHistoryPage({ ...validated, ...roleFilter });
     return { success: true, data: page };
   } catch (error) {
     const appError = transformError(error);

--- a/src/app/(protected)/groups/[id]/group-detail-content.tsx
+++ b/src/app/(protected)/groups/[id]/group-detail-content.tsx
@@ -20,6 +20,7 @@ type Props = {
     name: string;
     description: string | null;
     ownerid: number;
+    ownerName: string | null;
     members: Array<{
       memberId: number;
       ownername: string;
@@ -140,6 +141,7 @@ export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAd
 
       <h1 className="font-angkor text-3xl text-prfc-brown">{group.name}</h1>
       {group.description && <p className="mt-2 text-muted-foreground">{group.description}</p>}
+      {isAdmin && group.ownerName && <p className="mt-1 text-sm text-muted-foreground">Created by {group.ownerName}</p>}
 
       <div className="mt-6 flex items-center gap-3">
         <div className="relative flex-1 max-w-md">

--- a/src/app/(protected)/groups/[id]/page.tsx
+++ b/src/app/(protected)/groups/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { verifySession } from "@/lib/dal";
 import { getGroupById, enrichGroupMembers, isGroupOwner } from "@/services/contact-group";
-import { getAllMembers } from "@/lib/api/member-api";
+import { getAllMembers, getMemberById } from "@/lib/api/member-api";
 import { AppError } from "@/utils/errors";
 import { GroupDetailContent } from "./group-detail-content";
 
@@ -24,6 +24,7 @@ export default async function GroupDetailPage({ params }: { params: Promise<{ id
   if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) notFound();
 
   const [enriched, allMembers] = await Promise.all([loadGroup(groupId), getAllMembers()]);
+  const owner = await getMemberById(enriched.ownerid);
 
   return (
     <GroupDetailContent
@@ -32,6 +33,7 @@ export default async function GroupDetailPage({ params }: { params: Promise<{ id
         name: enriched.name,
         description: enriched.description,
         ownerid: enriched.ownerid,
+        ownerName: owner?.ownername ?? null,
         members: enriched.members.map((m) => ({
           memberId: m.memberId,
           ownername: m.ownername,

--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -12,18 +12,21 @@ import { CreateGroupModal } from "@/components/groups/create-group-modal";
 import { DeleteGroupModal } from "@/components/groups/delete-group-modal";
 import { useGroupsModal, EMPTY_GROUP } from "@/components/groups/use-groups-modal";
 import { useFuzzySearch } from "@/hooks/use-fuzzy-search";
+import { cn } from "@/lib/utils";
 import type { GroupWithCount } from "@/services/contact-group";
 import type { MemberSummary } from "@/lib/api/member-api";
 
 interface GroupsContentProps {
-  groups: GroupWithCount[];
+  myGroups: GroupWithCount[];
+  allGroups: GroupWithCount[];
   isAdmin: boolean;
   ownerId: number;
   members: MemberSummary[];
 }
 
-export function GroupsContent({ groups, ownerId, members }: GroupsContentProps) {
+export function GroupsContent({ myGroups, allGroups, isAdmin, ownerId, members }: GroupsContentProps) {
   const router = useRouter();
+  const [view, setView] = useState<"my" | "all">("my");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("all");
   const {
@@ -40,7 +43,13 @@ export function GroupsContent({ groups, ownerId, members }: GroupsContentProps) 
     handleDeleteCancel,
   } = useGroupsModal(ownerId);
 
-  const filteredGroups = useFuzzySearch(groups, { keys: ["name", "description"] }, searchQuery);
+  const ownerNameMap = useMemo(() => new Map(members.map((m) => [m.ownerid, m.ownername])), [members]);
+  const groups = view === "all" ? allGroups : myGroups;
+  const groupsWithOwner = useMemo(
+    () => groups.map((g) => ({ ...g, ownerName: ownerNameMap.get(g.ownerid) ?? "" })),
+    [groups, ownerNameMap],
+  );
+  const filteredGroups = useFuzzySearch(groupsWithOwner, { keys: ["name", "description", "ownerName"] }, searchQuery);
 
   const sortedGroups = [...filteredGroups].sort((a, b) => {
     if (sortBy === "name") return a.name.localeCompare(b.name);
@@ -54,7 +63,31 @@ export function GroupsContent({ groups, ownerId, members }: GroupsContentProps) 
       <h1 className="font-angkor text-3xl text-prfc-brown">Groups</h1>
 
       <div className="mt-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 max-w-md">
+        {isAdmin && (
+          <div className="flex rounded-lg border border-border">
+            <button
+              type="button"
+              onClick={() => setView("my")}
+              className={cn(
+                "rounded-l-lg px-4 py-2 text-sm font-medium transition-colors",
+                view === "my" ? "bg-prfc-brown text-white" : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              My Groups
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("all")}
+              className={cn(
+                "rounded-r-lg px-4 py-2 text-sm font-medium transition-colors",
+                view === "all" ? "bg-prfc-brown text-white" : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              All Groups
+            </button>
+          </div>
+        )}
+        <div className="relative max-w-md flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             value={searchQuery}
@@ -83,7 +116,9 @@ export function GroupsContent({ groups, ownerId, members }: GroupsContentProps) 
 
       <div className="mt-6">
         {groups.length === 0 ? (
-          <p className="py-20 text-center text-muted-foreground">No groups have been created yet.</p>
+          <p className="py-20 text-center text-muted-foreground">
+            {view === "my" ? "You are not a member of any groups yet." : "No groups have been created yet."}
+          </p>
         ) : sortedGroups.length === 0 ? (
           <p className="text-muted-foreground">No groups match your search.</p>
         ) : (

--- a/src/app/(protected)/groups/page.tsx
+++ b/src/app/(protected)/groups/page.tsx
@@ -7,10 +7,19 @@ export default async function GroupsPage() {
   const session = await getSessionWithName();
   const isAdmin = session.isAdmin;
 
-  const [groups, members] = await Promise.all([
-    isAdmin ? getAllGroups() : getGroupsByOwner(session.ownerid),
+  const [myGroups, allGroups, members] = await Promise.all([
+    getGroupsByOwner(session.ownerid),
+    isAdmin ? getAllGroups() : Promise.resolve([]),
     getAllMembers(),
   ]);
 
-  return <GroupsContent groups={groups} isAdmin={isAdmin} ownerId={session.ownerid} members={members} />;
+  return (
+    <GroupsContent
+      myGroups={myGroups}
+      allGroups={allGroups}
+      isAdmin={isAdmin}
+      ownerId={session.ownerid}
+      members={members}
+    />
+  );
 }

--- a/src/app/(protected)/messages/messages-content.tsx
+++ b/src/app/(protected)/messages/messages-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useEffect, useEffectEvent, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { Plus, Search } from "lucide-react";
 import { toast } from "sonner";
@@ -18,6 +18,7 @@ import type { MessageDetail, RecipientStatus } from "@/types/message";
 type Props = {
   initialPage: MessageHistoryPage;
   isAdmin: boolean;
+  smsFeatureEnabled: boolean;
 };
 
 function useMessagePagination(initialPage: MessageHistoryPage) {
@@ -62,7 +63,7 @@ function useMessagePagination(initialPage: MessageHistoryPage) {
   return { page, startIndex, isPending, refetch, goNext, goPrev };
 }
 
-export function MessagesContent({ initialPage }: Props) {
+export function MessagesContent({ initialPage, smsFeatureEnabled }: Props) {
   const { page, startIndex, isPending, refetch, goNext, goPrev } = useMessagePagination(initialPage);
   const [searchQuery, setSearchQuery] = useState("");
   const [channelFilter, setChannelFilter] = useState<string>("all");
@@ -73,13 +74,17 @@ export function MessagesContent({ initialPage }: Props) {
   const debouncedSearch = useDebounce(searchQuery, 300);
   const isInitialMount = useRef(true);
 
+  const onSearchChange = useEffectEvent(() => {
+    const channel = channelFilter === "all" ? undefined : (channelFilter as "email" | "sms");
+    refetch({ search: debouncedSearch, channel, sort: sortOrder, pageSize });
+  });
+
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
       return;
     }
-    fetchFirstPage();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    onSearchChange();
   }, [debouncedSearch]);
 
   const fetchFirstPage = (overrides?: { channel?: string; sort?: "recent" | "oldest"; pageSize?: 10 | 25 | 50 }) => {
@@ -153,22 +158,24 @@ export function MessagesContent({ initialPage }: Props) {
             aria-label="Search messages"
           />
         </div>
-        <Select
-          value={channelFilter}
-          onValueChange={(v) => {
-            setChannelFilter(v);
-            fetchFirstPage({ channel: v });
-          }}
-        >
-          <SelectTrigger className="w-40">
-            <SelectValue placeholder="Message Type" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All</SelectItem>
-            <SelectItem value="email">Email</SelectItem>
-            <SelectItem value="sms">SMS</SelectItem>
-          </SelectContent>
-        </Select>
+        {smsFeatureEnabled && (
+          <Select
+            value={channelFilter}
+            onValueChange={(v) => {
+              setChannelFilter(v);
+              fetchFirstPage({ channel: v });
+            }}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Message Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="email">Email</SelectItem>
+              <SelectItem value="sms">SMS</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
         <Select
           value={sortOrder}
           onValueChange={(v) => {

--- a/src/app/(protected)/messages/page.tsx
+++ b/src/app/(protected)/messages/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { verifySession } from "@/lib/dal";
 import { getMessageHistoryPage } from "@/services/message";
+import { env } from "@/env";
 import { MessagesContent } from "./messages-content";
 
 export const metadata: Metadata = {
@@ -9,8 +10,7 @@ export const metadata: Metadata = {
 
 export default async function MessagesPage() {
   const session = await verifySession();
-  const senderId = session.isAdmin ? undefined : session.ownerid;
-  const initialPage = await getMessageHistoryPage({ senderId });
+  const initialPage = await getMessageHistoryPage(session.isAdmin ? {} : { recipientId: session.ownerid });
 
-  return <MessagesContent initialPage={initialPage} isAdmin={session.isAdmin} />;
+  return <MessagesContent initialPage={initialPage} isAdmin={session.isAdmin} smsFeatureEnabled={env.SMS_ENABLED} />;
 }

--- a/src/components/groups/use-groups-modal.ts
+++ b/src/components/groups/use-groups-modal.ts
@@ -20,6 +20,7 @@ export const EMPTY_GROUP: EnrichedGroupData = {
   description: null,
   members: [],
   memberCount: 0,
+  ownerName: null,
 };
 
 function buildGroupFormData(data: { name: string; description: string | null }): FormData {

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -383,6 +383,7 @@ export async function getMessageHistoryPage(query: MessageHistoryQuery): Promise
   try {
     const {
       senderId,
+      recipientId,
       search,
       channel,
       sort = "recent",
@@ -393,7 +394,12 @@ export async function getMessageHistoryPage(query: MessageHistoryQuery): Promise
 
     const where: Record<string, unknown> = {};
     if (senderId) where.senderId = senderId;
-    if (channel) where.recipients = { some: { channel } };
+    const recipientFilter: Record<string, unknown> = {};
+    if (recipientId) recipientFilter.memberId = recipientId;
+    if (channel) recipientFilter.channel = channel;
+    if (Object.keys(recipientFilter).length > 0) {
+      where.recipients = { some: recipientFilter };
+    }
     if (search) where.subject = { contains: search };
 
     const isBackward = direction === "backward";

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -30,6 +30,7 @@ export interface EnrichedGroupData {
   description: string | null;
   members: Array<{ memberId: number; ownername: string }>;
   memberCount: number;
+  ownerName: string | null;
 }
 
 export interface MemberRow {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -56,6 +56,7 @@ export interface MessageHistoryPage {
 
 export interface MessageHistoryQuery {
   senderId?: number;
+  recipientId?: number;
   search?: string;
   channel?: "email" | "sms";
   sort?: "recent" | "oldest";

--- a/test/actions/message-query.test.ts
+++ b/test/actions/message-query.test.ts
@@ -8,7 +8,6 @@ import { mockVerifySession } from "../mocks";
 vi.mock("@/services/message", () => ({
   sendGroupMessage: vi.fn(),
   sendBlastMessage: vi.fn(),
-  getAllMessageHistory: vi.fn(),
   getMessageHistoryPage: vi.fn(),
   getMessageById: vi.fn(),
   getMessageRecipients: vi.fn(),
@@ -20,82 +19,19 @@ vi.mock("@/services/contact-group", () => ({
 }));
 
 import {
-  getAllMessageHistory,
   getMessageHistoryPage,
   getMessageById,
   getMessageRecipients,
   previewRecipientCounts,
 } from "@/services/message";
 import { isGroupOwner } from "@/services/contact-group";
-import {
-  fetchMessageHistory,
-  fetchMessageHistoryPage,
-  fetchMessageDetail,
-  fetchRecipientPreview,
-} from "@/actions/contact-group";
+import { fetchMessageHistoryPage, fetchMessageDetail, fetchRecipientPreview } from "@/actions/contact-group";
 
-const mockGetAllMessageHistory = getAllMessageHistory as MockedFunction<typeof getAllMessageHistory>;
 const mockGetMessageHistoryPage = getMessageHistoryPage as MockedFunction<typeof getMessageHistoryPage>;
 const mockGetMessageById = getMessageById as MockedFunction<typeof getMessageById>;
 const mockGetMessageRecipients = getMessageRecipients as MockedFunction<typeof getMessageRecipients>;
 const mockPreviewRecipientCounts = previewRecipientCounts as MockedFunction<typeof previewRecipientCounts>;
 const mockIsGroupOwner = isGroupOwner as MockedFunction<typeof isGroupOwner>;
-
-describe("fetchMessageHistory", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("returns all messages for admin", async () => {
-    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
-    const messages = [
-      {
-        id: 1,
-        subject: "Test",
-        body: "Test body content",
-        sentAt: new Date(),
-        emailCount: 5,
-        smsCount: 0,
-        failedCount: 0,
-        isBlast: false,
-        groupNames: ["Garden Club"],
-      },
-    ];
-    mockGetAllMessageHistory.mockResolvedValue(messages);
-
-    const result = await fetchMessageHistory({});
-
-    expect(result).toEqual({ success: true, data: messages });
-    expect(mockGetAllMessageHistory).toHaveBeenCalledWith({ senderId: undefined });
-  });
-
-  it("filters by senderId for non-admin member", async () => {
-    mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
-    mockGetAllMessageHistory.mockResolvedValue([]);
-
-    await fetchMessageHistory({});
-
-    expect(mockGetAllMessageHistory).toHaveBeenCalledWith({ senderId: 100003 });
-  });
-
-  it("passes channel filter through", async () => {
-    mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
-    mockGetAllMessageHistory.mockResolvedValue([]);
-
-    await fetchMessageHistory({ channel: "email" });
-
-    expect(mockGetAllMessageHistory).toHaveBeenCalledWith(expect.objectContaining({ channel: "email" }));
-  });
-
-  it("returns error when not authenticated", async () => {
-    mockVerifySession.mockRejectedValue(new AppError("UNAUTHORIZED", "Authentication required"));
-
-    const result = await fetchMessageHistory({});
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Authentication required");
-  });
-});
 
 describe("fetchMessageDetail", () => {
   beforeEach(() => {
@@ -222,23 +158,23 @@ describe("fetchMessageHistoryPage", () => {
     vi.clearAllMocks();
   });
 
-  it("returns paginated messages for admin without senderId filter", async () => {
+  it("returns paginated messages for admin without role filter", async () => {
     mockVerifySession.mockResolvedValue({ ownerid: 100001, isAdmin: true });
     mockGetMessageHistoryPage.mockResolvedValue(mockPage);
 
     const result = await fetchMessageHistoryPage({});
 
     expect(result).toEqual({ success: true, data: mockPage });
-    expect(mockGetMessageHistoryPage).toHaveBeenCalledWith({ senderId: undefined });
+    expect(mockGetMessageHistoryPage).toHaveBeenCalledWith({});
   });
 
-  it("filters by senderId for non-admin member", async () => {
+  it("filters by recipientId for non-admin member", async () => {
     mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
     mockGetMessageHistoryPage.mockResolvedValue(mockPage);
 
     await fetchMessageHistoryPage({});
 
-    expect(mockGetMessageHistoryPage).toHaveBeenCalledWith({ senderId: 100003 });
+    expect(mockGetMessageHistoryPage).toHaveBeenCalledWith({ recipientId: 100003 });
   });
 
   it("rejects invalid pageSize via Zod", async () => {


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Three access control gaps fixed. Members saw all groups they belonged to instead of only groups they own. The messages page filtered by senderId for members, so they only saw messages they sent rather than messages they received. The channel filter dropdown (All/Email/SMS) rendered even when SMS_ENABLED=false.

- `src/app/(protected)/groups/page.tsx` - switched from getGroupsByMembership to getGroupsByOwner for the member query
- `src/app/(protected)/groups/groups-content.tsx` - added My Groups / All Groups segmented control for admins, added ownerName to fuzzy search keys via client-side Map from existing members data
- `src/app/(protected)/groups/[id]/page.tsx` - resolves group ownerid to owner name via getMemberById
- `src/app/(protected)/groups/[id]/group-detail-content.tsx` - shows "Created by [name]" for admins on the detail page
- `src/types/group.ts` - added ownerName to EnrichedGroupData
- `src/components/groups/use-groups-modal.ts` - added ownerName to EMPTY_GROUP
- `src/app/(protected)/messages/page.tsx` - members filter by recipientId instead of senderId, added smsFeatureEnabled prop from env
- `src/app/(protected)/messages/messages-content.tsx` - channel filter hidden when SMS disabled, replaced eslint-disable with useEffectEvent for debounced search
- `src/services/message.ts` - added recipientId to where clause builder, fixed filter merge logic for combined recipientId + channel queries
- `src/types/message.ts` - added recipientId to MessageHistoryQuery
- `src/actions/contact-group.ts` - removed dead fetchMessageHistory action, removed unused getAllMessageHistory import, member pagination uses recipientId
- `src/services/contact-group.ts` - removed dead getGroupsByMembership function
- `src/components/groups/.gitkeep` - deleted, directory has real files
- `test/actions/message-query.test.ts` - removed dead fetchMessageHistory tests, updated member filter assertion to recipientId

## How to test

1. Log in as member, visit /groups - only groups the member owns appear, no segmented control
2. Log in as admin, visit /groups - "My Groups" shows owned groups, "All Groups" shows everything, segmented control visible
3. Log in as admin, visit /groups/[id] - "Created by [name]" appears below description
4. Search for a member name in the groups search bar (admin) - groups created by that person appear
5. Log in as member, visit /messages - messages the member received appear (not messages they sent)
6. Log in as admin, visit /messages - all messages appear
7. Set SMS_ENABLED=false in .env.local, restart dev server, visit /messages - channel filter dropdown is hidden

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers