### PR TITLE
feat: event invitation filter, rsvp ui, quick action deep links, ui fixes

### DIFF
--- a/src/actions/event.ts
+++ b/src/actions/event.ts
@@ -150,11 +150,14 @@ export async function fetchEventDetail(eventId: number): Promise<
   }
 }
 
-export async function fetchEventsForWeek(weekStart: Date): Promise<ActionResult<EventSummary[]>> {
+export async function fetchEventsForWeek(
+  weekStart: Date,
+  filters?: { inviteeMemberId?: number },
+): Promise<ActionResult<EventSummary[]>> {
   try {
     await verifySession();
     const validatedWeekStart = WeekStartSchema.parse(weekStart);
-    const events = await getEventsForWeek(validatedWeekStart);
+    const events = await getEventsForWeek(validatedWeekStart, filters);
     return { success: true, data: events };
   } catch (error) {
     const appError = transformError(error);
@@ -165,7 +168,7 @@ export async function fetchEventsForWeek(weekStart: Date): Promise<ActionResult<
 export async function fetchEventsForMonth(
   year: number,
   month: number,
-  filters?: { eventType?: EventType; groupId?: number },
+  filters?: { eventType?: EventType; groupId?: number; inviteeMemberId?: number },
 ): Promise<ActionResult<EventSummary[]>> {
   try {
     await verifySession();

--- a/src/app/(protected)/events/events-content.tsx
+++ b/src/app/(protected)/events/events-content.tsx
@@ -2,6 +2,7 @@
 
 import { handleActionError } from "@/utils/auth-redirect";
 import { useEffect, useMemo, useState, useTransition } from "react";
+import { useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -76,13 +77,22 @@ export function EventsContent({
   const [currentDate, setCurrentDate] = useState<Date>(() => new Date(initialDateIso));
   const [weekEvents, setWeekEvents] = useState<EventSummary[]>(() => parseEvents(initialWeekEvents));
   const [monthEvents, setMonthEvents] = useState<EventSummary[]>([]);
+  const [eventScope, setEventScope] = useState<"my" | "all">(isAdmin ? "all" : "my");
   const [groupFilter, setGroupFilter] = useState<string>("all");
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [selectedDay, setSelectedDay] = useState<Date>(initialSelected);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createDefaultDate, setCreateDefaultDate] = useState<Date | undefined>();
+  const searchParams = useSearchParams();
+  const shouldAutoCreate = searchParams.get("create") === "true";
+  const [createOpen, setCreateOpen] = useState(shouldAutoCreate);
+  const [createDefaultDate, setCreateDefaultDate] = useState<Date | undefined>(() => {
+    if (!shouldAutoCreate) return undefined;
+    const now = coopNow();
+    return coopWallClockToUtc(now.year, now.month0, now.day, DEFAULT_EVENT_START_HOUR, 0);
+  });
   const [editingEvent, setEditingEvent] = useState<EventWithRsvpCount | null>(null);
   const [editingInviteeIds, setEditingInviteeIds] = useState<number[]>([]);
+  const [editingRsvps, setEditingRsvps] = useState<Array<{ memberId: number; memberName: string; status: string }>>([]);
+  const [currentUserRsvpStatus, setCurrentUserRsvpStatus] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const groupOptions: GroupOption[] = useMemo(
@@ -118,24 +128,30 @@ export function EventsContent({
   );
   const weekHeading = useMemo(() => buildWeekHeading(currentDate), [currentDate]);
 
+  const inviteeFilter = eventScope === "my" ? currentUserOwnerid : undefined;
+
   useEffect(() => {
     if (view !== "month") return;
     const groupId = groupFilter === "all" ? undefined : Number(groupFilter);
     const eventType = typeFilter === "all" ? undefined : (typeFilter as EventType);
     const { year, month0 } = coopDateParts(currentDate);
     startTransition(async () => {
-      const result = await fetchEventsForMonth(year, month0 + 1, { eventType, groupId });
+      const result = await fetchEventsForMonth(year, month0 + 1, {
+        eventType,
+        groupId,
+        inviteeMemberId: inviteeFilter,
+      });
       if (result.success && result.data) {
         setMonthEvents(parseEvents(result.data));
       } else if (!result.success) {
         toast.error(handleActionError(result.error, "Failed to load events"));
       }
     });
-  }, [view, currentDate, groupFilter, typeFilter]);
+  }, [view, currentDate, groupFilter, typeFilter, inviteeFilter]);
 
   const refetchWeek = (anchor: Date) => {
     startTransition(async () => {
-      const result = await fetchEventsForWeek(coopStartOfWeek(anchor));
+      const result = await fetchEventsForWeek(coopStartOfWeek(anchor), { inviteeMemberId: inviteeFilter });
       if (result.success && result.data) {
         setWeekEvents(parseEvents(result.data));
       } else if (!result.success) {
@@ -149,13 +165,30 @@ export function EventsContent({
     const eventType = typeFilter === "all" ? undefined : (typeFilter as EventType);
     const { year, month0 } = coopDateParts(anchor);
     startTransition(async () => {
-      const result = await fetchEventsForMonth(year, month0 + 1, { eventType, groupId });
+      const result = await fetchEventsForMonth(year, month0 + 1, {
+        eventType,
+        groupId,
+        inviteeMemberId: inviteeFilter,
+      });
       if (result.success && result.data) {
         setMonthEvents(parseEvents(result.data));
       } else if (!result.success) {
         toast.error(handleActionError(result.error, "Failed to load events"));
       }
     });
+  };
+
+  const handleScopeChange = (scope: "my" | "all") => {
+    setEventScope(scope);
+    if (view === "week") {
+      const newFilter = scope === "my" ? currentUserOwnerid : undefined;
+      startTransition(async () => {
+        const result = await fetchEventsForWeek(coopStartOfWeek(currentDate), { inviteeMemberId: newFilter });
+        if (result.success && result.data) {
+          setWeekEvents(parseEvents(result.data));
+        }
+      });
+    }
   };
 
   const advanceMonth = (delta: number): Date => {
@@ -203,6 +236,15 @@ export function EventsContent({
         const parsed = EventWithRsvpCountSchema.parse(result.data.event) as EventWithRsvpCount;
         setEditingEvent(parsed);
         setEditingInviteeIds(result.data.inviteeMemberIds);
+        setEditingRsvps(
+          (result.data.rsvps ?? []).map((r) => ({
+            memberId: r.memberId,
+            memberName: r.memberName,
+            status: r.status,
+          })),
+        );
+        const myRsvp = result.data.rsvps?.find((r) => r.memberId === currentUserOwnerid);
+        setCurrentUserRsvpStatus(myRsvp?.status ?? null);
         setCreateDefaultDate(undefined);
         setCreateOpen(true);
       } else if (!result.success) {
@@ -284,6 +326,28 @@ export function EventsContent({
         >
           <ChevronRight className="h-5 w-5 text-prfc-brown" />
         </button>
+        <div className="flex rounded-lg border border-border">
+          <button
+            type="button"
+            onClick={() => handleScopeChange("my")}
+            className={cn(
+              "rounded-l-lg px-4 py-2 text-sm font-medium transition-colors",
+              eventScope === "my" ? "bg-prfc-brown text-white" : "text-muted-foreground hover:bg-muted",
+            )}
+          >
+            My Events
+          </button>
+          <button
+            type="button"
+            onClick={() => handleScopeChange("all")}
+            className={cn(
+              "rounded-r-lg px-4 py-2 text-sm font-medium transition-colors",
+              eventScope === "all" ? "bg-prfc-brown text-white" : "text-muted-foreground hover:bg-muted",
+            )}
+          >
+            All Events
+          </button>
+        </div>
         {view === "month" && (
           <>
             <Select value={groupFilter} onValueChange={setGroupFilter}>
@@ -400,6 +464,10 @@ export function EventsContent({
             initialMemberIds={editingInviteeIds}
             canEdit={canEditCurrent}
             onDeleted={handleDeleted}
+            currentUserOwnerid={currentUserOwnerid}
+            currentUserRsvpStatus={currentUserRsvpStatus}
+            inviteeMemberIds={editingInviteeIds}
+            rsvps={editingRsvps}
           />
         </DialogContent>
       </Dialog>

--- a/src/app/(protected)/groups/groups-content.tsx
+++ b/src/app/(protected)/groups/groups-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Plus, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -29,6 +29,7 @@ export function GroupsContent({ myGroups, allGroups, isAdmin, ownerId, members }
   const [view, setView] = useState<"my" | "all">("my");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("all");
+  const searchParams = useSearchParams();
   const {
     modal,
     isPending,
@@ -41,7 +42,7 @@ export function GroupsContent({ myGroups, allGroups, isAdmin, ownerId, members }
     handleConfirmDelete,
     handleCreateSubmit,
     handleDeleteCancel,
-  } = useGroupsModal(ownerId);
+  } = useGroupsModal(ownerId, searchParams.get("create") === "true");
 
   const ownerNameMap = useMemo(() => new Map(members.map((m) => [m.ownerid, m.ownername])), [members]);
   const groups = view === "all" ? allGroups : myGroups;

--- a/src/app/(protected)/home/home-content.tsx
+++ b/src/app/(protected)/home/home-content.tsx
@@ -36,8 +36,8 @@ export function HomeContent({
         <TotalMembersCard count={totalMembers} />
         <EventsThisMonthCard count={eventsThisMonth} />
         <QuickActionsCard
-          onCreateEvent={() => router.push("/events")}
-          onCreateGroup={() => router.push("/groups")}
+          onCreateEvent={() => router.push("/events?create=true")}
+          onCreateGroup={() => router.push("/groups?create=true")}
           onSendMessage={() => router.push("/messages/compose")}
         />
       </div>

--- a/src/app/(protected)/messages/messages-content.tsx
+++ b/src/app/(protected)/messages/messages-content.tsx
@@ -205,53 +205,55 @@ export function MessagesContent({ initialPage, smsFeatureEnabled }: Props) {
         <MessageHistoryTable messages={page.items} onView={handleView} />
       </div>
 
-      <div className="mt-4 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Rows per page</span>
-          <Select
-            value={String(pageSize)}
-            onValueChange={(v) => {
-              const size = Number(v) as 10 | 25 | 50;
-              setPageSize(size);
-              fetchFirstPage({ pageSize: size });
-            }}
-          >
-            <SelectTrigger className="w-20">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="10">10</SelectItem>
-              <SelectItem value="25">25</SelectItem>
-              <SelectItem value="50">50</SelectItem>
-            </SelectContent>
-          </Select>
+      {page.totalCount > 0 && (
+        <div className="mt-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Rows per page</span>
+            <Select
+              value={String(pageSize)}
+              onValueChange={(v) => {
+                const size = Number(v) as 10 | 25 | 50;
+                setPageSize(size);
+                fetchFirstPage({ pageSize: size });
+              }}
+            >
+              <SelectTrigger className="w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10</SelectItem>
+                <SelectItem value="25">25</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <span className="text-sm text-muted-foreground">
+            {page.totalCount === 0 ? "No messages" : `Showing ${startIndex}-${endIndex} of ${page.totalCount}`}
+          </span>
+
+          <nav className="flex items-center gap-2" aria-label="Pagination">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handlePrevPage}
+              disabled={!page.prevCursor || isPending}
+              aria-disabled={!page.prevCursor || isPending}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleNextPage}
+              disabled={!page.nextCursor || isPending}
+              aria-disabled={!page.nextCursor || isPending}
+            >
+              Next
+            </Button>
+          </nav>
         </div>
-
-        <span className="text-sm text-muted-foreground">
-          {page.totalCount === 0 ? "No messages" : `Showing ${startIndex}-${endIndex} of ${page.totalCount}`}
-        </span>
-
-        <nav className="flex items-center gap-2" aria-label="Pagination">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handlePrevPage}
-            disabled={!page.prevCursor || isPending}
-            aria-disabled={!page.prevCursor || isPending}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleNextPage}
-            disabled={!page.nextCursor || isPending}
-            aria-disabled={!page.nextCursor || isPending}
-          >
-            Next
-          </Button>
-        </nav>
-      </div>
+      )}
 
       {viewModal && (
         <ViewMessageModal

--- a/src/components/dashboard/recent-activity-card.tsx
+++ b/src/components/dashboard/recent-activity-card.tsx
@@ -1,4 +1,3 @@
-import { ChevronRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface RecentActivityCardProps {
@@ -28,13 +27,6 @@ export function RecentActivityCard({ activities }: RecentActivityCardProps) {
             ))
           )}
         </div>
-        <hr className="mt-3 border-prfc-border/30" />
-        <button
-          type="button"
-          className="mt-3 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        >
-          View all <ChevronRight className="h-4 w-4" />
-        </button>
       </CardContent>
     </Card>
   );

--- a/src/components/events/create-event-popover.tsx
+++ b/src/components/events/create-event-popover.tsx
@@ -21,7 +21,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { DateTimePicker } from "@/components/events/date-time-picker";
 import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { InviteeCombobox, type GroupOption, type MemberOption } from "@/components/events/invitee-combobox";
-import { createEventAction, deleteEventAction, updateEventAction } from "@/actions/event";
+import { createEventAction, deleteEventAction, updateEventAction, rsvpAction } from "@/actions/event";
 import {
   DEFAULT_EVENT_DURATION_MS,
   DEFAULT_EVENT_START_HOUR,
@@ -44,6 +44,10 @@ type Props = {
   initialMemberIds?: number[];
   canEdit?: boolean;
   onDeleted?: (eventId: number) => void;
+  currentUserOwnerid?: number;
+  currentUserRsvpStatus?: string | null;
+  inviteeMemberIds?: number[];
+  rsvps?: Array<{ memberId: number; memberName: string; status: string }>;
 };
 
 const EVENT_TYPES: { value: EventType; label: string; dot: string }[] = [
@@ -74,6 +78,10 @@ export function CreateEventPopover({
   initialMemberIds,
   canEdit = true,
   onDeleted,
+  currentUserOwnerid,
+  currentUserRsvpStatus,
+  inviteeMemberIds = [],
+  rsvps = [],
 }: Props) {
   const isEditMode = editingEvent !== undefined;
   const readOnly = isEditMode && !canEdit;
@@ -111,6 +119,19 @@ export function CreateEventPopover({
   const [error, setError] = useState("");
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const [rsvpStatus, setRsvpStatus] = useState<string | null>(currentUserRsvpStatus ?? null);
+
+  const handleRsvp = (status: "going" | "maybe" | "declined") => {
+    if (!editingEvent) return;
+    setRsvpStatus(status);
+    startTransition(async () => {
+      const result = await rsvpAction({ eventId: editingEvent.id, status });
+      if (!result.success) {
+        setRsvpStatus(currentUserRsvpStatus ?? null);
+        toast.error(handleActionError(result.error, "Failed to update RSVP"));
+      }
+    });
+  };
 
   useEffect(() => {
     if (!readOnly) titleRef.current?.focus();
@@ -244,7 +265,7 @@ export function CreateEventPopover({
           placeholder="New Event Title"
           maxLength={200}
           disabled={readOnly}
-          className="w-full border-none bg-transparent font-angkor text-3xl text-prfc-red outline-none placeholder:text-foreground disabled:cursor-default disabled:opacity-100"
+          className="w-full border-none bg-transparent font-angkor text-3xl text-prfc-red outline-none placeholder:text-muted-foreground disabled:cursor-default disabled:opacity-100"
           aria-label="Event title"
         />
 
@@ -358,6 +379,29 @@ export function CreateEventPopover({
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {isEditMode &&
+          rsvps.length > 0 &&
+          (canEdit || (currentUserOwnerid && inviteeMemberIds.includes(currentUserOwnerid))) && (
+            <div className="mt-4 border-t border-prfc-border/20 pt-4">
+              <p className="mb-2 text-sm font-semibold text-foreground">Responses ({rsvps.length})</p>
+              <div className="space-y-2">
+                {["going", "maybe", "declined"].map((status) => {
+                  const group = rsvps.filter((r) => r.status === status);
+                  if (group.length === 0) return null;
+                  const label = status === "going" ? "Going" : status === "maybe" ? "Maybe" : "No";
+                  return (
+                    <div key={status}>
+                      <p className="text-xs font-medium text-muted-foreground">
+                        {label} ({group.length})
+                      </p>
+                      <p className="text-sm">{group.map((r) => r.memberName).join(", ")}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
       </div>
 
       <div className="flex items-center justify-end gap-2 border-t border-prfc-border/30 bg-white px-6 py-4">
@@ -373,9 +417,50 @@ export function CreateEventPopover({
             Delete
           </Button>
         )}
-        <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onClose}
+          disabled={isPending}
+          className={readOnly ? "mr-auto" : ""}
+        >
           {readOnly ? "Close" : "Cancel"}
         </Button>
+        {readOnly && editingEvent && currentUserOwnerid && inviteeMemberIds.includes(currentUserOwnerid) && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-muted-foreground">RSVP</span>
+            <Button
+              type="button"
+              variant={rsvpStatus === "going" ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleRsvp("going")}
+              disabled={isPending}
+              className={rsvpStatus === "going" ? "bg-green-700 text-white hover:bg-green-800" : ""}
+            >
+              Going
+            </Button>
+            <Button
+              type="button"
+              variant={rsvpStatus === "maybe" ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleRsvp("maybe")}
+              disabled={isPending}
+              className={rsvpStatus === "maybe" ? "bg-amber-600 text-white hover:bg-amber-700" : ""}
+            >
+              Maybe
+            </Button>
+            <Button
+              type="button"
+              variant={rsvpStatus === "declined" ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleRsvp("declined")}
+              disabled={isPending}
+              className={rsvpStatus === "declined" ? "bg-red-700 text-white hover:bg-red-800" : ""}
+            >
+              No
+            </Button>
+          </div>
+        )}
         {!readOnly && (
           <Button
             type="button"

--- a/src/components/events/invitee-avatar-stack.tsx
+++ b/src/components/events/invitee-avatar-stack.tsx
@@ -39,7 +39,7 @@ export function InviteeAvatarStack({ invitees, max = 6 }: Props) {
       ))}
       {overflow > 0 && (
         <span
-          className="ml-[-8px] flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-paso-light-brown text-xs font-semibold text-prfc-brown"
+          className="ml-[-8px] flex h-8 min-w-8 items-center justify-center rounded-full border-2 border-white bg-paso-light-brown px-2 text-xs font-semibold text-prfc-brown"
           style={{ zIndex: 0 }}
         >
           +{overflow}

--- a/src/components/groups/use-groups-modal.ts
+++ b/src/components/groups/use-groups-modal.ts
@@ -41,8 +41,8 @@ export type ModalState =
   | { type: "delete"; group: EnrichedGroupData }
   | { type: "addMembers"; group: EnrichedGroupData; memberRows: MemberRow[] };
 
-export function useGroupsModal(ownerId: number) {
-  const [modal, setModal] = useState<ModalState>({ type: "closed" });
+export function useGroupsModal(ownerId: number, initialCreate: boolean = false) {
+  const [modal, setModal] = useState<ModalState>(initialCreate ? { type: "create" } : { type: "closed" });
   const [isPending, startTransition] = useTransition();
   const [loadingGroupId, setLoadingGroupId] = useState<number | null>(null);
 

--- a/src/schema/event.ts
+++ b/src/schema/event.ts
@@ -32,6 +32,7 @@ export const FetchEventsForMonthSchema = z.object({
     .object({
       eventType: z.enum(["social", "networking", "volunteer", "meeting"]).optional(),
       groupId: z.number().int().positive().optional(),
+      inviteeMemberId: z.number().int().positive().optional(),
     })
     .optional(),
 });

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -91,7 +91,7 @@ export async function getUpcomingEvents(limit: number = 5): Promise<EventSummary
 export async function getEventsForMonth(
   year: number,
   month: number,
-  filters?: { eventType?: EventType; groupId?: number },
+  filters?: { eventType?: EventType; groupId?: number; inviteeMemberId?: number },
 ): Promise<EventSummary[]> {
   try {
     const coopStart = coopStartOfMonth(year, month);
@@ -109,6 +109,16 @@ export async function getEventsForMonth(
         },
         ...(filters?.eventType ? [{ eventType: filters.eventType }] : []),
         ...(filters?.groupId ? [{ groupId: filters.groupId }] : []),
+        ...(filters?.inviteeMemberId
+          ? [
+              {
+                OR: [
+                  { invitees: { some: { memberId: filters.inviteeMemberId } } },
+                  { ownerid: filters.inviteeMemberId },
+                ],
+              },
+            ]
+          : []),
       ],
     });
   } catch (error) {
@@ -116,7 +126,10 @@ export async function getEventsForMonth(
   }
 }
 
-export async function getEventsForWeek(weekStart: Date): Promise<EventSummary[]> {
+export async function getEventsForWeek(
+  weekStart: Date,
+  filters?: { inviteeMemberId?: number },
+): Promise<EventSummary[]> {
   try {
     const coopStart = coopStartOfWeek(weekStart);
     const coopEnd = coopEndOfWeek(weekStart);
@@ -124,9 +137,23 @@ export async function getEventsForWeek(weekStart: Date): Promise<EventSummary[]>
     const floatingEnd = utcEndOfWeek(weekStart);
 
     return await queryEventSummaries({
-      OR: [
-        { isAllDay: false, startDate: { gte: coopStart, lte: coopEnd } },
-        { isAllDay: true, startDate: { gte: floatingStart, lte: floatingEnd } },
+      AND: [
+        {
+          OR: [
+            { isAllDay: false, startDate: { gte: coopStart, lte: coopEnd } },
+            { isAllDay: true, startDate: { gte: floatingStart, lte: floatingEnd } },
+          ],
+        },
+        ...(filters?.inviteeMemberId
+          ? [
+              {
+                OR: [
+                  { invitees: { some: { memberId: filters.inviteeMemberId } } },
+                  { ownerid: filters.inviteeMemberId },
+                ],
+              },
+            ]
+          : []),
       ],
     });
   } catch (error) {

--- a/test/actions/event.test.ts
+++ b/test/actions/event.test.ts
@@ -239,7 +239,7 @@ describe("fetchEventsForWeek", () => {
     const result = await fetchEventsForWeek(weekStart);
 
     expect(result).toEqual({ success: true, data: events });
-    expect(mockGetEventsForWeek).toHaveBeenCalledWith(weekStart);
+    expect(mockGetEventsForWeek).toHaveBeenCalledWith(weekStart, undefined);
   });
 
   it("returns error when service throws", async () => {

--- a/test/components/events-content.test.tsx
+++ b/test/components/events-content.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 vi.mock("@/actions/event", () => ({
   fetchEventsForWeek: vi.fn().mockResolvedValue({ success: true, data: [] }),
   fetchEventsForMonth: vi.fn().mockResolvedValue({ success: true, data: [] }),

--- a/test/services/event.test.ts
+++ b/test/services/event.test.ts
@@ -172,21 +172,33 @@ describe("getEventsForMonth", () => {
 });
 
 describe("getEventsForWeek", () => {
-  it("queries timed events in coop-zone week and all-day events in UTC week via OR clause", async () => {
+  it("queries timed events in coop-zone week and all-day events in UTC week", async () => {
     mockPrisma.event.findMany.mockResolvedValue([] as never);
 
     await getEventsForWeek(new Date("2026-04-15T21:00:00.000Z"));
 
     const call = mockPrisma.event.findMany.mock.calls[0][0] as {
-      where: { OR: Array<{ isAllDay: boolean; startDate: { gte: Date; lte: Date } }> };
+      where: { AND: Array<{ OR?: Array<{ isAllDay: boolean; startDate: { gte: Date; lte: Date } }> }> };
     };
-    expect(call.where.OR).toHaveLength(2);
-    const timed = call.where.OR.find((c) => c.isAllDay === false);
-    const allDay = call.where.OR.find((c) => c.isAllDay === true);
+    const dateFilter = call.where.AND[0].OR!;
+    expect(dateFilter).toHaveLength(2);
+    const timed = dateFilter.find((c) => c.isAllDay === false);
+    const allDay = dateFilter.find((c) => c.isAllDay === true);
     expect(timed?.startDate.gte.toISOString()).toBe("2026-04-12T07:00:00.000Z");
     expect(timed?.startDate.lte.toISOString()).toBe("2026-04-19T06:59:59.999Z");
     expect(allDay?.startDate.gte.toISOString()).toBe("2026-04-12T00:00:00.000Z");
     expect(allDay?.startDate.lte.toISOString()).toBe("2026-04-18T23:59:59.999Z");
+  });
+
+  it("filters by inviteeMemberId when provided", async () => {
+    mockPrisma.event.findMany.mockResolvedValue([] as never);
+
+    await getEventsForWeek(new Date("2026-04-15T21:00:00.000Z"), { inviteeMemberId: 100003 });
+
+    const call = mockPrisma.event.findMany.mock.calls[0][0] as {
+      where: { AND: unknown[] };
+    };
+    expect(call.where.AND).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I added a My Events / All Events segmented control to the events page, RSVP buttons for invited members in the event detail popover, and deep-link support for dashboard quick action buttons. Fixed several UI gaps found during gap analysis.

- `src/services/event.ts` - getEventsForMonth and getEventsForWeek accept inviteeMemberId filter, queries invitees OR event owner
- `src/schema/event.ts` - added inviteeMemberId to FetchEventsForMonthSchema
- `src/actions/event.ts` - fetchEventsForWeek accepts filters, fetchEventsForMonth passes inviteeMemberId through
- `src/app/(protected)/events/events-content.tsx` - My Events / All Events segmented control, members default to "my", admins to "all", auto-opens create dialog on ?create=true via useState initializer
- `src/components/events/create-event-popover.tsx` - Going/Maybe/No RSVP buttons for invited members in read-only mode, RSVP responses list visible to admins/owner/invitees grouped by status, placeholder text changed to muted-foreground, rsvpAction now called from UI
- `src/components/events/invitee-avatar-stack.tsx` - overflow count badge changed from fixed circle to pill shape for 3-digit numbers
- `src/app/(protected)/groups/groups-content.tsx` - auto-opens create modal on ?create=true via useGroupsModal initialCreate param
- `src/components/groups/use-groups-modal.ts` - added initialCreate parameter
- `src/app/(protected)/home/home-content.tsx` - quick actions pass ?create=true to events and groups routes
- `src/components/dashboard/recent-activity-card.tsx` - removed dead "View all" button with no handler
- `src/app/(protected)/messages/messages-content.tsx` - pagination footer hidden when no messages
- `test/services/event.test.ts` - updated week query tests for new AND structure, added inviteeMemberId filter test
- `test/actions/event.test.ts` - updated fetchEventsForWeek assertion for filters param
- `test/components/events-content.test.tsx` - added useSearchParams mock

## How to test

1. Visit /events as member - verify "My Events" is active, only invited/created events show
2. Toggle "All Events" - all events appear
3. Click an event you were invited to - verify Going/Maybe/No buttons in footer
4. Click Going - button turns green, status persists on reopen
5. Open an event you were not invited to - no RSVP buttons
6. Visit /home, click "Create Event" - navigates to /events with create dialog open
7. Click "Create Group" - navigates to /groups with create modal open
8. Visit /messages with no messages - verify single "No messages yet" text, no pagination footer

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers