### PR TITLE
fix: profile photo sync across sessions, back link on compose page

### DIFF
--- a/e2e/profile-photo-sync.spec.ts
+++ b/e2e/profile-photo-sync.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Page, type BrowserContext } from "@playwright/test";
+import path from "node:path";
+import fs from "node:fs";
+
+const TEST_PHOTO_PATH = path.join(__dirname, "fixtures", "test-photo.png");
+
+function ensureTestPhoto() {
+  const dir = path.join(__dirname, "fixtures");
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  if (!fs.existsSync(TEST_PHOTO_PATH)) {
+    const png = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+      "base64",
+    );
+    fs.writeFileSync(TEST_PHOTO_PATH, png);
+  }
+}
+
+async function loginAs(page: Page, ownerid: string) {
+  await page.goto("/dev/mock-portal");
+  await page.getByText("Dev Tools").click();
+  await page.getByLabel("Select Member").selectOption(ownerid);
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.waitForURL("/home");
+}
+
+function getHeaderAvatar(page: Page) {
+  return page.locator("#user-menu-trigger img");
+}
+
+async function assertHeaderPhotoVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  await expect(getHeaderAvatar(page)).toBeVisible({ timeout: 10000 });
+}
+
+async function assertHeaderPhotoHidden(page: Page) {
+  await expect(getHeaderAvatar(page)).not.toBeVisible({ timeout: 5000 });
+}
+
+test.describe.serial("Profile photo cross-session sync", () => {
+  let contextA: BrowserContext;
+  let contextB: BrowserContext;
+  let pageA: Page;
+  let pageB: Page;
+
+  test.beforeAll(() => {
+    ensureTestPhoto();
+  });
+
+  test.beforeEach(async ({ browser }) => {
+    contextA = await browser.newContext();
+    contextB = await browser.newContext();
+    pageA = await contextA.newPage();
+    pageB = await contextB.newPage();
+
+    await loginAs(pageA, "100001");
+    await loginAs(pageB, "100001");
+  });
+
+  test.afterEach(async () => {
+    await contextA.close();
+    await contextB.close();
+  });
+
+  test("session B uploads photo, both sessions see it on every page", async () => {
+    await pageB.goto("/profile");
+    const fileInput = pageB.getByLabel("Upload profile photo");
+    await fileInput.setInputFiles(TEST_PHOTO_PATH);
+    await expect(pageB.getByText("Photo updated")).toBeVisible({ timeout: 15000 });
+
+    await pageB.goto("/home");
+    await assertHeaderPhotoVisible(pageB);
+
+    await pageB.goto("/messages");
+    await assertHeaderPhotoVisible(pageB);
+
+    await pageB.goto("/events");
+    await assertHeaderPhotoVisible(pageB);
+
+    await pageB.goto("/groups");
+    await assertHeaderPhotoVisible(pageB);
+
+    await pageB.goto("/settings");
+    await assertHeaderPhotoVisible(pageB);
+
+    await pageA.goto("/home");
+    await assertHeaderPhotoVisible(pageA);
+
+    await pageA.goto("/messages");
+    await assertHeaderPhotoVisible(pageA);
+
+    await pageA.goto("/events");
+    await assertHeaderPhotoVisible(pageA);
+
+    await pageA.goto("/groups");
+    await assertHeaderPhotoVisible(pageA);
+
+    await pageA.goto("/settings");
+    await assertHeaderPhotoVisible(pageA);
+
+    await pageA.goto("/profile");
+    await assertHeaderPhotoVisible(pageA);
+    await expect(pageA.getByRole("button", { name: "Remove" })).toBeVisible({ timeout: 5000 });
+  });
+
+  test("session B deletes photo, both sessions see it removed on every page", async () => {
+    await pageB.goto("/profile");
+    await expect(pageB.getByRole("button", { name: "Remove" })).toBeVisible({ timeout: 5000 });
+    await pageB.getByRole("button", { name: "Remove" }).click();
+    await expect(pageB.getByText("Photo removed")).toBeVisible({ timeout: 10000 });
+
+    await pageB.goto("/home");
+    await assertHeaderPhotoHidden(pageB);
+
+    await pageB.goto("/messages");
+    await assertHeaderPhotoHidden(pageB);
+
+    await pageB.goto("/events");
+    await assertHeaderPhotoHidden(pageB);
+
+    await pageA.goto("/home");
+    await assertHeaderPhotoHidden(pageA);
+
+    await pageA.goto("/messages");
+    await assertHeaderPhotoHidden(pageA);
+
+    await pageA.goto("/profile");
+    await assertHeaderPhotoHidden(pageA);
+    await expect(pageA.getByRole("button", { name: "Remove" })).not.toBeVisible();
+  });
+});

--- a/src/app/(protected)/profile/profile-content.tsx
+++ b/src/app/(protected)/profile/profile-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { handleActionError } from "@/utils/auth-redirect";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ProfilePhotoUpload } from "@/components/profile/profile-photo-upload";
 import { PersonalInformationCard } from "@/components/profile/personal-information-card";
@@ -18,6 +18,10 @@ type Props = {
 export function ProfileContent({ profile, photoUrl, userName, isAdmin }: Props) {
   const [currentPhotoUrl, setCurrentPhotoUrl] = useState(photoUrl);
   const [isUploading, setIsUploading] = useState(false);
+
+  useEffect(() => {
+    setCurrentPhotoUrl(photoUrl);
+  }, [photoUrl]);
 
   const handleUpload = async (file: File) => {
     setIsUploading(true);

--- a/src/components/messages/compose-message-form.tsx
+++ b/src/components/messages/compose-message-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { AlertCircle, Check, ChevronDown, Loader2, Mail, MessageCircle, X } from "lucide-react";
+import Link from "next/link";
+import { AlertCircle, ArrowLeft, Check, ChevronDown, Loader2, Mail, MessageCircle, X } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -108,6 +109,13 @@ export function ComposeMessageForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      <Link
+        href="/messages"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Messages
+      </Link>
       <h1 className="font-angkor text-3xl text-prfc-red">New Message</h1>
 
       <div>


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

- `src/app/(protected)/profile/profile-content.tsx` - added useEffect to sync server-provided photoUrl prop to local state. Previously, if another session uploaded a photo, refreshing the profile page still showed the old photo because useState only reads the initial value on mount.
- `src/components/messages/compose-message-form.tsx` - added ArrowLeft back link above the form heading, navigates to /messages deterministically (not router.back which fails on direct links).
- `e2e/profile-photo-sync.spec.ts` - 2 serial tests verifying cross-session photo consistency. Session B uploads, both sessions see the photo in the header on every protected page. Session B deletes, both sessions confirm removal.

## How to test

1. Open two browser windows, log in as the same user
2. In window B, upload a profile photo on /profile
3. In window A, navigate to /home, /messages, /events, /groups - header avatar shows the photo
4. On compose page, verify "Back to Messages" link above the heading navigates to /messages
5. Run `npx playwright test e2e/profile-photo-sync.spec.ts --project=chromium`

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers