### PR TITLE
fix: unauthorized/forbidden pages, auth validation hardening, CSRF gap

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,97 +1,124 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Unauthenticated access to protected routes", () => {
-  test("/groups without auth redirects or errors", async ({ page }) => {
-    const response = await page.goto("/groups");
+const PROTECTED_PAGES = [
+  "/home",
+  "/groups",
+  "/events",
+  "/messages",
+  "/messages/compose",
+  "/settings",
+  "/profile",
+  "/referral-database",
+];
 
-    const url = page.url();
-    const status = response?.status() ?? 0;
-    const isRedirected = !url.includes("/groups");
-    const isErrorStatus = status >= 400;
-    expect(isRedirected || isErrorStatus).toBe(true);
+test.describe("Unauthenticated access to protected pages", () => {
+  for (const path of PROTECTED_PAGES) {
+    test(`${path} without cookie redirects to /unauthorized`, async ({ page }) => {
+      await page.goto(path);
+
+      expect(page.url()).toContain("/unauthorized");
+      await expect(page.getByText("Sign in required")).toBeVisible();
+    });
+  }
+});
+
+test.describe("Unauthenticated API access", () => {
+  test("GET /api/members returns 401", async ({ request }) => {
+    const response = await request.get("/api/members");
+    expect(response.status()).toBe(401);
   });
 
-  test("/settings without auth redirects or errors", async ({ page }) => {
-    const response = await page.goto("/settings");
-
-    const url = page.url();
-    const status = response?.status() ?? 0;
-    const isRedirected = !url.includes("/settings");
-    const isErrorStatus = status >= 400;
-    expect(isRedirected || isErrorStatus).toBe(true);
+  test("GET /api/members/100001 returns 401", async ({ request }) => {
+    const response = await request.get("/api/members/100001");
+    expect(response.status()).toBe(401);
   });
 
-  test("/events without auth redirects or errors", async ({ page }) => {
-    const response = await page.goto("/events");
-
-    const url = page.url();
-    const status = response?.status() ?? 0;
-    const isRedirected = !url.includes("/events");
-    const isErrorStatus = status >= 400;
-    expect(isRedirected || isErrorStatus).toBe(true);
+  test("GET /api/referrals returns 401", async ({ request }) => {
+    const response = await request.get("/api/referrals");
+    expect(response.status()).toBe(401);
   });
 
-  test("/messages without auth redirects or errors", async ({ page }) => {
-    const response = await page.goto("/messages");
+  test("PATCH /api/referrals/1 returns 401", async ({ request }) => {
+    const response = await request.patch("/api/referrals/1", { data: { redeemed: true } });
+    expect(response.status()).toBe(401);
+  });
 
-    const url = page.url();
-    const status = response?.status() ?? 0;
-    const isRedirected = !url.includes("/messages");
-    const isErrorStatus = status >= 400;
-    expect(isRedirected || isErrorStatus).toBe(true);
+  test("DELETE /api/referrals/1 returns 401", async ({ request }) => {
+    const response = await request.delete("/api/referrals/1");
+    expect(response.status()).toBe(401);
   });
 });
 
-test.describe("Auth callback edge cases", () => {
-  test("invalid token in auth callback redirects to /", async ({ page }) => {
-    // Submit an invalid token to the auth callback endpoint
-    await page.goto("/dev/mock-portal");
+test.describe("Expired or tampered cookie on protected pages", () => {
+  for (const path of PROTECTED_PAGES) {
+    test(`${path} with invalid cookie redirects to /unauthorized`, async ({ page, context }) => {
+      await context.addCookies([{ name: "prfc_auth", value: "tampered|0|0|bad", domain: "localhost", path: "/" }]);
+      await page.goto(path);
 
-    // Use page.evaluate to POST directly with an invalid token
-    const response = await page.request.post("/api/auth/callback", {
+      expect(page.url()).toContain("/unauthorized");
+      await expect(page.getByText("Sign in required")).toBeVisible();
+    });
+  }
+});
+
+test.describe("Forbidden access for non-admin members", () => {
+  test("/referral-database redirects member to /forbidden", async ({ page }) => {
+    await page.goto("/dev/mock-portal");
+    await page.getByText("Dev Tools").click();
+    await page.getByLabel("Select Member").selectOption("100003");
+    await page.getByRole("button", { name: "Login" }).click();
+    await page.waitForURL("/home");
+
+    await page.goto("/referral-database");
+
+    expect(page.url()).toContain("/forbidden");
+    await expect(page.getByText("No permission")).toBeVisible();
+  });
+});
+
+test.describe("Invalid auth token", () => {
+  test("auth callback with bad token redirects to /", async ({ request }) => {
+    const response = await request.post("/api/auth/callback", {
       form: { token: "invalid-token-value" },
       maxRedirects: 0,
     });
 
-    // Should redirect to / (302 with Location: /)
+    expect(response.status()).toBe(307);
+    expect(response.headers()["location"]).toContain("/");
+  });
+
+  test("auth callback with empty token redirects to /", async ({ request }) => {
+    const response = await request.post("/api/auth/callback", {
+      form: { token: "" },
+      maxRedirects: 0,
+    });
+
     expect(response.status()).toBe(307);
     expect(response.headers()["location"]).toContain("/");
   });
 });
 
 test.describe("Back after logout", () => {
-  test("browser back after logout does not show protected content", async ({ page }) => {
-    // Log in first via the inline flow
+  test("navigating to protected page after logout does not show protected content", async ({ page }) => {
     await page.goto("/dev/mock-portal");
     await page.getByText("Dev Tools").click();
     await page.getByLabel("Select Member").selectOption("100001");
     await page.getByRole("button", { name: "Login" }).click();
     await page.waitForURL("/home");
 
-    // Verify we're on a protected page
     await expect(page.getByLabel("User menu")).toBeVisible();
 
-    // Log out via the user menu
     await page.getByLabel("User menu").click();
-    await expect(page.getByRole("menuitem", { name: "Sign out" })).toBeVisible();
-    await page.getByRole("menuitem", { name: "Sign out" }).click();
+    await expect(page.getByRole("menuitem", { name: "Back to Portal" })).toBeVisible();
+    await page.getByRole("menuitem", { name: "Back to Portal" }).click();
     await expect(page).toHaveURL("/dev/mock-portal");
 
-    // Go back — should not show protected content
-    await page.goBack();
-
-    // Either redirected away from /home, or the page shows error/login, not protected content
+    const response = await page.goto("/home");
+    const status = response?.status() ?? 0;
     const url = page.url();
-    if (url.includes("/home")) {
-      // If the browser cache shows /home, the user menu should not be functional
-      // (server will reject the session on next navigation)
-      const response = await page.goto("/home");
-      const finalUrl = page.url();
-      const status = response?.status() ?? 0;
-      const isRedirected = !finalUrl.includes("/home");
-      const isErrorStatus = status >= 400;
-      expect(isRedirected || isErrorStatus).toBe(true);
-    }
-    // If URL is not /home, the redirect already worked
+
+    const isRedirected = !url.includes("/home");
+    const isErrorStatus = status >= 400;
+    expect(isRedirected || isErrorStatus).toBe(true);
   });
 });

--- a/src/app/(protected)/error.tsx
+++ b/src/app/(protected)/error.tsx
@@ -10,20 +10,19 @@ export default function ProtectedError({ error, reset }: { error: Error & { dige
 
   return (
     <div className="flex min-h-[50vh] items-center justify-center">
-      <div className="text-center px-4">
-        <h1 className="font-komika text-prfc-red text-4xl mb-4">Database Error</h1>
-        <p className="font-montserrat text-prfc-dark-brown mb-6">Failed to load referral database.</p>
-        <div className="flex gap-4 justify-center">
+      <div className="px-4 text-center">
+        <h1 className="font-angkor text-4xl text-prfc-red">Something went wrong</h1>
+        <p className="mt-4 text-muted-foreground">
+          An unexpected error occurred. Try again or return to the dashboard.
+        </p>
+        <div className="mt-6 flex justify-center gap-4">
           <button
             onClick={reset}
-            className="bg-prfc-red text-white px-6 py-3 rounded font-montserrat hover:bg-prfc-brown transition-colors"
+            className="rounded-lg bg-prfc-red px-6 py-3 font-medium text-white hover:bg-prfc-red/90"
           >
             Try again
           </button>
-          <Link
-            href="/home"
-            className="bg-prfc-border text-white px-6 py-3 rounded font-montserrat hover:bg-prfc-dark-brown transition-colors"
-          >
+          <Link href="/home" className="rounded-lg bg-prfc-border px-6 py-3 font-medium text-white hover:bg-prfc-brown">
             Go home
           </Link>
         </div>

--- a/src/app/(protected)/events/events-content.tsx
+++ b/src/app/(protected)/events/events-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { toast } from "sonner";
@@ -127,7 +128,7 @@ export function EventsContent({
       if (result.success && result.data) {
         setMonthEvents(parseEvents(result.data));
       } else if (!result.success) {
-        toast.error(result.error ?? "Failed to load events");
+        toast.error(handleActionError(result.error, "Failed to load events"));
       }
     });
   }, [view, currentDate, groupFilter, typeFilter]);
@@ -138,7 +139,7 @@ export function EventsContent({
       if (result.success && result.data) {
         setWeekEvents(parseEvents(result.data));
       } else if (!result.success) {
-        toast.error(result.error ?? "Failed to load events");
+        toast.error(handleActionError(result.error, "Failed to load events"));
       }
     });
   };
@@ -152,7 +153,7 @@ export function EventsContent({
       if (result.success && result.data) {
         setMonthEvents(parseEvents(result.data));
       } else if (!result.success) {
-        toast.error(result.error ?? "Failed to load events");
+        toast.error(handleActionError(result.error, "Failed to load events"));
       }
     });
   };
@@ -205,7 +206,7 @@ export function EventsContent({
         setCreateDefaultDate(undefined);
         setCreateOpen(true);
       } else if (!result.success) {
-        toast.error(result.error ?? "Failed to load event details");
+        toast.error(handleActionError(result.error, "Failed to load event details"));
       }
     });
   };

--- a/src/app/(protected)/groups/[id]/group-detail-content.tsx
+++ b/src/app/(protected)/groups/[id]/group-detail-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -102,7 +103,7 @@ export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAd
         setAddMembersOpen(false);
         router.refresh();
       } else {
-        toast.error(result.error ?? "Failed to add members");
+        toast.error(handleActionError(result.error, "Failed to add members"));
       }
     });
   };
@@ -117,6 +118,7 @@ export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAd
       const results = await Promise.all(Array.from(removedIds).map((memberId) => removeMember(group.id, memberId)));
       const failures = results.filter((r) => !r.success);
       if (failures.length > 0) {
+        handleActionError(failures[0].error, "");
         toast.error(`Failed to remove ${failures.length} member(s)`);
       } else {
         toast.success(`Removed ${removedIds.size} member(s)`);

--- a/src/app/(protected)/groups/[id]/page.tsx
+++ b/src/app/(protected)/groups/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { verifySession } from "@/lib/dal";
 import { getGroupById, enrichGroupMembers, isGroupOwner } from "@/services/contact-group";
 import { getAllMembers, getMemberById } from "@/lib/api/member-api";
@@ -21,7 +21,7 @@ export default async function GroupDetailPage({ params }: { params: Promise<{ id
   if (isNaN(groupId) || groupId <= 0) notFound();
 
   const session = await verifySession();
-  if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) notFound();
+  if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) redirect("/forbidden");
 
   const [enriched, allMembers] = await Promise.all([loadGroup(groupId), getAllMembers()]);
   const owner = await getMemberById(enriched.ownerid);

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,5 +1,7 @@
+import { redirect } from "next/navigation";
 import { getSessionWithName } from "@/lib/dal";
 import { getUnseenNotificationCount, getLastNotificationSeenAt } from "@/services/dashboard";
+import { AppError } from "@/utils/errors";
 import { TopBarActionProvider } from "@/components/layout/top-bar-action-context";
 import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
 import { SidebarProvider } from "@/components/layout/sidebar-context";
@@ -8,7 +10,15 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { LayoutContent } from "./layout-content";
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
-  const session = await getSessionWithName();
+  let session;
+  try {
+    session = await getSessionWithName();
+  } catch (error) {
+    if (error instanceof AppError && error.code === "UNAUTHORIZED") {
+      redirect("/unauthorized");
+    }
+    throw error;
+  }
   const userRole = session.isAdmin ? "Admin Manager" : "Member";
   const [unseenCount, lastSeenAt] = await Promise.all([
     getUnseenNotificationCount(session.ownerid),

--- a/src/app/(protected)/messages/compose/compose-content.tsx
+++ b/src/app/(protected)/messages/compose/compose-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -49,7 +50,7 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
             channels: { email: data.sendEmail, sms: data.sendSms },
           });
         } else {
-          toast.error(result.error ?? "Failed to send message");
+          toast.error(handleActionError(result.error, "Failed to send message"));
         }
       } else {
         if (data.groupIds.length === 0) {
@@ -69,7 +70,7 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
             channels: { email: data.sendEmail, sms: data.sendSms },
           });
         } else {
-          toast.error(result.error ?? "Failed to send message");
+          toast.error(handleActionError(result.error, "Failed to send message"));
         }
       }
     });

--- a/src/app/(protected)/messages/messages-content.tsx
+++ b/src/app/(protected)/messages/messages-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useEffect, useEffectEvent, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { Plus, Search } from "lucide-react";
@@ -47,7 +48,7 @@ function useMessagePagination(initialPage: MessageHistoryPage) {
       if (result.success && result.data) {
         setPage(result.data);
       } else {
-        toast.error(result.error ?? "Failed to load messages");
+        toast.error(handleActionError(result.error, "Failed to load messages"));
       }
     });
   };
@@ -136,7 +137,7 @@ export function MessagesContent({ initialPage, smsFeatureEnabled }: Props) {
       if (result.success && result.data) {
         setViewModal({ message: result.data.message, recipients: result.data.recipients });
       } else {
-        toast.error(result.error ?? "Failed to load message details");
+        toast.error(handleActionError(result.error, "Failed to load message details"));
       }
     });
   };

--- a/src/app/(protected)/profile/profile-content.tsx
+++ b/src/app/(protected)/profile/profile-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ProfilePhotoUpload } from "@/components/profile/profile-photo-upload";
@@ -28,7 +29,7 @@ export function ProfileContent({ profile, photoUrl, userName, isAdmin }: Props) 
       setCurrentPhotoUrl(result.data.url);
       toast.success("Photo updated");
     } else {
-      toast.error(result.error ?? "Failed to upload photo");
+      toast.error(handleActionError(result.error, "Failed to upload photo"));
     }
   };
 

--- a/src/app/(protected)/referral-database/page.tsx
+++ b/src/app/(protected)/referral-database/page.tsx
@@ -1,6 +1,11 @@
+import { redirect } from "next/navigation";
+import { verifySession } from "@/lib/dal";
 import { ReferralDataGrid } from "@/components/referral/referral-data-grid";
 
-export default function ReferralDatabasePage() {
+export default async function ReferralDatabasePage() {
+  const session = await verifySession();
+  if (!session.isAdmin) redirect("/forbidden");
+
   return (
     <div>
       <h1 className="font-komika text-[2rem] text-[#333] mb-4">Referral History</h1>

--- a/src/app/(protected)/settings/settings-content.tsx
+++ b/src/app/(protected)/settings/settings-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useState } from "react";
 import { toast } from "sonner";
 import { NotificationPreferencesCard } from "@/components/settings/notification-preferences-card";
@@ -28,7 +29,7 @@ export function SettingsContent({ preferences, smsConsent, phone, smsFeatureEnab
     } else {
       if (key === "notifyEmailDefault") setEmailEnabled(!value);
       else setSmsEnabled(!value);
-      toast.error(result.error ?? "Failed to update preferences");
+      toast.error(handleActionError(result.error, "Failed to update preferences"));
     }
   };
 

--- a/src/app/(public)/forbidden/page.tsx
+++ b/src/app/(public)/forbidden/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "No Permission | PRFC Connect",
+};
+
+export default function ForbiddenPage() {
+  return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center px-4 text-center">
+      <h1 className="font-angkor text-3xl text-prfc-brown sm:text-4xl">No permission</h1>
+      <p className="mt-4 max-w-md text-lg text-muted-foreground">
+        You don't have access to this page. Contact an admin if you think this is a mistake.
+      </p>
+      <Link
+        href="/home"
+        className="mt-8 rounded-lg bg-prfc-red px-8 py-3 text-lg font-medium text-white hover:bg-prfc-red/90"
+      >
+        Go to Dashboard
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(public)/unauthorized/page.tsx
+++ b/src/app/(public)/unauthorized/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Sign In Required | PRFC Connect",
+};
+
+export default function UnauthorizedPage() {
+  return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center px-4 text-center">
+      <h1 className="font-angkor text-3xl text-prfc-brown sm:text-4xl">Sign in required</h1>
+      <p className="mt-4 max-w-md text-lg text-muted-foreground">
+        Paso Robles Food Co-op Connect requires authentication. Sign in through the member portal to continue.
+      </p>
+      <Link
+        href="/dev/mock-portal"
+        className="mt-8 rounded-lg bg-prfc-red px-8 py-3 text-lg font-medium text-white hover:bg-prfc-red/90"
+      >
+        Sign in with Member Portal
+      </Link>
+    </div>
+  );
+}

--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -6,6 +6,8 @@ import { AppError, apiErrorHandler } from "@/utils/errors";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    await verifySession();
+
     if (membersRateLimiter) {
       const forwarded = req.headers.get("x-forwarded-for");
       const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
@@ -24,8 +26,6 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         );
       }
     }
-
-    await verifySession();
 
     const { id } = await params;
 

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -6,6 +6,8 @@ import { apiErrorHandler } from "@/utils/errors";
 
 export async function GET(req: NextRequest) {
   try {
+    await verifySession();
+
     if (membersRateLimiter) {
       const forwarded = req.headers.get("x-forwarded-for");
       const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
@@ -24,8 +26,6 @@ export async function GET(req: NextRequest) {
         );
       }
     }
-
-    await verifySession();
 
     const members = await getAllMembers();
 

--- a/src/app/api/referrals/[id]/route.ts
+++ b/src/app/api/referrals/[id]/route.ts
@@ -7,11 +7,11 @@ import { AppError, apiErrorHandler } from "@/utils/errors";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    await requireAdmin();
+
     if (!validateOrigin(req)) {
       return NextResponse.json({ error: { code: "FORBIDDEN", message: "Invalid origin" } }, { status: 403 });
     }
-
-    await requireAdmin();
 
     const { id } = await params;
     if (!/^\d+$/.test(id)) {
@@ -29,9 +29,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   }
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     await requireAdmin();
+
+    if (!validateOrigin(req)) {
+      return NextResponse.json({ error: { code: "FORBIDDEN", message: "Invalid origin" } }, { status: 403 });
+    }
 
     const { id } = await params;
     if (!/^\d+$/.test(id)) {

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -13,11 +13,11 @@ export async function POST(req: NextRequest) {
   const idempotencyKey = req.headers.get("idempotency-key");
 
   try {
+    await verifySession();
+
     if (!validateOrigin(req)) {
       return NextResponse.json({ error: { code: "FORBIDDEN", message: "Invalid origin" } }, { status: 403 });
     }
-
-    await verifySession();
 
     if (idempotencyKey) {
       const cached = await getIdempotentResponse(idempotencyKey);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,24 +1,33 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 
-export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+export default function RootError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     console.error(error);
   }, [error]);
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-prfc-tan">
-      <div className="text-center px-4">
-        <h1 className="font-komika text-prfc-red text-4xl mb-4">Something went wrong</h1>
-        <p className="font-montserrat text-prfc-dark-brown mb-6">An error occurred. Try refreshing the page.</p>
+    <div className="fixed inset-0 flex flex-col items-center justify-center px-4 text-center">
+      <h1 className="font-angkor text-3xl text-prfc-brown sm:text-4xl">Something went wrong</h1>
+      <p className="mt-4 max-w-md text-lg text-muted-foreground">
+        An unexpected error occurred. Try again or return to the dashboard.
+      </p>
+      <div className="mt-8 flex gap-4">
         <button
           onClick={reset}
-          className="bg-prfc-red text-white px-6 py-3 rounded font-montserrat hover:bg-prfc-brown transition-colors"
+          className="rounded-lg bg-prfc-red px-8 py-3 text-lg font-medium text-white hover:bg-prfc-red/90"
         >
           Try again
         </button>
+        <Link
+          href="/home"
+          className="rounded-lg border border-border px-8 py-3 text-lg font-medium text-foreground hover:bg-muted"
+        >
+          Go to Dashboard
+        </Link>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -2,15 +2,17 @@
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
-    <html>
-      <body className="min-h-screen flex items-center justify-center bg-gray-100">
-        <div className="text-center px-4">
-          <h1 className="text-red-600 text-4xl mb-4 font-bold">Something went wrong</h1>
-          <p className="text-gray-700 mb-6">An unexpected error occurred. Please try again.</p>
-          {error.digest && <p className="text-gray-500 text-sm mb-4">Error ID: {error.digest}</p>}
+    <html lang="en">
+      <body>
+        <div className="fixed inset-0 flex flex-col items-center justify-center px-4 text-center">
+          <h1 className="text-3xl font-bold text-red-700 sm:text-4xl">Something went wrong</h1>
+          <p className="mt-4 max-w-md text-lg text-gray-600">
+            An unexpected error occurred. Try again or reload the page.
+          </p>
+          {error.digest && <p className="mt-2 text-sm text-gray-400">Error ID: {error.digest}</p>}
           <button
             onClick={reset}
-            className="bg-red-600 text-white px-6 py-3 rounded hover:bg-red-700 transition-colors"
+            className="mt-8 rounded-lg bg-red-700 px-8 py-3 text-lg font-medium text-white hover:bg-red-800"
           >
             Try again
           </button>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,20 +2,15 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-prfc-tan">
-      <div className="text-center px-4">
-        <h1 className="font-komika text-prfc-red text-6xl mb-2">404</h1>
-        <h2 className="font-komika text-prfc-brown text-2xl mb-4">Page not found</h2>
-        <p className="font-montserrat text-prfc-dark-brown mb-6">
-          The page you're looking for doesn't exist or has been moved.
-        </p>
-        <Link
-          href="/"
-          className="bg-prfc-red text-white px-6 py-3 rounded font-montserrat hover:bg-prfc-brown transition-colors inline-block"
-        >
-          Go home
-        </Link>
-      </div>
-    </main>
+    <div className="fixed inset-0 flex flex-col items-center justify-center px-4 text-center">
+      <h1 className="font-angkor text-3xl text-prfc-brown sm:text-4xl">Page not found</h1>
+      <p className="mt-4 max-w-md text-lg text-muted-foreground">This page doesn't exist or has been removed.</p>
+      <Link
+        href="/home"
+        className="mt-8 rounded-lg bg-prfc-red px-8 py-3 text-lg font-medium text-white hover:bg-prfc-red/90"
+      >
+        Go to Dashboard
+      </Link>
+    </div>
   );
 }

--- a/src/components/events/create-event-popover.tsx
+++ b/src/components/events/create-event-popover.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { Clock, MapPin, CalendarCheck, List, Loader2, Trash2 } from "lucide-react";
+import { handleActionError } from "@/utils/auth-redirect";
 import { toast } from "sonner";
 import {
   AlertDialog,
@@ -173,7 +174,7 @@ export function CreateEventPopover({
           onSaved?.(editingEvent.id);
           onClose();
         } else {
-          const message = result.error ?? "Failed to update event";
+          const message = handleActionError(result.error, "Failed to update event");
           toast.error(message);
           setError(message);
         }
@@ -196,7 +197,7 @@ export function CreateEventPopover({
         onSaved?.(result.data!.id);
         onClose();
       } else {
-        const message = result.error ?? "Failed to create event";
+        const message = handleActionError(result.error, "Failed to create event");
         toast.error(message);
         setError(message);
       }
@@ -213,7 +214,7 @@ export function CreateEventPopover({
         setConfirmDeleteOpen(false);
         onClose();
       } else {
-        const message = result.error ?? "Failed to delete event";
+        const message = handleActionError(result.error, "Failed to delete event");
         toast.error(message);
         setError(message);
         setConfirmDeleteOpen(false);

--- a/src/components/groups/use-groups-modal.ts
+++ b/src/components/groups/use-groups-modal.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { handleActionError } from "@/utils/auth-redirect";
 import { useCallback, useState, useTransition } from "react";
 import { toast } from "sonner";
 
@@ -61,7 +62,7 @@ export function useGroupsModal(ownerId: number) {
       if (result.success && result.data) {
         setModal({ type: "detail", group: result.data });
       } else {
-        toast.error(result.error ?? "Failed to load group details");
+        toast.error(handleActionError(result.error, "Failed to load group details"));
       }
     });
   }, []);
@@ -80,7 +81,7 @@ export function useGroupsModal(ownerId: number) {
       if (result.success && result.data) {
         setModal({ type: "edit", group: result.data });
       } else {
-        toast.error(result.error ?? "Failed to load group details");
+        toast.error(handleActionError(result.error, "Failed to load group details"));
       }
     });
   }, []);
@@ -93,7 +94,7 @@ export function useGroupsModal(ownerId: number) {
       if (result.success && result.data) {
         setModal({ type: "delete", group: result.data });
       } else {
-        toast.error(result.error ?? "Failed to load group details");
+        toast.error(handleActionError(result.error, "Failed to load group details"));
       }
     });
   }, []);
@@ -109,7 +110,7 @@ export function useGroupsModal(ownerId: number) {
           toast.success("Group updated successfully");
           setModal({ type: "closed" });
         } else {
-          toast.error(result.error ?? "Failed to update group");
+          toast.error(handleActionError(result.error, "Failed to update group"));
         }
       });
     },
@@ -132,7 +133,7 @@ export function useGroupsModal(ownerId: number) {
         toast.success("Group deleted successfully");
         setModal({ type: "closed" });
       } else {
-        toast.error(result.error ?? "Failed to delete group");
+        toast.error(handleActionError(result.error, "Failed to delete group"));
       }
     });
   }, [modal]);
@@ -239,7 +240,7 @@ export function useGroupsModal(ownerId: number) {
         toast.success("Group created successfully");
         setModal({ type: "closed" });
       } else {
-        toast.error(result.error ?? "Failed to create group");
+        toast.error(handleActionError(result.error, "Failed to create group"));
       }
     });
   }, []);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,26 +7,15 @@ interface HeaderProps {
 
 export function Header({ className }: HeaderProps) {
   return (
-    <header
-      className={cn(
-        "w-full bg-white flex items-center justify-start px-[5vh] py-[5vh]",
-        "h-[8vw] shadow-[0_1px_3px_rgba(0,0,0,0.1)]",
-        "max-md:h-auto max-md:px-5 max-md:py-[60px] max-md:shadow-none",
-        "max-md:bg-[linear-gradient(rgba(255,255,255,0.5),rgba(255,255,255,0.5)),url('/assets/produce.jpg')]",
-        "max-md:bg-[length:100%_auto] max-md:bg-no-repeat max-md:bg-center",
-        className,
-      )}
-    >
-      <div className="flex items-center max-md:w-full">
-        <Image
-          src="/assets/logo.png"
-          alt="Paso Robles Food Co-op Logo"
-          className={cn("h-[4vw] min-h-[60px] w-auto", "max-md:h-auto max-md:max-h-[50px] max-md:w-auto")}
-          width={120}
-          height={60}
-          priority
-        />
-      </div>
+    <header className={cn("flex h-16 w-full items-center border-b border-border bg-paso-grey px-6", className)}>
+      <Image
+        src="/assets/logo.png"
+        alt="Paso Robles Food Co-op Logo"
+        className="h-10 w-auto"
+        width={140}
+        height={48}
+        priority
+      />
     </header>
   );
 }

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -48,10 +48,10 @@ export function validateToken(token: string, secret: string): Session | null {
   if (!verifyHmac(payload, signature, secret)) return null;
 
   const tokenTime = parseInt(timestamp, 10);
-  if (isNaN(tokenTime) || Date.now() - tokenTime > TOKEN_EXPIRY_MS) return null;
+  if (isNaN(tokenTime) || tokenTime > Date.now() || Date.now() - tokenTime > TOKEN_EXPIRY_MS) return null;
 
   const parsedOwnerId = parseInt(ownerid, 10);
-  if (isNaN(parsedOwnerId)) return null;
+  if (isNaN(parsedOwnerId) || parsedOwnerId <= 0) return null;
 
   return {
     ownerid: parsedOwnerId,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { timingSafeEqual } from "crypto";
 
 const AUTH_COOKIE = "prfc_auth";
-const PROTECTED_PATHS = ["/referral-database", "/groups"];
+const PROTECTED_PATHS = ["/home", "/groups", "/events", "/messages", "/settings", "/profile", "/referral-database"];
 
 function isBasicAuthValid(request: NextRequest): boolean {
   const authHeader = request.headers.get("authorization");
@@ -44,7 +44,7 @@ export async function proxy(request: NextRequest) {
   if (isProtectedPath) {
     const hasSession = request.cookies.get(AUTH_COOKIE);
     if (!hasSession?.value) {
-      return NextResponse.redirect(new URL("/", request.url));
+      return NextResponse.redirect(new URL("/unauthorized", request.url));
     }
   }
 

--- a/src/utils/auth-redirect.ts
+++ b/src/utils/auth-redirect.ts
@@ -1,0 +1,10 @@
+export function handleActionError(
+  error: string | undefined,
+  fallback: string = "An unexpected error occurred",
+): string {
+  if (error === "Authentication required" || error === "Invalid or expired token") {
+    window.location.href = "/unauthorized";
+    return "";
+  }
+  return error ?? fallback;
+}

--- a/test/auth/auth-flow.test.ts
+++ b/test/auth/auth-flow.test.ts
@@ -97,6 +97,25 @@ describe("validateToken", () => {
   it("rejects token with empty fields", () => {
     expect(validateToken("||1234|abcd1234", SECRET)).toBeNull();
   });
+
+  it("rejects token with future timestamp", () => {
+    const futureTimestamp = Date.now() + 60000;
+    const token = createToken(100001, true, futureTimestamp);
+
+    expect(validateToken(token, SECRET)).toBeNull();
+  });
+
+  it("rejects token with zero ownerid", () => {
+    const token = createToken(0, false, Date.now());
+
+    expect(validateToken(token, SECRET)).toBeNull();
+  });
+
+  it("rejects token with negative ownerid", () => {
+    const token = createToken(-1, false, Date.now());
+
+    expect(validateToken(token, SECRET)).toBeNull();
+  });
 });
 
 describe("POST /api/auth/callback", () => {


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Unauthenticated users saw "Database Error" instead of a login prompt. The proxy only covered 2 of 7 protected routes. Token validation accepted future timestamps and non-positive ownerids. The DELETE /api/referrals/[id] handler had no CSRF check.

- `src/proxy.ts` - expanded PROTECTED_PATHS to all 7 protected routes, redirect target changed from / to /unauthorized
- `src/app/(public)/unauthorized/page.tsx` - new page, viewport-centered "Sign in required" with portal link
- `src/app/(public)/forbidden/page.tsx` - new page, "No permission" with dashboard link
- `src/app/(protected)/layout.tsx` - catches UNAUTHORIZED from getSessionWithName and redirects to /unauthorized (handles expired/tampered cookies that pass the proxy)
- `src/app/(protected)/error.tsx` - updated from "Database Error" to generic "Something went wrong"
- `src/app/not-found.tsx` - updated to match new visual style
- `src/app/error.tsx` - updated to match new visual style
- `src/app/global-error.tsx` - updated to match new visual style
- `src/components/layout/header.tsx` - fixed height at 64px (Material Design 3 standard) with bg-paso-grey
- `src/lib/dal.ts` - validateToken rejects future timestamps and ownerid <= 0
- `src/app/api/referrals/[id]/route.ts` - added validateOrigin to DELETE handler, moved auth before CSRF in PATCH
- `src/app/api/members/route.ts` - moved verifySession before rate limiter
- `src/app/api/members/[id]/route.ts` - moved verifySession before rate limiter
- `src/app/api/referrals/route.ts` - moved verifySession before CSRF in POST
- `src/app/(protected)/referral-database/page.tsx` - added server-side admin check, redirects member to /forbidden
- `src/app/(protected)/groups/[id]/page.tsx` - changed notFound to redirect /forbidden for non-owner non-admin
- `src/utils/auth-redirect.ts` - new utility, redirects to /unauthorized on auth errors from server actions
- 10 client files updated to use handleActionError for expired session handling
- `e2e/auth.spec.ts` - 25 tests covering no cookie, tampered cookie, forbidden access, invalid tokens, logout
- `test/auth/auth-flow.test.ts` - 3 new unit tests for future timestamp, zero ownerid, negative ownerid

## How to test

1. Open a private window, visit /home - redirects to /unauthorized with "Sign in required"
2. Log in as member (100003), visit /referral-database - redirects to /forbidden
3. Log in as member, visit /groups/[admin-owned-id] - redirects to /forbidden
4. Tamper with prfc_auth cookie value, refresh - redirects to /unauthorized
5. `curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/members` returns 401
6. `curl -X DELETE -H "Origin: http://evil.com" -b "prfc_auth=..." http://localhost:3000/api/referrals/1` returns 403

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers