### PR TITLE
fix: make photo url fetch non-critical to prevent layout crash on db drift

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -24,7 +24,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   const [unseenCount, lastSeenAt, photoUrl] = await Promise.all([
     getUnseenNotificationCount(session.ownerid),
     getLastNotificationSeenAt(session.ownerid),
-    getProfilePhotoUrl(session.ownerid),
+    getProfilePhotoUrl(session.ownerid).catch(() => null),
   ]);
 
   return (

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -12,7 +12,7 @@ export default async function ProfilePage() {
   const session = await getSessionWithName();
   const [profile, photoUrl] = await Promise.all([
     getMemberProfile(session.ownerid, session.isAdmin),
-    getProfilePhotoUrl(session.ownerid),
+    getProfilePhotoUrl(session.ownerid).catch(() => null),
   ]);
 
   return (


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

PR #193 added `getProfilePhotoUrl` to the protected layout's `Promise.all`. On staging, the `photo_url` column may not exist (TiDB used db push, not migration files). Prisma throws "column does not exist" which crashes the entire layout render since `Promise.all` rejects on any failure.

- `src/app/(protected)/layout.tsx` - `.catch(() => null)` on photo fetch so layout degrades to initials
- `src/app/(protected)/profile/page.tsx` - same resilience for the profile page

Reproduced locally by dropping the `photo_url` column and confirming the layout crashed. With the fix, the page renders normally with initials as fallback.

The correct long-term fix is running `prisma db push` or the migration on staging. This `.catch` ensures the app stays functional regardless.

## How to test

1. Deploy to staging - login should work, avatar shows initials
2. Run the photo_url migration on staging DB
3. Upload a photo - avatar updates to show photo everywhere

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers