### PR TITLE
fix: sms feature gate on compose, avatar consistency, remove staging infra

### DIFF
--- a/e2e/feature-flows.spec.ts
+++ b/e2e/feature-flows.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, type Page } from "@playwright/test";
+import path from "node:path";
+
+async function loginAs(page: Page, ownerid: string) {
+  await page.goto("/dev/mock-portal");
+  await page.getByText("Dev Tools").click();
+  await page.getByLabel("Select Member").selectOption(ownerid);
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.waitForURL("/home");
+}
+
+// ── Block 6: Dashboard ──────────────────────────────────
+
+test.describe("Dashboard", () => {
+  test("displays stat cards with data", async ({ page }) => {
+    await loginAs(page, "100001");
+
+    await expect(page.getByText("Total Members")).toBeVisible();
+    await expect(page.getByText("Events This Month")).toBeVisible();
+    await expect(page.getByText("Quick Actions")).toBeVisible();
+  });
+
+  test("quick action Create Event navigates and opens dialog", async ({ page }) => {
+    await loginAs(page, "100001");
+
+    await page.getByRole("button", { name: "Create Event" }).click();
+    await page.waitForURL("/events?create=true");
+
+    await expect(page.getByPlaceholder("New Event Title")).toBeVisible();
+  });
+
+  test("quick action Create Group navigates and opens modal", async ({ page }) => {
+    await loginAs(page, "100001");
+
+    await page.getByRole("button", { name: "Create Group" }).click();
+    await page.waitForURL("/groups?create=true");
+
+    await expect(page.getByText("Create Group")).toBeVisible();
+  });
+
+  test("quick action Send Message navigates to compose", async ({ page }) => {
+    await loginAs(page, "100001");
+
+    await page.getByRole("button", { name: "Send Message" }).click();
+    await page.waitForURL("/messages/compose");
+
+    await expect(page.getByText("New Message")).toBeVisible();
+  });
+
+  test("dashboard loads for member", async ({ page }) => {
+    await loginAs(page, "100003");
+
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  });
+});
+
+// ── Block 2: Group lifecycle ────────────────────────────
+
+test.describe("Groups", () => {
+  test("admin sees My Groups and All Groups toggle", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/groups");
+
+    await expect(page.getByRole("button", { name: "My Groups" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "All Groups" })).toBeVisible();
+  });
+
+  test("member does not see All Groups toggle", async ({ page }) => {
+    await loginAs(page, "100003");
+    await page.goto("/groups");
+
+    await expect(page.getByRole("button", { name: "All Groups" })).not.toBeVisible();
+  });
+
+  test("admin creates a group and it appears in the list", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/groups?create=true");
+
+    const groupName = `E2E Test Group ${Date.now()}`;
+    await page.getByPlaceholder("Group Name").fill(groupName);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByText("Group created")).toBeVisible({ timeout: 10000 });
+    await page.goto("/groups");
+    await expect(page.getByText(groupName)).toBeVisible();
+  });
+
+  test("admin creates group, member sees it under All Groups", async ({ page }) => {
+    const groupName = `Member View Test ${Date.now()}`;
+
+    await loginAs(page, "100001");
+    await page.goto("/groups?create=true");
+    await page.getByPlaceholder("Group Name").fill(groupName);
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("Group created")).toBeVisible({ timeout: 10000 });
+
+    await loginAs(page, "100003");
+    await page.goto("/groups");
+
+    await expect(page.getByText(groupName)).not.toBeVisible();
+  });
+});
+
+// ── Block 3: Events ─────────────────────────────────────
+
+test.describe("Events", () => {
+  test("admin sees My Events and All Events toggle", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/events");
+
+    await expect(page.getByRole("button", { name: "My Events" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "All Events" })).toBeVisible();
+  });
+
+  test("week and month view toggle works", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/events");
+
+    const viewSelect = page.locator("select, [role='combobox']").filter({ hasText: "Week" });
+    await expect(viewSelect.first()).toBeVisible();
+  });
+
+  test("events title heading is visible", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/events");
+
+    await expect(page.getByRole("heading", { name: "Events" })).toBeVisible();
+  });
+});
+
+// ── Block 4: Messages ───────────────────────────────────
+
+test.describe("Messages", () => {
+  test("message history page loads with heading", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/messages");
+
+    await expect(page.getByRole("heading", { name: "Message History" })).toBeVisible();
+  });
+
+  test("search input is visible and functional", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/messages");
+
+    const search = page.getByLabel("Search messages");
+    await expect(search).toBeVisible();
+    await search.fill("test query");
+    await expect(search).toHaveValue("test query");
+  });
+
+  test("compose page accessible from messages", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/messages");
+
+    await page.getByRole("link", { name: "New Message" }).click();
+    await page.waitForURL("/messages/compose");
+
+    await expect(page.getByText("New Message")).toBeVisible();
+  });
+
+  test("member with no messages sees empty state", async ({ page }) => {
+    await loginAs(page, "100003");
+    await page.goto("/messages");
+
+    await expect(page.getByText("No messages yet")).toBeVisible();
+  });
+});
+
+// ── Block 5: Settings ───────────────────────────────────
+
+test.describe("Settings", () => {
+  test("settings page loads with notification preferences", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/settings");
+
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByText("Notifications")).toBeVisible();
+  });
+
+  test("email toggle is visible with description", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/settings");
+
+    await expect(page.getByText("Receive event announcements and group messages via email")).toBeVisible();
+    await expect(page.getByText("Turning this off stops all group emails")).toBeVisible();
+  });
+});
+
+// ── Block 5: Profile ────────────────────────────────────
+
+test.describe("Profile", () => {
+  test("profile page loads with user info", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/profile");
+
+    await expect(page.getByRole("heading", { name: "My Profile" })).toBeVisible();
+    await expect(page.getByText("Profile Photo")).toBeVisible();
+  });
+
+  test("upload button is visible", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/profile");
+
+    await expect(page.getByRole("button", { name: "Upload" })).toBeVisible();
+  });
+
+  test("rejects invalid file type via client validation", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/profile");
+
+    const fileInput = page.getByLabel("Upload profile photo");
+    await fileInput.setInputFiles({
+      name: "test.gif",
+      mimeType: "image/gif",
+      buffer: Buffer.from("fake gif content"),
+    });
+
+    await expect(page.getByText("Profile photo must be JPG or PNG")).toBeVisible();
+  });
+
+  test("uploads a valid photo and shows success toast", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/profile");
+
+    const fileInput = page.getByLabel("Upload profile photo");
+    await fileInput.setInputFiles(path.join(__dirname, "fixtures", "test-photo.png"));
+
+    await expect(page.getByText("Photo updated")).toBeVisible({ timeout: 15000 });
+  });
+});
+
+// ── Block 7: Authorization ──────────────────────────────
+
+test.describe("Authorization", () => {
+  test("member cannot access referral database", async ({ page }) => {
+    await loginAs(page, "100003");
+    await page.goto("/referral-database");
+
+    expect(page.url()).toContain("/forbidden");
+    await expect(page.getByText("No permission")).toBeVisible();
+  });
+
+  test("admin can access referral database", async ({ page }) => {
+    await loginAs(page, "100001");
+    await page.goto("/referral-database");
+
+    expect(page.url()).toContain("/referral-database");
+  });
+
+  test("unauthenticated user is redirected to unauthorized", async ({ page }) => {
+    await page.goto("/home");
+
+    expect(page.url()).toContain("/unauthorized");
+    await expect(page.getByText("Sign in required")).toBeVisible();
+  });
+});

--- a/src/app/(dev)/dev/mock-portal/page.tsx
+++ b/src/app/(dev)/dev/mock-portal/page.tsx
@@ -1,7 +1,7 @@
 import MockPortalContent from "./mock-portal-content";
 
 export default function MockPortalPage() {
-  if (process.env.NODE_ENV === "production" && process.env.STAGING !== "true") {
+  if (process.env.NODE_ENV === "production") {
     return (
       <main className="flex flex-1 items-center justify-center">
         <p>Not available in production</p>

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getSessionWithName } from "@/lib/dal";
 import { getUnseenNotificationCount, getLastNotificationSeenAt } from "@/services/dashboard";
+import { getProfilePhotoUrl } from "@/services/user-preference";
 import { AppError } from "@/utils/errors";
 import { TopBarActionProvider } from "@/components/layout/top-bar-action-context";
 import { TopBarSearchProvider } from "@/components/layout/top-bar-search-context";
@@ -20,9 +21,10 @@ export default async function ProtectedLayout({ children }: { children: React.Re
     throw error;
   }
   const userRole = session.isAdmin ? "Admin Manager" : "Member";
-  const [unseenCount, lastSeenAt] = await Promise.all([
+  const [unseenCount, lastSeenAt, photoUrl] = await Promise.all([
     getUnseenNotificationCount(session.ownerid),
     getLastNotificationSeenAt(session.ownerid),
+    getProfilePhotoUrl(session.ownerid),
   ]);
 
   return (
@@ -35,6 +37,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
             userRole={userRole}
             unseenCount={unseenCount}
             lastSeenAt={lastSeenAt?.toISOString() ?? null}
+            photoUrl={photoUrl}
           />
           <LayoutContent>{children}</LayoutContent>
         </TopBarSearchProvider>

--- a/src/app/(protected)/messages/compose/compose-content.tsx
+++ b/src/app/(protected)/messages/compose/compose-content.tsx
@@ -12,9 +12,10 @@ type Props = {
   groups: Array<{ id: number; name: string }>;
   currentUser: { name: string; photoUrl?: string | null };
   isAdmin: boolean;
+  smsFeatureEnabled: boolean;
 };
 
-export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
+export function ComposeContent({ groups, currentUser, isAdmin, smsFeatureEnabled }: Props) {
   const router = useRouter();
   const [sentResult, setSentResult] = useState<{
     recipientCount: number;
@@ -89,5 +90,13 @@ export function ComposeContent({ groups, currentUser, isAdmin }: Props) {
     );
   }
 
-  return <ComposeMessageForm groups={groups} currentUser={currentUser} onSend={handleSend} isSending={isPending} />;
+  return (
+    <ComposeMessageForm
+      groups={groups}
+      currentUser={currentUser}
+      onSend={handleSend}
+      isSending={isPending}
+      smsFeatureEnabled={smsFeatureEnabled}
+    />
+  );
 }

--- a/src/app/(protected)/messages/compose/page.tsx
+++ b/src/app/(protected)/messages/compose/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getSessionWithName } from "@/lib/dal";
 import { getAllGroups } from "@/services/contact-group";
+import { env } from "@/env";
 import { ComposeContent } from "./compose-content";
 
 export const metadata: Metadata = {
@@ -16,6 +17,7 @@ export default async function ComposeMessagePage() {
       groups={groups.map((g) => ({ id: g.id, name: g.name }))}
       currentUser={{ name: session.ownername }}
       isAdmin={session.isAdmin}
+      smsFeatureEnabled={env.SMS_ENABLED}
     />
   );
 }

--- a/src/app/api/dev/token/route.ts
+++ b/src/app/api/dev/token/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { generateToken } from "@/lib/dal";
 
 export async function POST(req: NextRequest) {
-  if (process.env.NODE_ENV === "production" && process.env.STAGING !== "true") {
+  if (process.env.NODE_ENV === "production") {
     return NextResponse.json({ error: "Not available" }, { status: 404 });
   }
 

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -15,9 +15,10 @@ interface TopBarProps {
   userRole: "Admin Manager" | "Member";
   unseenCount?: number;
   lastSeenAt?: string | null;
+  photoUrl?: string | null;
 }
 
-export function TopBar({ userName, userRole, unseenCount = 0, lastSeenAt = null }: TopBarProps) {
+export function TopBar({ userName, userRole, unseenCount = 0, lastSeenAt = null, photoUrl = null }: TopBarProps) {
   const action = useTopBarAction();
   const { toggle } = useSidebar();
 
@@ -58,7 +59,7 @@ export function TopBar({ userName, userRole, unseenCount = 0, lastSeenAt = null 
 
           <NotificationDropdown initialUnseenCount={unseenCount} lastSeenAt={lastSeenAt} />
 
-          <UserMenu userName={userName} userRole={userRole} />
+          <UserMenu userName={userName} userRole={userRole} photoUrl={photoUrl} />
         </div>
       </div>
     </header>

--- a/src/components/layout/user-menu.tsx
+++ b/src/components/layout/user-menu.tsx
@@ -4,7 +4,7 @@ import { useTransition } from "react";
 import Link from "next/link";
 import { ChevronDown, ExternalLink, Settings, UserRound } from "lucide-react";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,9 +19,10 @@ import { logout } from "@/actions/auth";
 interface UserMenuProps {
   userName: string;
   userRole: "Admin Manager" | "Member";
+  photoUrl?: string | null;
 }
 
-export function UserMenu({ userName, userRole }: UserMenuProps) {
+export function UserMenu({ userName, userRole, photoUrl }: UserMenuProps) {
   const [isPending, startTransition] = useTransition();
   const initials = getInitials(userName);
   const avatarColor = getAvatarColor(userName);
@@ -40,6 +41,7 @@ export function UserMenu({ userName, userRole }: UserMenuProps) {
             <p className="truncate text-sm text-muted-foreground">{userRole}</p>
           </div>
           <Avatar className="h-10 w-10">
+            {photoUrl && <AvatarImage src={photoUrl} alt={userName} />}
             <AvatarFallback className={cn("text-sm font-semibold text-white")} style={{ backgroundColor: avatarColor }}>
               {initials}
             </AvatarFallback>

--- a/src/components/messages/compose-message-form.tsx
+++ b/src/components/messages/compose-message-form.tsx
@@ -28,6 +28,7 @@ interface ComposeMessageFormProps {
     sendSms: boolean;
   }) => void;
   isSending?: boolean;
+  smsFeatureEnabled?: boolean;
 }
 
 export function ComposeMessageForm({
@@ -36,12 +37,13 @@ export function ComposeMessageForm({
   smsConsent,
   onSend,
   isSending = false,
+  smsFeatureEnabled = false,
 }: ComposeMessageFormProps) {
   const [isBlast, setIsBlast] = useState(false);
   const [selectedGroupIds, setSelectedGroupIds] = useState<Set<number>>(new Set());
   const [groupPickerOpen, setGroupPickerOpen] = useState(false);
   const [sendSms, setSendSms] = useState(false);
-  const [sendEmail, setSendEmail] = useState(false);
+  const [sendEmail, setSendEmail] = useState(!smsFeatureEnabled);
   const [smsBody, setSmsBody] = useState("");
   const [emailSubject, setEmailSubject] = useState("");
   const [emailBody, setEmailBody] = useState("");
@@ -180,21 +182,23 @@ export function ComposeMessageForm({
         </Popover>
       </div>
 
-      <div>
-        <p className="mb-2 text-sm font-semibold">Select a Channel</p>
-        <div className="space-y-2">
-          <label className="flex cursor-pointer items-center gap-3">
-            <Checkbox checked={sendSms} onCheckedChange={(checked) => setSendSms(checked === true)} />
-            <MessageCircle className="h-5 w-5 text-muted-foreground" />
-            <span className="text-sm">Text Message</span>
-          </label>
-          <label className="flex cursor-pointer items-center gap-3">
-            <Checkbox checked={sendEmail} onCheckedChange={(checked) => setSendEmail(checked === true)} />
-            <Mail className="h-5 w-5 text-muted-foreground" />
-            <span className="text-sm">Email</span>
-          </label>
+      {smsFeatureEnabled && (
+        <div>
+          <p className="mb-2 text-sm font-semibold">Select a Channel</p>
+          <div className="space-y-2">
+            <label className="flex cursor-pointer items-center gap-3">
+              <Checkbox checked={sendSms} onCheckedChange={(checked) => setSendSms(checked === true)} />
+              <MessageCircle className="h-5 w-5 text-muted-foreground" />
+              <span className="text-sm">Text Message</span>
+            </label>
+            <label className="flex cursor-pointer items-center gap-3">
+              <Checkbox checked={sendEmail} onCheckedChange={(checked) => setSendEmail(checked === true)} />
+              <Mail className="h-5 w-5 text-muted-foreground" />
+              <span className="text-sm">Email</span>
+            </label>
+          </div>
         </div>
-      </div>
+      )}
 
       {sendSms && (
         <div>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -21,7 +21,7 @@ const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full object-cover", className)} {...props} />
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -28,13 +28,6 @@ const envSchema = z.object({
   TWILIO_AUTH_TOKEN: z.string().min(1).optional(),
   TWILIO_FROM_NUMBER: z.string().min(1).optional(),
 
-  STAGING: z
-    .string()
-    .default("false")
-    .transform((v) => v === "true"),
-  STAGING_USERNAME: z.string().min(1).optional(),
-  STAGING_PASSWORD: z.string().min(1).optional(),
-
   // Member Portal API integration toggle
   USE_MOCK_MEMBER_API: z
     .string()

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,46 +1,11 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { timingSafeEqual } from "crypto";
 
 const AUTH_COOKIE = "prfc_auth";
 const PROTECTED_PATHS = ["/home", "/groups", "/events", "/messages", "/settings", "/profile", "/referral-database"];
-const PUBLIC_PATHS = ["/privacy", "/terms", "/unauthorized", "/forbidden"];
-
-function isBasicAuthValid(request: NextRequest): boolean {
-  const authHeader = request.headers.get("authorization");
-  if (!authHeader?.startsWith("Basic ")) return false;
-
-  const decoded = atob(authHeader.slice(6));
-  const separatorIndex = decoded.indexOf(":");
-  if (separatorIndex === -1) return false;
-
-  const username = decoded.slice(0, separatorIndex);
-  const password = decoded.slice(separatorIndex + 1);
-
-  const expectedUsername = process.env.STAGING_USERNAME ?? "";
-  const expectedPassword = process.env.STAGING_PASSWORD ?? "";
-  if (!expectedUsername || !expectedPassword) return false;
-
-  if (username.length !== expectedUsername.length || password.length !== expectedPassword.length) return false;
-
-  const usernameMatch = timingSafeEqual(Buffer.from(username), Buffer.from(expectedUsername));
-  const passwordMatch = timingSafeEqual(Buffer.from(password), Buffer.from(expectedPassword));
-
-  return usernameMatch && passwordMatch;
-}
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const isPublicPath = PUBLIC_PATHS.some((p) => pathname.startsWith(p));
-
-  if (process.env.STAGING === "true" && !isPublicPath) {
-    if (!isBasicAuthValid(request)) {
-      return new NextResponse("Authentication required", {
-        status: 401,
-        headers: { "WWW-Authenticate": 'Basic realm="Staging"' },
-      });
-    }
-  }
   const isProtectedPath = PROTECTED_PATHS.some((p) => pathname.startsWith(p));
 
   if (isProtectedPath) {


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Fixed three categories of gaps found during e2e testing:

- `src/proxy.ts` - removed all staging/Basic Auth infrastructure (STAGING env var, username/password validation, PUBLIC_PATHS). Proxy now only redirects unauthenticated users on protected paths.
- `src/env.ts` - removed STAGING, STAGING_USERNAME, STAGING_PASSWORD from env schema
- `src/app/(dev)/dev/mock-portal/page.tsx`, `src/app/api/dev/token/route.ts` - removed STAGING bypass checks
- `src/components/messages/compose-message-form.tsx` - hides entire channel selector when SMS_ENABLED=false, defaults sendEmail to true so email compose shows immediately
- `src/app/(protected)/messages/compose/page.tsx`, `compose-content.tsx` - passes smsFeatureEnabled prop from server env
- `src/app/(protected)/layout.tsx` - fetches user photo URL alongside notification data
- `src/components/layout/top-bar.tsx`, `user-menu.tsx` - wires photo through to header avatar for WCAG 3.2.4 consistent identification
- `src/components/ui/avatar.tsx` - adds object-cover to prevent distortion on non-square uploads
- `e2e/feature-flows.spec.ts` - 25 e2e tests covering dashboard, groups, events, messages, settings, profile, authorization

## How to test

1. Set SMS_ENABLED=false in .env.local, visit /messages/compose - only email compose shows, no channel selector
2. Set SMS_ENABLED=true - channel selector with both checkboxes appears
3. Upload a profile photo on /profile - header avatar updates to show the photo
4. Upload a wide/landscape image - renders as center-cropped circle, no distortion
5. Run `npx playwright test e2e/feature-flows.spec.ts`

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers