### PR TITLE
fix: sms stop footer, referral email address, inbound stop webhook

### DIFF
--- a/src/app/api/sms/inbound/route.ts
+++ b/src/app/api/sms/inbound/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyTwilioSignature } from "@/lib/sms";
+import { revokeConsentByPhone } from "@/services/sms-consent";
+
+const STOP_KEYWORDS = new Set(["stop", "stopall", "unsubscribe", "cancel", "end", "quit", "optout", "revoke"]);
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData();
+    const params: Record<string, string> = {};
+    formData.forEach((value, key) => {
+      params[key] = value.toString();
+    });
+
+    const signature = req.headers.get("x-twilio-signature") ?? "";
+    const url = `${req.nextUrl.origin}/api/sms/inbound`;
+
+    if (!verifyTwilioSignature(signature, url, params)) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 403 });
+    }
+
+    const from = params.From ?? "";
+    const body = (params.Body ?? "").trim().toLowerCase();
+
+    if (STOP_KEYWORDS.has(body)) {
+      await revokeConsentByPhone(from, "sms_reply_stop", params.Body ?? "");
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json({ error: "Webhook processing failed" }, { status: 500 });
+  }
+}

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import twilio from "twilio";
+import twilio, { validateRequest } from "twilio";
 import { env } from "@/env";
 import { AppError } from "@/utils/errors";
 
@@ -12,6 +12,11 @@ function getClient(): ReturnType<typeof twilio> {
   }
   _client = twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN);
   return _client;
+}
+
+export function verifyTwilioSignature(signature: string, url: string, params: Record<string, string>): boolean {
+  if (!env.TWILIO_AUTH_TOKEN) return false;
+  return validateRequest(env.TWILIO_AUTH_TOKEN, signature, url, params);
 }
 
 export async function sendSms(to: string, body: string): Promise<{ sid: string }> {

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -99,6 +99,7 @@ function generateEmailHtml(prospectName: string, memberName: string, referralCod
       <div style="margin-top: 20px; border-top: 1px solid #eee; padding-top: 15px;">
         <p style="margin: 5px 0;">📧 <a href="mailto:info@pasofoodcooperative.com" style="color: #333; text-decoration: none;">info@pasofoodcooperative.com</a></p>
         <p style="margin: 5px 0;">🌐 <a href="www.pasofoodcooperative.com" style="color: #333; text-decoration: none;">www.pasofoodcooperative.com</a></p>
+        <p style="margin: 5px 0; font-size: 12px; color: #666;">Paso Robles Food Cooperative, Inc. P.O. Box 922, Paso Robles, CA 93447</p>
       </div>
     </div>
   </div>`;

--- a/src/services/sms-consent.ts
+++ b/src/services/sms-consent.ts
@@ -89,6 +89,22 @@ export async function revokeSmsConsent(memberId: number, method: string, message
   }
 }
 
+export async function revokeConsentByPhone(phone: string, method: string, message: string | null): Promise<void> {
+  try {
+    const hash = blindIndex(phone);
+    await prisma.smsConsent.updateMany({
+      where: { phoneHash: hash, revokedAt: null },
+      data: {
+        revokedAt: new Date(),
+        revokeMethod: method,
+        revokeMessage: message,
+      },
+    });
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
 export async function getConsentedPhones(memberIds: number[]): Promise<Map<number, string>> {
   try {
     const consents = await prisma.smsConsent.findMany({

--- a/src/services/sms.ts
+++ b/src/services/sms.ts
@@ -40,6 +40,8 @@ export async function sendGroupSms(params: {
       return { sent: 0, failed: 0, results: [] };
     }
 
+    const bodyWithFooter = `${body}\n\nReply STOP to opt out. Msg & data rates may apply.`;
+
     let sent = 0;
     let failed = 0;
     const results: RecipientSendResult[] = [];
@@ -47,7 +49,7 @@ export async function sendGroupSms(params: {
     for (let i = 0; i < recipients.length; i += SMS_BATCH_SIZE) {
       const batch = recipients.slice(i, i + SMS_BATCH_SIZE);
 
-      const batchResults = await Promise.allSettled(batch.map((r) => sendSms(r.phone, body)));
+      const batchResults = await Promise.allSettled(batch.map((r) => sendSms(r.phone, bodyWithFooter)));
 
       for (let j = 0; j < batchResults.length; j++) {
         const result = batchResults[j];

--- a/test/services/sms-consent.test.ts
+++ b/test/services/sms-consent.test.ts
@@ -5,6 +5,7 @@ import {
   getMemberSmsConsent,
   hasActiveConsent,
   revokeSmsConsent,
+  revokeConsentByPhone,
   getConsentedPhones,
   grantSmsConsent,
 } from "@/services/sms-consent";
@@ -190,5 +191,36 @@ describe("grantSmsConsent", () => {
     mockPrisma.smsConsent.findFirst.mockRejectedValue(new Error("Connection lost"));
 
     await expect(grantSmsConsent(100001, "+15551234567")).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+});
+
+describe("revokeConsentByPhone", () => {
+  it("revokes active consent by phone hash", async () => {
+    mockPrisma.smsConsent.updateMany.mockResolvedValue({ count: 1 });
+
+    await revokeConsentByPhone("+15551234567", "sms_reply_stop", "STOP");
+
+    expect(mockPrisma.smsConsent.updateMany).toHaveBeenCalledWith({
+      where: { phoneHash: "hash:+15551234567", revokedAt: null },
+      data: {
+        revokedAt: expect.any(Date),
+        revokeMethod: "sms_reply_stop",
+        revokeMessage: "STOP",
+      },
+    });
+  });
+
+  it("handles zero matching records without error", async () => {
+    mockPrisma.smsConsent.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(revokeConsentByPhone("+15559999999", "sms_reply_stop", "STOP")).resolves.toBeUndefined();
+  });
+
+  it("throws on database error", async () => {
+    mockPrisma.smsConsent.updateMany.mockRejectedValue(new Error("Connection lost"));
+
+    await expect(revokeConsentByPhone("+15551234567", "sms_reply_stop", "STOP")).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
   });
 });

--- a/test/services/sms.test.ts
+++ b/test/services/sms.test.ts
@@ -83,4 +83,18 @@ describe("sendGroupSms", () => {
 
     expect(result.results[0].externalId).toBe("SM_test_sid_123");
   });
+
+  it("appends STOP opt-out footer to every SMS", async () => {
+    mockTwilioSend.mockResolvedValueOnce({ sid: "SM001" });
+
+    await sendGroupSms({
+      recipients: [{ memberId: 100001, phone: "+15551111111" }],
+      body: "Event tomorrow at 3 PM",
+    });
+
+    const sentBody = mockTwilioSend.mock.calls[0][0].body;
+    expect(sentBody).toContain("Event tomorrow at 3 PM");
+    expect(sentBody).toContain("Reply STOP to opt out");
+    expect(sentBody).toContain("Msg & data rates may apply");
+  });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Three compliance gaps found during TDD audit. Every outbound SMS lacked TCPA-required opt-out text. Referral emails had no physical mailing address. No webhook existed to process inbound STOP replies from Twilio.

- `src/services/sms.ts` - sendGroupSms appends "Reply STOP to opt out. Msg & data rates may apply." to every SMS body before sending
- `src/services/email.ts` - added physical address to referral email footer (CAN-SPAM requirement for transactional emails)
- `src/services/sms-consent.ts` - added revokeConsentByPhone using blindIndex for phone-based consent lookup
- `src/lib/sms.ts` - added verifyTwilioSignature for webhook authentication
- `src/app/api/sms/inbound/route.ts` - new webhook endpoint, verifies Twilio signature, processes STOP/CANCEL/END/QUIT/UNSUBSCRIBE/OPTOUT/REVOKE/STOPALL keywords, revokes consent by phone hash
- `test/services/sms.test.ts` - added STOP footer assertion
- `test/services/sms-consent.test.ts` - 3 new tests for revokeConsentByPhone

## How to test

1. `npm test` - 561 tests pass
2. Send a test SMS - verify message body ends with opt-out footer
3. Configure Twilio Messaging Service webhook to POST to /api/sms/inbound
4. Reply STOP to the Twilio number - verify consent revoked in database

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers