### PR TITLE
feat: twilio sms integration, per-recipient tracking, privacy and terms pages

### DIFF
--- a/e2e/messages-compose.spec.ts
+++ b/e2e/messages-compose.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect, type Page } from "@playwright/test";
+
+async function loginAs(page: Page, ownerid: string) {
+  await page.goto("/dev/mock-portal");
+  await page.getByText("Dev Tools").click();
+  await page.getByLabel("Select Member").selectOption(ownerid);
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.waitForURL("/home");
+}
+
+test.describe("Compose message - admin", () => {
+  test("admin can access compose page", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/messages/compose");
+
+    await expect(page.getByText("New Message")).toBeVisible();
+  });
+
+  test("compose page has group picker and channel options", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/messages/compose");
+
+    await expect(page.getByRole("combobox")).toBeVisible();
+    await expect(page.getByText("Email")).toBeVisible();
+  });
+
+  test("send button is visible", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/messages/compose");
+
+    await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  });
+});
+
+test.describe("Compose message - member", () => {
+  test("member can access compose page", async ({ page }) => {
+    await loginAs(page, "100003");
+    await page.goto("/messages/compose");
+
+    await expect(page.getByText("New Message")).toBeVisible();
+  });
+});

--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -236,20 +236,21 @@ export async function sendMessage(input: {
   groupIds: number[];
   subject: string;
   body: string;
+  smsBody?: string;
   sendEmail?: boolean;
   sendSms?: boolean;
 }): Promise<ActionResult<MessageResult>> {
   try {
     const session = await verifySession();
+    const validated = ComposeMessageSchema.parse(input);
 
     if (!session.isAdmin) {
-      const ownerChecks = await Promise.all(input.groupIds.map((gid) => isGroupOwner(gid, session.ownerid)));
+      const ownerChecks = await Promise.all(validated.groupIds.map((gid) => isGroupOwner(gid, session.ownerid)));
       if (ownerChecks.some((isOwner) => !isOwner)) {
         return { success: false, error: "You do not have permission to send messages to one or more selected groups" };
       }
     }
 
-    const validated = ComposeMessageSchema.parse(input);
     const result = await sendGroupMessage(validated, session.ownerid);
 
     return { success: true, data: result };
@@ -262,18 +263,19 @@ export async function sendMessage(input: {
 export async function sendBlast(input: {
   subject: string;
   body: string;
+  smsBody?: string;
   sendEmail?: boolean;
   sendSms?: boolean;
   confirmationText: "SEND TO ALL";
 }): Promise<ActionResult<MessageResult>> {
   try {
     const session = await verifySession();
+    const validated = BlastMessageSchema.parse(input);
 
     if (!session.isAdmin) {
       return { success: false, error: "You do not have permission to send blast messages" };
     }
 
-    const validated = BlastMessageSchema.parse(input);
     const result = await sendBlastMessage(validated, session.ownerid);
 
     return { success: true, data: result };

--- a/src/app/(protected)/messages/compose/compose-content.tsx
+++ b/src/app/(protected)/messages/compose/compose-content.tsx
@@ -40,6 +40,7 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
         const result = await sendBlast({
           subject: data.subject,
           body: data.body,
+          smsBody: data.smsBody,
           sendEmail: data.sendEmail,
           sendSms: data.sendSms,
           confirmationText: "SEND TO ALL",
@@ -61,6 +62,7 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
           groupIds: data.groupIds,
           subject: data.subject,
           body: data.body,
+          smsBody: data.smsBody,
           sendEmail: data.sendEmail,
           sendSms: data.sendSms,
         });

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | PRFC Connect",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="font-angkor text-3xl text-prfc-brown">Privacy policy</h1>
+      <p className="mt-2 text-sm text-muted-foreground">Last updated: May 1, 2026</p>
+
+      <div className="mt-8 space-y-6 text-base leading-relaxed text-foreground">
+        <p>
+          Paso Robles Food Cooperative, Inc. ("the Co-op") operates PRFC Connect, an internal communication tool for
+          co-op members and staff. This policy describes what data the tool collects, how it is used, and how it is
+          protected.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Data collected</h2>
+        <p>
+          PRFC Connect stores member names, email addresses, and phone numbers provided through the co-op's member
+          portal. When a member opts in to SMS notifications, the phone number and the date of consent are recorded. The
+          tool also stores message history, event data, and group membership.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">How data is used</h2>
+        <p>
+          Member contact information is used to deliver event reminders, group messages, and operational notifications.
+          Email addresses are used for email delivery. Phone numbers are used for SMS delivery only when the member has
+          opted in. Message delivery status (sent, failed) is tracked for operational monitoring.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Data sharing</h2>
+        <p>
+          The Co-op does not sell, rent, or share member phone numbers, email addresses, or personal information with
+          third parties for marketing purposes. Contact data is shared only with the service providers that deliver
+          messages on the Co-op's behalf (Resend for email, Twilio for SMS). These providers process data solely to
+          deliver messages and are bound by their own privacy policies.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Data protection</h2>
+        <p>
+          Phone numbers and email addresses in the suppression and consent tables are encrypted at rest using
+          AES-256-GCM. Blind index hashes allow lookups without decrypting stored values. Authentication uses
+          HMAC-signed session tokens transmitted over HTTPS.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Your choices</h2>
+        <p>
+          Members can opt out of email notifications by clicking the unsubscribe link at the bottom of any email.
+          Members can opt out of SMS notifications by replying STOP to any message or toggling the SMS preference off in
+          account settings. Opting out takes effect immediately.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Contact</h2>
+        <p>
+          Paso Robles Food Cooperative, Inc.
+          <br />
+          P.O. Box 922, Paso Robles, CA 93447
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms and Conditions | PRFC Connect",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="font-angkor text-3xl text-prfc-brown">SMS terms and conditions</h1>
+      <p className="mt-2 text-sm text-muted-foreground">Last updated: May 1, 2026</p>
+
+      <div className="mt-8 space-y-6 text-base leading-relaxed text-foreground">
+        <h2 className="font-semibold text-lg text-prfc-brown">Program</h2>
+        <p>
+          Paso Robles Food Cooperative, Inc. ("the Co-op") sends SMS notifications to members through PRFC Connect, an
+          internal communication tool. Messages include event reminders, group messages, and operational notifications.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Message frequency</h2>
+        <p>Up to 8 messages per month. Frequency varies based on co-op events and group activity.</p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Costs</h2>
+        <p>
+          Message and data rates may apply. The Co-op does not charge for SMS notifications, but your mobile carrier may
+          charge standard messaging fees.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Opt-in</h2>
+        <p>
+          Members opt in to SMS notifications by toggling the SMS preference in their PRFC Connect account settings. The
+          opt-in screen displays the following disclosure before consent is recorded: "Up to 8 msgs/month. Msg & data
+          rates may apply. Reply STOP to cancel."
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Opt-out</h2>
+        <p>
+          Reply <strong>STOP</strong> to any message to unsubscribe from all SMS notifications. You can also toggle the
+          SMS preference off in your account settings. Opt-out takes effect immediately.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Help</h2>
+        <p>
+          Reply <strong>HELP</strong> to any message for support information. You can also contact the Co-op directly at
+          the address below.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Privacy</h2>
+        <p>
+          The Co-op does not sell, rent, or share member phone numbers with third parties for marketing purposes. See
+          the full privacy policy at /privacy.
+        </p>
+
+        <h2 className="font-semibold text-lg text-prfc-brown">Contact</h2>
+        <p>
+          Paso Robles Food Cooperative, Inc.
+          <br />
+          P.O. Box 922, Paso Robles, CA 93447
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,6 +24,10 @@ const envSchema = z.object({
     .default("false")
     .transform((v) => v === "true"),
 
+  TWILIO_ACCOUNT_SID: z.string().min(1).optional(),
+  TWILIO_AUTH_TOKEN: z.string().min(1).optional(),
+  TWILIO_FROM_NUMBER: z.string().min(1).optional(),
+
   STAGING: z
     .string()
     .default("false")

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -1,0 +1,28 @@
+import "server-only";
+import twilio from "twilio";
+import { env } from "@/env";
+import { AppError } from "@/utils/errors";
+
+let _client: ReturnType<typeof twilio> | null = null;
+
+function getClient(): ReturnType<typeof twilio> {
+  if (_client) return _client;
+  if (!env.TWILIO_ACCOUNT_SID || !env.TWILIO_AUTH_TOKEN) {
+    throw new AppError("INTERNAL_ERROR", "Twilio credentials are not configured");
+  }
+  _client = twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN);
+  return _client;
+}
+
+export async function sendSms(to: string, body: string): Promise<{ sid: string }> {
+  if (!env.TWILIO_FROM_NUMBER) {
+    throw new AppError("INTERNAL_ERROR", "Twilio from number is not configured");
+  }
+  const client = getClient();
+  const message = await client.messages.create({
+    to,
+    from: env.TWILIO_FROM_NUMBER,
+    body,
+  });
+  return { sid: message.sid };
+}

--- a/src/schema/contact-group.ts
+++ b/src/schema/contact-group.ts
@@ -47,12 +47,13 @@ export const BaseMessageSchema = z
   .object({
     subject: z.string().min(1).max(200),
     body: z.string().min(1).max(5000),
+    smsBody: z.string().min(1).max(160).optional(),
     sendEmail: z.boolean().default(true),
     sendSms: z.boolean().default(false),
   })
-  .refine((data) => !data.sendSms || data.body.length <= 160, {
-    message: "SMS messages must be 160 characters or fewer",
-    path: ["body"],
+  .refine((data) => !data.sendSms || !!data.smsBody, {
+    message: "SMS body is required when sending text messages",
+    path: ["smsBody"],
   });
 
 export const ComposeMessageSchema = BaseMessageSchema.extend({

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { Resend } from "resend";
 import type { Prospect } from "@/schema/referral";
 import { AppError } from "@/utils/errors";
+import type { RecipientSendResult } from "@/types/message";
 import { env } from "@/env";
 import { generateUnsubscribeToken } from "@/lib/unsubscribe-tokens";
 import { filterSuppressedEmails } from "./email-suppression";
@@ -27,6 +28,9 @@ function getReferralImage(): string {
 export function validateEmailAllowed(): void {
   if (!env.EMAIL_ENABLED) {
     throw new AppError("FORBIDDEN", "Email functionality is currently disabled", { reason: "EMAIL_DISABLED" });
+  }
+  if (!env.RESEND_API_KEY) {
+    throw new AppError("INTERNAL_ERROR", "Email provider API key is not configured");
   }
 }
 
@@ -120,7 +124,7 @@ interface GroupEmailParams {
 
 export async function sendGroupEmails(
   params: GroupEmailParams,
-): Promise<{ sent: number; failed: number; suppressed: number }> {
+): Promise<{ sent: number; failed: number; suppressed: number; results: RecipientSendResult[] }> {
   const { recipients, subject, body, senderName, replyTo, groupId } = params;
 
   const emails = recipients.map((r) => r.email);
@@ -129,6 +133,7 @@ export async function sendGroupEmails(
 
   let sent = 0;
   let failed = 0;
+  const recipientResults: RecipientSendResult[] = [];
 
   for (let i = 0; i < validRecipients.length; i += BATCH_SIZE) {
     const batch = validRecipients.slice(i, i + BATCH_SIZE);
@@ -150,7 +155,7 @@ export async function sendGroupEmails(
 
         const { to, subject: redirectedSubject } = applyRedirect(recipient.email, subject);
 
-        const { error } = await getClient().emails.send({
+        const { data, error } = await getClient().emails.send({
           from: `${senderName} <${env.FROM_EMAIL ?? ""}>`,
           to,
           replyTo,
@@ -163,15 +168,21 @@ export async function sendGroupEmails(
         });
 
         if (error) throw new Error(error.message);
+        return { memberId: recipient.memberId, externalId: data?.id };
       }),
     );
 
-    for (const result of results) {
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j];
+      const recipient = batch[j];
       if (result.status === "fulfilled") {
         sent++;
+        recipientResults.push({ memberId: recipient.memberId, status: "sent", externalId: result.value.externalId });
       } else {
         failed++;
+        const errorMsg = result.reason instanceof Error ? result.reason.message : "Unknown error";
         console.error("[EMAIL_SEND_ERROR]", result.reason);
+        recipientResults.push({ memberId: recipient.memberId, status: "failed", error: errorMsg });
       }
     }
 
@@ -180,5 +191,5 @@ export async function sendGroupEmails(
     }
   }
 
-  return { sent, failed, suppressed: suppressed.length };
+  return { sent, failed, suppressed: suppressed.length, results: recipientResults };
 }

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -4,8 +4,9 @@ import { env } from "@/env";
 import { AppError, transformError } from "@/utils/errors";
 import { getGroupRecipients } from "@/services/contact-group";
 import { sendGroupEmails, validateEmailAllowed } from "@/services/email";
+import { sendGroupSms, validateSmsAllowed } from "@/services/sms";
+import { getConsentedPhones } from "@/services/sms-consent";
 import { getMemberDetails, getAllActiveMemberIds } from "@/lib/api/member-api";
-import { coopHourOfDay } from "@/utils/time";
 import type { ComposeMessage, BlastMessage } from "@/schema/contact-group";
 import type { MockMember } from "@/lib/mock-members";
 import type {
@@ -62,23 +63,7 @@ export async function getGroupMessageHistory(
   }
 }
 
-export function isQuietHours(): boolean {
-  // TCPA compliance: no SMS before 8 AM or after 8 PM Pacific
-  const hour = coopHourOfDay(new Date());
-  return hour < 8 || hour >= 20;
-}
-
-export function validateSmsAllowed(): void {
-  if (!env.SMS_ENABLED) {
-    throw new AppError("FORBIDDEN", "SMS functionality is currently disabled", { reason: "SMS_DISABLED" });
-  }
-
-  if (isQuietHours()) {
-    throw new AppError("FORBIDDEN", "SMS messages cannot be sent during quiet hours (8 PM - 8 AM Pacific)", {
-      reason: "QUIET_HOURS",
-    });
-  }
-}
+export { isQuietHours, validateSmsAllowed } from "@/services/sms";
 
 async function sendEmailsForMessage(
   messageId: number,
@@ -101,31 +86,20 @@ async function sendEmailsForMessage(
       groupId: groupIds?.[0] ?? 0,
     });
 
-    if (emailResult.failed === 0) {
-      await prisma.messageRecipient.updateMany({
-        where: {
-          messageId,
-          channel: "email",
-          memberId: { in: recipients.map((r) => r.ownerid) },
-        },
-        data: {
-          status: "sent",
-          sentAt: new Date(),
-        },
-      });
-    } else {
-      await prisma.messageRecipient.updateMany({
-        where: {
-          messageId,
-          channel: "email",
-          memberId: { in: recipients.map((r) => r.ownerid) },
-        },
-        data: {
-          status: "failed",
-          sentAt: new Date(),
-        },
-      });
-    }
+    const now = new Date();
+    await Promise.all(
+      emailResult.results.map((r) =>
+        prisma.messageRecipient.updateMany({
+          where: { messageId, channel: "email", memberId: r.memberId },
+          data: {
+            status: r.status,
+            sentAt: now,
+            externalId: r.externalId ?? null,
+            error: r.error ?? null,
+          },
+        }),
+      ),
+    );
 
     return { sent: emailResult.sent, failed: emailResult.failed };
   } catch (error) {
@@ -134,9 +108,48 @@ async function sendEmailsForMessage(
   }
 }
 
+async function sendSmsForMessage(
+  messageId: number,
+  smsRecipientIds: number[],
+  smsBody: string,
+): Promise<{ sent: number; failed: number }> {
+  try {
+    const phoneMap = await getConsentedPhones(smsRecipientIds);
+    const recipients = smsRecipientIds
+      .filter((id) => phoneMap.has(id))
+      .map((id) => ({ memberId: id, phone: phoneMap.get(id)! }));
+
+    if (recipients.length === 0) {
+      return { sent: 0, failed: 0 };
+    }
+
+    const smsResult = await sendGroupSms({ recipients, body: smsBody });
+
+    const now = new Date();
+    await Promise.all(
+      smsResult.results.map((r) =>
+        prisma.messageRecipient.updateMany({
+          where: { messageId, channel: "sms", memberId: r.memberId },
+          data: {
+            status: r.status,
+            sentAt: now,
+            externalId: r.externalId ?? null,
+            error: r.error ?? null,
+          },
+        }),
+      ),
+    );
+
+    return { sent: smsResult.sent, failed: smsResult.failed };
+  } catch (error) {
+    console.error("[sendSmsForMessage] Failed:", error);
+    return { sent: 0, failed: smsRecipientIds.length };
+  }
+}
+
 export async function sendGroupMessage(input: ComposeMessage, senderId: number): Promise<MessageResult> {
   try {
-    const { groupIds, subject, body, sendEmail, sendSms } = input;
+    const { groupIds, subject, body, smsBody, sendEmail, sendSms } = input;
 
     if (!sendEmail && !sendSms) {
       throw new AppError("VALIDATION_ERROR", "At least one delivery method (email or SMS) must be selected");
@@ -191,7 +204,7 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
         });
       }
 
-      if (sendSms && smsRecipientIds.length > 0 && env.SMS_ENABLED) {
+      if (sendSms && smsRecipientIds.length > 0) {
         await tx.messageRecipient.createMany({
           data: smsRecipientIds.map((memberId) => ({
             messageId: message.id,
@@ -207,6 +220,8 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
 
     let emailsSent = 0;
     let emailsFailed = 0;
+    let smsSent = 0;
+    let smsFailed = 0;
 
     if (sendEmail && emailRecipientIds.length > 0) {
       const emailRecipients = members.filter((m) => emailRecipientIds.includes(m.ownerid));
@@ -215,12 +230,16 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
       emailsFailed = emailResult.failed;
     }
 
-    const smsSent = 0;
+    if (sendSms && smsRecipientIds.length > 0 && smsBody) {
+      const smsResult = await sendSmsForMessage(result.id, smsRecipientIds, smsBody);
+      smsSent = smsResult.sent;
+      smsFailed = smsResult.failed;
+    }
 
     await prisma.message.update({
       where: { id: result.id },
       data: {
-        failedCount: emailsFailed,
+        failedCount: emailsFailed + smsFailed,
       },
     });
 
@@ -228,7 +247,7 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
       messageId: result.id,
       emailCount: emailsSent,
       smsCount: smsSent,
-      failedCount: emailsFailed,
+      failedCount: emailsFailed + smsFailed,
     };
   } catch (error) {
     throw transformError(error);
@@ -237,7 +256,7 @@ export async function sendGroupMessage(input: ComposeMessage, senderId: number):
 
 export async function sendBlastMessage(input: BlastMessage, senderId: number): Promise<MessageResult> {
   try {
-    const { subject, body, sendEmail, sendSms } = input;
+    const { subject, body, smsBody, sendEmail, sendSms } = input;
 
     if (!sendEmail && !sendSms) {
       throw new AppError("VALIDATION_ERROR", "At least one delivery method (email or SMS) must be selected");
@@ -286,7 +305,7 @@ export async function sendBlastMessage(input: BlastMessage, senderId: number): P
         });
       }
 
-      if (sendSms && smsRecipientIds.length > 0 && env.SMS_ENABLED) {
+      if (sendSms && smsRecipientIds.length > 0) {
         await tx.messageRecipient.createMany({
           data: smsRecipientIds.map((memberId) => ({
             messageId: message.id,
@@ -302,6 +321,8 @@ export async function sendBlastMessage(input: BlastMessage, senderId: number): P
 
     let emailsSent = 0;
     let emailsFailed = 0;
+    let smsSent = 0;
+    let smsFailed = 0;
 
     if (sendEmail && emailRecipientIds.length > 0) {
       const emailResult = await sendEmailsForMessage(result.id, members, subject, body, null);
@@ -309,12 +330,16 @@ export async function sendBlastMessage(input: BlastMessage, senderId: number): P
       emailsFailed = emailResult.failed;
     }
 
-    const smsSent = 0;
+    if (sendSms && smsRecipientIds.length > 0 && smsBody) {
+      const smsResult = await sendSmsForMessage(result.id, smsRecipientIds, smsBody);
+      smsSent = smsResult.sent;
+      smsFailed = smsResult.failed;
+    }
 
     await prisma.message.update({
       where: { id: result.id },
       data: {
-        failedCount: emailsFailed,
+        failedCount: emailsFailed + smsFailed,
       },
     });
 
@@ -322,7 +347,7 @@ export async function sendBlastMessage(input: BlastMessage, senderId: number): P
       messageId: result.id,
       emailCount: emailsSent,
       smsCount: smsSent,
-      failedCount: emailsFailed,
+      failedCount: emailsFailed + smsFailed,
     };
   } catch (error) {
     throw transformError(error);

--- a/src/services/sms-consent.ts
+++ b/src/services/sms-consent.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import prisma from "@/lib/db";
 import { transformError } from "@/utils/errors";
-import { encrypt, blindIndex } from "@/lib/encryption";
+import { encrypt, decrypt, blindIndex } from "@/lib/encryption";
 
 export interface SmsConsentRecord {
   id: number;
@@ -84,6 +84,28 @@ export async function revokeSmsConsent(memberId: number, method: string, message
         revokeMessage: message,
       },
     });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
+export async function getConsentedPhones(memberIds: number[]): Promise<Map<number, string>> {
+  try {
+    const consents = await prisma.smsConsent.findMany({
+      where: { memberId: { in: memberIds }, revokedAt: null },
+      select: { memberId: true, phone: true },
+      orderBy: { consentedAt: "desc" },
+    });
+
+    const seen = new Set<number>();
+    const result = new Map<number, string>();
+    for (const c of consents) {
+      if (!seen.has(c.memberId)) {
+        seen.add(c.memberId);
+        result.set(c.memberId, decrypt(c.phone));
+      }
+    }
+    return result;
   } catch (error) {
     throw transformError(error);
   }

--- a/src/services/sms.ts
+++ b/src/services/sms.ts
@@ -1,0 +1,74 @@
+import "server-only";
+import { env } from "@/env";
+import { sendSms } from "@/lib/sms";
+import { AppError, transformError } from "@/utils/errors";
+import { coopHourOfDay } from "@/utils/time";
+import type { RecipientSendResult } from "@/types/message";
+
+const SMS_BATCH_SIZE = 10;
+const SMS_BATCH_DELAY_MS = 1000;
+
+export function isQuietHours(): boolean {
+  const hour = coopHourOfDay(new Date());
+  return hour < 8 || hour >= 20;
+}
+
+export function validateSmsAllowed(): void {
+  if (!env.SMS_ENABLED) {
+    throw new AppError("FORBIDDEN", "SMS functionality is currently disabled", { reason: "SMS_DISABLED" });
+  }
+
+  if (isQuietHours()) {
+    throw new AppError("FORBIDDEN", "SMS messages cannot be sent during quiet hours (8 PM - 8 AM Pacific)", {
+      reason: "QUIET_HOURS",
+    });
+  }
+
+  if (!env.TWILIO_ACCOUNT_SID || !env.TWILIO_AUTH_TOKEN || !env.TWILIO_FROM_NUMBER) {
+    throw new AppError("INTERNAL_ERROR", "SMS provider credentials are not configured");
+  }
+}
+
+export async function sendGroupSms(params: {
+  recipients: Array<{ phone: string; memberId: number }>;
+  body: string;
+}): Promise<{ sent: number; failed: number; results: RecipientSendResult[] }> {
+  try {
+    const { recipients, body } = params;
+
+    if (recipients.length === 0) {
+      return { sent: 0, failed: 0, results: [] };
+    }
+
+    let sent = 0;
+    let failed = 0;
+    const results: RecipientSendResult[] = [];
+
+    for (let i = 0; i < recipients.length; i += SMS_BATCH_SIZE) {
+      const batch = recipients.slice(i, i + SMS_BATCH_SIZE);
+
+      const batchResults = await Promise.allSettled(batch.map((r) => sendSms(r.phone, body)));
+
+      for (let j = 0; j < batchResults.length; j++) {
+        const result = batchResults[j];
+        const recipient = batch[j];
+        if (result.status === "fulfilled") {
+          sent++;
+          results.push({ memberId: recipient.memberId, status: "sent", externalId: result.value.sid });
+        } else {
+          failed++;
+          const errorMsg = result.reason instanceof Error ? result.reason.message : "Unknown error";
+          results.push({ memberId: recipient.memberId, status: "failed", error: errorMsg });
+        }
+      }
+
+      if (i + SMS_BATCH_SIZE < recipients.length) {
+        await new Promise((resolve) => setTimeout(resolve, SMS_BATCH_DELAY_MS));
+      }
+    }
+
+    return { sent, failed, results };
+  } catch (error) {
+    throw transformError(error);
+  }
+}

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -47,6 +47,20 @@ export interface RecipientCounts {
   smsIneligible: number;
 }
 
+export interface RecipientSendResult {
+  memberId: number;
+  status: "sent" | "failed";
+  externalId?: string;
+  error?: string;
+}
+
+export interface GroupEmailResult {
+  sent: number;
+  failed: number;
+  suppressed: number;
+  results: RecipientSendResult[];
+}
+
 export interface MessageHistoryPage {
   items: MessageHistoryItem[];
   totalCount: number;

--- a/test/api/unsubscribe.test.ts
+++ b/test/api/unsubscribe.test.ts
@@ -77,6 +77,22 @@ describe("POST /api/unsubscribe", () => {
     });
   });
 
+  it("returns 204 on double unsubscribe (idempotent)", async () => {
+    vi.mocked(verifyUnsubscribeToken).mockReturnValue({
+      valid: true,
+      memberId: 123,
+      groupId: 456,
+    });
+    mockPrisma.contactGroupMember.updateMany.mockResolvedValue({ count: 0 });
+
+    const req = new NextRequest("http://localhost/api/unsubscribe?token=valid-token", {
+      method: "POST",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(204);
+  });
+
   it("returns 500 on database error", async () => {
     vi.mocked(verifyUnsubscribeToken).mockReturnValue({
       valid: true,

--- a/test/lib/unsubscribe-tokens.test.ts
+++ b/test/lib/unsubscribe-tokens.test.ts
@@ -1,0 +1,67 @@
+import { vi } from "vitest";
+
+vi.mock("@/env", () => ({
+  env: {
+    UNSUBSCRIBE_SECRET: "test-secret-key-must-be-at-least-32-chars",
+  },
+}));
+
+import { generateUnsubscribeToken, verifyUnsubscribeToken } from "@/lib/unsubscribe-tokens";
+
+describe("unsubscribe token round-trip", () => {
+  it("generates and verifies a valid token", () => {
+    const token = generateUnsubscribeToken(100001, 5);
+    const result = verifyUnsubscribeToken(token);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.memberId).toBe(100001);
+      expect(result.groupId).toBe(5);
+    }
+  });
+
+  it("rejects tampered memberId", () => {
+    const token = generateUnsubscribeToken(100001, 5);
+    const decoded = Buffer.from(token, "base64url").toString("utf-8");
+    const parts = decoded.split("|");
+    parts[0] = "999999";
+    const tampered = Buffer.from(parts.join("|")).toString("base64url");
+
+    const result = verifyUnsubscribeToken(tampered);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects tampered groupId", () => {
+    const token = generateUnsubscribeToken(100001, 5);
+    const decoded = Buffer.from(token, "base64url").toString("utf-8");
+    const parts = decoded.split("|");
+    parts[1] = "999";
+    const tampered = Buffer.from(parts.join("|")).toString("base64url");
+
+    const result = verifyUnsubscribeToken(tampered);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects invalid base64", () => {
+    const result = verifyUnsubscribeToken("not-valid!!!");
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects token with wrong number of parts", () => {
+    const malformed = Buffer.from("only|two").toString("base64url");
+    const result = verifyUnsubscribeToken(malformed);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects token with non-numeric memberId", () => {
+    const malformed = Buffer.from("abc|5|12345|fakesig").toString("base64url");
+    const result = verifyUnsubscribeToken(malformed);
+    expect(result.valid).toBe(false);
+  });
+
+  it("handles signature length mismatch without crashing", () => {
+    const malformed = Buffer.from("100001|5|12345|short").toString("base64url");
+    const result = verifyUnsubscribeToken(malformed);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/test/schema/message.test.ts
+++ b/test/schema/message.test.ts
@@ -1,7 +1,7 @@
 import { BaseMessageSchema } from "@/schema/contact-group";
 import { MessageHistoryQuerySchema } from "@/schema/message";
 
-describe("BaseMessageSchema SMS body length", () => {
+describe("BaseMessageSchema SMS body", () => {
   it("allows long body when sendSms is false", () => {
     const result = BaseMessageSchema.safeParse({
       subject: "Test",
@@ -13,21 +13,10 @@ describe("BaseMessageSchema SMS body length", () => {
     expect(result.success).toBe(true);
   });
 
-  it("allows 160 character body when sendSms is true", () => {
+  it("requires smsBody when sendSms is true", () => {
     const result = BaseMessageSchema.safeParse({
       subject: "Test",
-      body: "a".repeat(160),
-      sendEmail: false,
-      sendSms: true,
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it("rejects body over 160 characters when sendSms is true", () => {
-    const result = BaseMessageSchema.safeParse({
-      subject: "Test",
-      body: "a".repeat(161),
+      body: "a".repeat(500),
       sendEmail: false,
       sendSms: true,
     });
@@ -35,12 +24,37 @@ describe("BaseMessageSchema SMS body length", () => {
     expect(result.success).toBe(false);
   });
 
-  it("allows long body when both channels enabled but sendSms is false", () => {
+  it("accepts smsBody at 160 characters when sendSms is true", () => {
     const result = BaseMessageSchema.safeParse({
       subject: "Test",
-      body: "a".repeat(500),
+      body: "Email body",
+      smsBody: "a".repeat(160),
+      sendEmail: false,
+      sendSms: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects smsBody over 160 characters", () => {
+    const result = BaseMessageSchema.safeParse({
+      subject: "Test",
+      body: "Email body",
+      smsBody: "a".repeat(161),
+      sendEmail: false,
+      sendSms: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("allows long email body with separate short smsBody", () => {
+    const result = BaseMessageSchema.safeParse({
+      subject: "Test",
+      body: "a".repeat(5000),
+      smsBody: "Short SMS",
       sendEmail: true,
-      sendSms: false,
+      sendSms: true,
     });
 
     expect(result.success).toBe(true);

--- a/test/services/message.test.ts
+++ b/test/services/message.test.ts
@@ -169,7 +169,7 @@ describe("sendGroupMessage", () => {
   it("creates Message record with correct data", async () => {
     vi.mocked(getGroupRecipients).mockResolvedValue([100002, 100003, 100004]);
     vi.mocked(getMemberDetails).mockResolvedValue(testRecipients);
-    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 3, failed: 0, suppressed: 0 });
+    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 3, failed: 0, suppressed: 0, results: [] });
     mockPrisma.message.create.mockResolvedValue({ ...testMessage, id: 1 });
     mockPrisma.messageRecipient.createMany.mockResolvedValue({ count: 3 });
     mockPrisma.messageRecipient.updateMany.mockResolvedValue({ count: 3 });
@@ -194,7 +194,7 @@ describe("sendGroupMessage", () => {
   it("creates MessageRecipient records for email recipients", async () => {
     vi.mocked(getGroupRecipients).mockResolvedValue([100002, 100003, 100004]);
     vi.mocked(getMemberDetails).mockResolvedValue(testRecipients);
-    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 3, failed: 0, suppressed: 0 });
+    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 3, failed: 0, suppressed: 0, results: [] });
     mockPrisma.message.create.mockResolvedValue({ ...testMessage, id: 1 });
     mockPrisma.messageRecipient.createMany.mockResolvedValue({ count: 3 });
     mockPrisma.messageRecipient.updateMany.mockResolvedValue({ count: 3 });
@@ -230,7 +230,7 @@ describe("sendGroupMessage", () => {
   it("updates failedCount when emails fail", async () => {
     vi.mocked(getGroupRecipients).mockResolvedValue([100002, 100003, 100004]);
     vi.mocked(getMemberDetails).mockResolvedValue(testRecipients);
-    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 1, failed: 2, suppressed: 0 });
+    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 1, failed: 2, suppressed: 0, results: [] });
     mockPrisma.message.create.mockResolvedValue({ ...testMessage, id: 1 });
     mockPrisma.messageRecipient.createMany.mockResolvedValue({ count: 3 });
     mockPrisma.messageRecipient.updateMany.mockResolvedValue({ count: 2 });
@@ -267,7 +267,7 @@ describe("sendBlastMessage", () => {
   it("creates Message with isBlast=true and no groupId", async () => {
     vi.mocked(getAllActiveMemberIds).mockResolvedValue(allMemberIds);
     vi.mocked(getMemberDetails).mockResolvedValue([...mockMembers]);
-    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 389, failed: 0, suppressed: 0 });
+    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 389, failed: 0, suppressed: 0, results: [] });
     mockPrisma.message.create.mockResolvedValue({ ...testBlastMessage, id: 2 });
     mockPrisma.messageRecipient.createMany.mockResolvedValue({ count: 389 });
     mockPrisma.messageRecipient.updateMany.mockResolvedValue({ count: 389 });
@@ -288,7 +288,7 @@ describe("sendBlastMessage", () => {
   it("sends to all active members", async () => {
     vi.mocked(getAllActiveMemberIds).mockResolvedValue(allMemberIds);
     vi.mocked(getMemberDetails).mockResolvedValue([...mockMembers]);
-    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 389, failed: 0, suppressed: 0 });
+    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 389, failed: 0, suppressed: 0, results: [] });
     mockPrisma.message.create.mockResolvedValue({ ...testBlastMessage, id: 2 });
     mockPrisma.messageRecipient.createMany.mockResolvedValue({ count: 389 });
     mockPrisma.messageRecipient.updateMany.mockResolvedValue({ count: 389 });
@@ -303,7 +303,7 @@ describe("sendBlastMessage", () => {
   it("updates failedCount when emails fail", async () => {
     vi.mocked(getAllActiveMemberIds).mockResolvedValue(allMemberIds);
     vi.mocked(getMemberDetails).mockResolvedValue([...mockMembers]);
-    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 350, failed: 39, suppressed: 0 });
+    vi.mocked(sendGroupEmails).mockResolvedValue({ sent: 350, failed: 39, suppressed: 0, results: [] });
     mockPrisma.message.create.mockResolvedValue({ ...testBlastMessage, id: 2 });
     mockPrisma.messageRecipient.createMany.mockResolvedValue({ count: 389 });
     mockPrisma.messageRecipient.updateMany.mockResolvedValue({ count: 39 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I added Twilio SMS sending, fixed the per-recipient email status tracking bug, added a separate smsBody schema field, and created public privacy policy and terms pages for A2P 10DLC compliance.

- `src/lib/sms.ts` - new Twilio client with lazy singleton, sendSms function
- `src/services/sms.ts` - new SMS service with sendGroupSms, validateSmsAllowed, isQuietHours, TCPA consent checking via getConsentedPhones
- `src/services/sms-consent.ts` - added getConsentedPhones for batch phone number lookup with decryption
- `src/services/email.ts` - sendGroupEmails now returns per-recipient results with memberId/status/externalId, validateEmailAllowed checks RESEND_API_KEY
- `src/services/message.ts` - sendEmailsForMessage updates each MessageRecipient individually instead of all-or-nothing, added sendSmsForMessage helper, sendGroupMessage and sendBlastMessage accept smsBody and call actual SMS sending
- `src/schema/contact-group.ts` - added smsBody field to BaseMessageSchema, refine requires smsBody when sendSms is true
- `src/types/message.ts` - added RecipientSendResult and GroupEmailResult interfaces
- `src/env.ts` - added TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
- `src/actions/contact-group.ts` - sendMessage validates schema before ownership check, passes smsBody through
- `src/app/(protected)/messages/compose/compose-content.tsx` - passes smsBody to actions
- `src/app/(public)/privacy/page.tsx` - new privacy policy page
- `src/app/(public)/terms/page.tsx` - new SMS terms and conditions page
- `e2e/messages-compose.spec.ts` - 4 new e2e tests for compose page
- `test/lib/unsubscribe-tokens.test.ts` - 7 new tests for HMAC token round-trip
- `test/api/unsubscribe.test.ts` - added double-unsubscribe idempotency test
- `test/schema/message.test.ts` - updated for smsBody field validation
- `test/services/message.test.ts` - updated mocks for per-recipient results

## How to test

1. Visit /privacy and /terms - verify pages render with correct content
2. Compose a message with email only - verify per-recipient status updates in database
3. Compose a message with SMS enabled - verify smsBody field is sent and Twilio attempts delivery
4. Set SMS_ENABLED=false, verify SMS toggle hidden and SMS validation rejects
5. Verify email fails with clear error when RESEND_API_KEY is missing

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers