### PR TITLE
test: add sms service and consent test coverage

### DIFF
--- a/test/mocks/twilio.ts
+++ b/test/mocks/twilio.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+
+export const mockTwilioSend = vi.fn();
+
+vi.mock("twilio", () => {
+  return {
+    default: () => ({
+      messages: {
+        create: mockTwilioSend,
+      },
+    }),
+  };
+});

--- a/test/services/sms-consent.test.ts
+++ b/test/services/sms-consent.test.ts
@@ -1,6 +1,13 @@
 import { mockPrisma } from "../mocks/prisma";
+import "../mocks/encryption";
 import { activeConsentKermit } from "../mocks/sms-consent";
-import { getMemberSmsConsent, hasActiveConsent, revokeSmsConsent } from "@/services/sms-consent";
+import {
+  getMemberSmsConsent,
+  hasActiveConsent,
+  revokeSmsConsent,
+  getConsentedPhones,
+  grantSmsConsent,
+} from "@/services/sms-consent";
 
 describe("getMemberSmsConsent", () => {
   it("returns active consent record when found", async () => {
@@ -99,5 +106,89 @@ describe("revokeSmsConsent", () => {
     await expect(revokeSmsConsent(100001, "user_settings", null)).rejects.toMatchObject({
       code: "INTERNAL_ERROR",
     });
+  });
+});
+
+describe("getConsentedPhones", () => {
+  it("returns decrypted phones for members with active consent", async () => {
+    mockPrisma.smsConsent.findMany.mockResolvedValue([
+      { memberId: 100001, phone: "encrypted_phone_1" },
+      { memberId: 100002, phone: "encrypted_phone_2" },
+    ] as never);
+
+    const result = await getConsentedPhones([100001, 100002]);
+
+    expect(result.size).toBe(2);
+    expect(result.get(100001)).toBe("encrypted_phone_1");
+    expect(result.get(100002)).toBe("encrypted_phone_2");
+  });
+
+  it("returns empty map when no members have consent", async () => {
+    mockPrisma.smsConsent.findMany.mockResolvedValue([]);
+
+    const result = await getConsentedPhones([100001]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("filters to only active consent (revokedAt null)", async () => {
+    mockPrisma.smsConsent.findMany.mockResolvedValue([] as never);
+
+    await getConsentedPhones([100001, 100002]);
+
+    expect(mockPrisma.smsConsent.findMany).toHaveBeenCalledWith({
+      where: { memberId: { in: [100001, 100002] }, revokedAt: null },
+      select: { memberId: true, phone: true },
+      orderBy: { consentedAt: "desc" },
+    });
+  });
+
+  it("deduplicates by memberId keeping most recent consent", async () => {
+    mockPrisma.smsConsent.findMany.mockResolvedValue([
+      { memberId: 100001, phone: "newer_phone" },
+      { memberId: 100001, phone: "older_phone" },
+    ] as never);
+
+    const result = await getConsentedPhones([100001]);
+
+    expect(result.size).toBe(1);
+    expect(result.get(100001)).toBe("newer_phone");
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.smsConsent.findMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(getConsentedPhones([100001])).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("grantSmsConsent", () => {
+  it("creates consent record when no active consent exists", async () => {
+    mockPrisma.smsConsent.findFirst.mockResolvedValue(null);
+    mockPrisma.smsConsent.create.mockResolvedValue({} as never);
+
+    await grantSmsConsent(100001, "+15551234567");
+
+    expect(mockPrisma.smsConsent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        memberId: 100001,
+        consentMethod: "web_settings",
+        consentPurpose: "group_messaging",
+      }),
+    });
+  });
+
+  it("skips creation when active consent already exists", async () => {
+    mockPrisma.smsConsent.findFirst.mockResolvedValue({ id: 1 } as never);
+
+    await grantSmsConsent(100001, "+15551234567");
+
+    expect(mockPrisma.smsConsent.create).not.toHaveBeenCalled();
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.smsConsent.findFirst.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(grantSmsConsent(100001, "+15551234567")).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
   });
 });

--- a/test/services/sms.test.ts
+++ b/test/services/sms.test.ts
@@ -1,0 +1,86 @@
+import { vi } from "vitest";
+import { mockTwilioSend } from "../mocks/twilio";
+
+vi.mock("@/env", () => ({
+  env: {
+    SMS_ENABLED: true,
+    TWILIO_ACCOUNT_SID: "ACtest",
+    TWILIO_AUTH_TOKEN: "testtoken",
+    TWILIO_FROM_NUMBER: "+15551234567",
+  },
+}));
+
+import { sendGroupSms, validateSmsAllowed } from "@/services/sms";
+
+describe("validateSmsAllowed", () => {
+  it("passes when SMS_ENABLED is true and credentials are set", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T18:00:00Z"));
+
+    expect(() => validateSmsAllowed()).not.toThrow();
+
+    vi.useRealTimers();
+  });
+});
+
+describe("sendGroupSms", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends SMS to all recipients and returns per-recipient results", async () => {
+    mockTwilioSend.mockResolvedValueOnce({ sid: "SM001" }).mockResolvedValueOnce({ sid: "SM002" });
+
+    const result = await sendGroupSms({
+      recipients: [
+        { memberId: 100001, phone: "+15551111111" },
+        { memberId: 100002, phone: "+15552222222" },
+      ],
+      body: "Test message",
+    });
+
+    expect(result.sent).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toEqual({ memberId: 100001, status: "sent", externalId: "SM001" });
+    expect(result.results[1]).toEqual({ memberId: 100002, status: "sent", externalId: "SM002" });
+  });
+
+  it("handles partial failures with per-recipient error tracking", async () => {
+    mockTwilioSend.mockResolvedValueOnce({ sid: "SM001" }).mockRejectedValueOnce(new Error("Unverified number"));
+
+    const result = await sendGroupSms({
+      recipients: [
+        { memberId: 100001, phone: "+15551111111" },
+        { memberId: 100002, phone: "+15552222222" },
+      ],
+      body: "Test message",
+    });
+
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.results[0].status).toBe("sent");
+    expect(result.results[1].status).toBe("failed");
+    expect(result.results[1].error).toBe("Unverified number");
+  });
+
+  it("returns empty results for empty recipient list", async () => {
+    const result = await sendGroupSms({ recipients: [], body: "Test" });
+
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.results).toEqual([]);
+    expect(mockTwilioSend).not.toHaveBeenCalled();
+  });
+
+  it("captures Twilio SID as externalId", async () => {
+    mockTwilioSend.mockResolvedValueOnce({ sid: "SM_test_sid_123" });
+
+    const result = await sendGroupSms({
+      recipients: [{ memberId: 100001, phone: "+15551111111" }],
+      body: "Test",
+    });
+
+    expect(result.results[0].externalId).toBe("SM_test_sid_123");
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Added 13 unit tests for SMS functions that had zero coverage. The Twilio API call succeeded during manual testing (SID returned, status queued) but carrier rejected with error 30034 (A2P 10DLC pending). These tests verify the code is correct independent of carrier approval.

- `test/mocks/twilio.ts` - new Twilio SDK mock
- `test/services/sms.test.ts` - 5 tests for sendGroupSms (success, partial failure, empty recipients, SID capture) and validateSmsAllowed
- `test/services/sms-consent.test.ts` - 8 new tests for getConsentedPhones (active consent filter, empty, deduplication, DB error) and grantSmsConsent (create, skip duplicate, DB error)

## How to test

1. `npm test` - 557 tests pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers