### PR TITLE
fix: message recipient access, leave confirmation, photo delete, empty states, email description

### DIFF
--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -27,6 +27,7 @@ import {
   sendBlastMessage,
   getMessageHistoryPage,
   getMessageById,
+  isMessageRecipient,
   getMessageRecipients,
   previewRecipientCounts,
 } from "@/services/message";
@@ -324,7 +325,9 @@ export async function fetchMessageDetail(messageId: number): Promise<
     const session = await verifySession();
     const message = await getMessageById(messageId);
 
-    if (!session.isAdmin && message.senderId !== session.ownerid) {
+    const isSender = message.senderId === session.ownerid;
+    const isRecipient = await isMessageRecipient(messageId, session.ownerid);
+    if (!session.isAdmin && !isSender && !isRecipient) {
       return { success: false, error: "You do not have permission to view this message" };
     }
 

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -5,7 +5,7 @@ import { verifySession } from "@/lib/dal";
 import { UpdatePreferencesSchema } from "@/schema/settings";
 import { grantSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
 import { getMemberProfile } from "@/services/profile";
-import { updateUserPreferences, uploadProfilePhoto } from "@/services/user-preference";
+import { updateUserPreferences, uploadProfilePhoto, deleteProfilePhoto } from "@/services/user-preference";
 import { transformError } from "@/utils/errors";
 import type { ActionResult } from "@/types/action";
 import type { UserPreferenceData } from "@/services/user-preference";
@@ -45,6 +45,19 @@ export async function uploadPhotoAction(formData: FormData): Promise<ActionResul
     revalidatePath("/profile");
     revalidatePath("/settings");
     return { success: true, data: { url } };
+  } catch (error) {
+    const appError = transformError(error);
+    return { success: false, error: appError.message };
+  }
+}
+
+export async function deletePhotoAction(): Promise<ActionResult> {
+  try {
+    const session = await verifySession();
+    await deleteProfilePhoto(session.ownerid);
+    revalidatePath("/profile");
+    revalidatePath("/settings");
+    return { success: true };
   } catch (error) {
     const appError = transformError(error);
     return { success: false, error: appError.message };

--- a/src/app/(protected)/groups/[id]/group-detail-content.tsx
+++ b/src/app/(protected)/groups/[id]/group-detail-content.tsx
@@ -8,6 +8,17 @@ import { ChevronLeft, Search, UserPlus } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { GroupMemberTable } from "@/components/groups/group-member-table";
 import { AddMembersModal, type MemberRow } from "@/components/groups/add-members-modal";
 import { Switch } from "@/components/ui/switch";
@@ -196,15 +207,37 @@ export function GroupDetailContent({ group, allMembers, currentUserOwnerid, isAd
             </label>
           </div>
           {!isOwner && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleLeaveGroup}
-              disabled={isPending}
-              className="text-destructive border-destructive hover:bg-destructive/10"
-            >
-              Leave Group
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending}
+                  className="text-destructive border-destructive hover:bg-destructive/10"
+                >
+                  Leave Group
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Leave {group.name}?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    You will be removed from this group and stop receiving its messages. An admin can add you back if
+                    needed.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleLeaveGroup}
+                    disabled={isPending}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Leave Group
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           )}
         </div>
       )}

--- a/src/app/(protected)/profile/profile-content.tsx
+++ b/src/app/(protected)/profile/profile-content.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { ProfilePhotoUpload } from "@/components/profile/profile-photo-upload";
 import { PersonalInformationCard } from "@/components/profile/personal-information-card";
-import { uploadPhotoAction } from "@/actions/settings";
+import { uploadPhotoAction, deletePhotoAction } from "@/actions/settings";
 import type { MemberProfile } from "@/services/profile";
 
 type Props = {
@@ -43,6 +43,17 @@ export function ProfileContent({ profile, photoUrl, userName, isAdmin }: Props) 
           name={userName}
           photoUrl={currentPhotoUrl}
           onUpload={handleUpload}
+          onDelete={async () => {
+            setIsUploading(true);
+            const result = await deletePhotoAction();
+            setIsUploading(false);
+            if (result.success) {
+              setCurrentPhotoUrl(null);
+              toast.success("Photo removed");
+            } else {
+              toast.error(handleActionError(result.error, "Failed to remove photo"));
+            }
+          }}
           isUploading={isUploading}
         />
       </div>

--- a/src/components/dashboard/stat-card.tsx
+++ b/src/components/dashboard/stat-card.tsx
@@ -7,7 +7,7 @@ type StatCardProps = {
   label: string;
   value: string;
   icon: React.ReactNode;
-  viewAllHref: string;
+  viewAllHref?: string;
   className?: string;
 };
 
@@ -21,13 +21,17 @@ export function StatCard({ label, value, icon, viewAllHref, className }: StatCar
         </div>
         <div className="ml-4 shrink-0">{icon}</div>
       </div>
-      <div className="border-t border-prfc-border/20" />
-      <Link
-        href={viewAllHref}
-        className="flex items-center gap-1 px-6 py-3 text-sm text-muted-foreground hover:text-prfc-brown"
-      >
-        View all <ChevronRight className="h-4 w-4" />
-      </Link>
+      {viewAllHref && (
+        <>
+          <div className="border-t border-prfc-border/20" />
+          <Link
+            href={viewAllHref}
+            className="flex items-center gap-1 px-6 py-3 text-sm text-muted-foreground hover:text-prfc-brown"
+          >
+            View all <ChevronRight className="h-4 w-4" />
+          </Link>
+        </>
+      )}
     </Card>
   );
 }

--- a/src/components/dashboard/total-members-card.tsx
+++ b/src/components/dashboard/total-members-card.tsx
@@ -17,12 +17,5 @@ function TargetIcon() {
 type Props = { count: number };
 
 export function TotalMembersCard({ count }: Props) {
-  return (
-    <StatCard
-      label="Total Members"
-      value={`${count}/${MEMBER_CAPACITY}`}
-      icon={<TargetIcon />}
-      viewAllHref="/referral-database"
-    />
-  );
+  return <StatCard label="Total Members" value={`${count}/${MEMBER_CAPACITY}`} icon={<TargetIcon />} />;
 }

--- a/src/components/groups/group-member-table.tsx
+++ b/src/components/groups/group-member-table.tsx
@@ -18,6 +18,10 @@ interface GroupMemberTableProps {
 }
 
 export function GroupMemberTable({ members, mode, removedIds, onRemove, onRestore }: GroupMemberTableProps) {
+  if (members.length === 0) {
+    return <p className="py-8 text-center text-muted-foreground">No members in this group.</p>;
+  }
+
   return (
     <Table>
       <TableHeader>

--- a/src/components/profile/profile-photo-upload.tsx
+++ b/src/components/profile/profile-photo-upload.tsx
@@ -12,10 +12,11 @@ type Props = {
   name: string;
   photoUrl: string | null;
   onUpload: (file: File) => void;
+  onDelete?: () => void;
   isUploading?: boolean;
 };
 
-export function ProfilePhotoUpload({ name, photoUrl, onUpload, isUploading = false }: Props) {
+export function ProfilePhotoUpload({ name, photoUrl, onUpload, onDelete, isUploading = false }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -63,16 +64,29 @@ export function ProfilePhotoUpload({ name, photoUrl, onUpload, isUploading = fal
         className="hidden"
         aria-label="Upload profile photo"
       />
-      <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
-        {isUploading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <>
-            <Upload className="mr-2 h-4 w-4" />
-            Upload
-          </>
+      <div className="flex gap-2">
+        <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
+          {isUploading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <>
+              <Upload className="mr-2 h-4 w-4" />
+              Upload
+            </>
+          )}
+        </Button>
+        {photoUrl && onDelete && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onDelete}
+            disabled={isUploading}
+            className="text-destructive"
+          >
+            Remove
+          </Button>
         )}
-      </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/settings/notification-preferences-card.tsx
+++ b/src/components/settings/notification-preferences-card.tsx
@@ -36,7 +36,8 @@ export function NotificationPreferencesCard({
               Receive event announcements and group messages via email
             </label>
             <p className="text-sm text-muted-foreground">
-              You can unsubscribe from any email using the link at the bottom of the message.
+              Turning this off stops all group emails. You can also unsubscribe from individual groups on their detail
+              page.
             </p>
           </div>
           <Switch

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -542,6 +542,18 @@ export async function getMessageById(messageId: number): Promise<MessageDetail> 
   }
 }
 
+export async function isMessageRecipient(messageId: number, memberId: number): Promise<boolean> {
+  try {
+    const record = await prisma.messageRecipient.findFirst({
+      where: { messageId, memberId },
+      select: { id: true },
+    });
+    return record !== null;
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
 export async function getMessageRecipients(messageId: number): Promise<RecipientStatus[]> {
   try {
     const recipients = await prisma.messageRecipient.findMany({

--- a/test/actions/message-query.test.ts
+++ b/test/actions/message-query.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/services/message", () => ({
   sendBlastMessage: vi.fn(),
   getMessageHistoryPage: vi.fn(),
   getMessageById: vi.fn(),
+  isMessageRecipient: vi.fn(),
   getMessageRecipients: vi.fn(),
   previewRecipientCounts: vi.fn(),
 }));
@@ -21,6 +22,7 @@ vi.mock("@/services/contact-group", () => ({
 import {
   getMessageHistoryPage,
   getMessageById,
+  isMessageRecipient,
   getMessageRecipients,
   previewRecipientCounts,
 } from "@/services/message";
@@ -29,6 +31,7 @@ import { fetchMessageHistoryPage, fetchMessageDetail, fetchRecipientPreview } fr
 
 const mockGetMessageHistoryPage = getMessageHistoryPage as MockedFunction<typeof getMessageHistoryPage>;
 const mockGetMessageById = getMessageById as MockedFunction<typeof getMessageById>;
+const mockIsMessageRecipient = isMessageRecipient as MockedFunction<typeof isMessageRecipient>;
 const mockGetMessageRecipients = getMessageRecipients as MockedFunction<typeof getMessageRecipients>;
 const mockPreviewRecipientCounts = previewRecipientCounts as MockedFunction<typeof previewRecipientCounts>;
 const mockIsGroupOwner = isGroupOwner as MockedFunction<typeof isGroupOwner>;
@@ -36,6 +39,7 @@ const mockIsGroupOwner = isGroupOwner as MockedFunction<typeof isGroupOwner>;
 describe("fetchMessageDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsMessageRecipient.mockResolvedValue(false);
   });
 
   const messageDetail = {
@@ -75,7 +79,18 @@ describe("fetchMessageDetail", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects non-sender non-admin access", async () => {
+  it("returns message detail for recipient who is not the sender", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
+    mockGetMessageById.mockResolvedValue(messageDetail);
+    mockIsMessageRecipient.mockResolvedValue(true);
+    mockGetMessageRecipients.mockResolvedValue(recipients);
+
+    const result = await fetchMessageDetail(1);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-sender non-recipient non-admin access", async () => {
     mockVerifySession.mockResolvedValue({ ownerid: 100003, isAdmin: false });
     mockGetMessageById.mockResolvedValue(messageDetail);
 

--- a/test/components/dashboard-cards.test.tsx
+++ b/test/components/dashboard-cards.test.tsx
@@ -7,7 +7,7 @@ describe("TotalMembersCard", () => {
     render(<TotalMembersCard count={376} />);
     expect(screen.getByText("376/500")).toBeInTheDocument();
     expect(screen.getByText("Total Members")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /View all/ })).toHaveAttribute("href", "/referral-database");
+    expect(screen.queryByRole("link", { name: /View all/ })).not.toBeInTheDocument();
   });
 
   it("renders the empty state as 0/500", () => {


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Gap analysis found 6 UI/UX issues. Members could not view messages sent to them. The Leave Group button had no confirmation dialog. The Total Members card linked to an admin-only page. The group member table had no empty state. There was no way to delete a profile photo. The email toggle description did not explain the relationship between global and per-group settings.

- `src/services/message.ts` - added isMessageRecipient function for recipient permission checks
- `src/actions/contact-group.ts` - fetchMessageDetail now allows recipients (not just senders) to view message details
- `src/app/(protected)/groups/[id]/group-detail-content.tsx` - Leave Group button wrapped in AlertDialog confirmation with destructive styling
- `src/components/dashboard/stat-card.tsx` - viewAllHref prop now optional
- `src/components/dashboard/total-members-card.tsx` - removed broken link to /referral-database
- `src/components/groups/group-member-table.tsx` - added empty state message when no members
- `src/actions/settings.ts` - added deletePhotoAction
- `src/components/profile/profile-photo-upload.tsx` - added onDelete prop and Remove button visible when photo exists
- `src/app/(protected)/profile/profile-content.tsx` - wired deletePhotoAction to Remove button
- `src/components/settings/notification-preferences-card.tsx` - updated email toggle description to explain global vs per-group behavior
- `test/actions/message-query.test.ts` - added recipient access test
- `test/components/dashboard-cards.test.tsx` - updated for removed link

## How to test

1. Log in as member, visit /messages, click a message sent to them - verify detail modal opens
2. Visit /groups/[id], click Leave Group - verify confirmation dialog appears before action
3. Visit /home - verify Total Members card has no "View all" link
4. Visit /groups/[id] for a group with no members - verify "No members in this group." text
5. Visit /profile with a photo - verify "Remove" button appears next to "Upload"
6. Visit /settings - verify email toggle description says "Turning this off stops all group emails"

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers