### PR TITLE
fix: gate mock portal on USE_MOCK_MEMBER_API instead of NODE_ENV alone

### DIFF
--- a/src/app/(dev)/dev/mock-portal/page.tsx
+++ b/src/app/(dev)/dev/mock-portal/page.tsx
@@ -1,7 +1,7 @@
 import MockPortalContent from "./mock-portal-content";
 
 export default function MockPortalPage() {
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.NODE_ENV === "production" && process.env.USE_MOCK_MEMBER_API !== "true") {
     return (
       <main className="flex flex-1 items-center justify-center">
         <p>Not available in production</p>

--- a/src/app/api/dev/token/route.ts
+++ b/src/app/api/dev/token/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { generateToken } from "@/lib/dal";
 
 export async function POST(req: NextRequest) {
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.NODE_ENV === "production" && process.env.USE_MOCK_MEMBER_API !== "true") {
     return NextResponse.json({ error: "Not available" }, { status: 404 });
   }
 


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

PR #193 removed the STAGING env var but left mock portal gated on `NODE_ENV === "production"` alone. On Vercel where NODE_ENV is always production, this blocks the mock portal entirely - the only way to log in since there's no real auth provider yet.

- `src/app/(dev)/dev/mock-portal/page.tsx` - allow access when USE_MOCK_MEMBER_API=true
- `src/app/api/dev/token/route.ts` - same gate for the token generation endpoint

The mock portal is now accessible when the mock member API is in use (the logical dependency), regardless of NODE_ENV. When a real auth provider is integrated and USE_MOCK_MEMBER_API is set to false, both endpoints block in production automatically.

## How to test

1. Run `npm run build && npm start` (NODE_ENV=production locally)
2. Visit /dev/mock-portal - should load since USE_MOCK_MEMBER_API defaults to true
3. Set USE_MOCK_MEMBER_API=false, rebuild - mock portal shows "Not available in production"

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers