### PR TITLE
fix: rsvp auth and deadline enforcement, event scoping, blast visibility, sms consent guard, admin sidebar

### DIFF
--- a/src/actions/event.ts
+++ b/src/actions/event.ts
@@ -120,6 +120,18 @@ export async function rsvpAction(input: { eventId: number; status: string }): Pr
   try {
     const session = await verifySession();
     const validated = RsvpSchema.parse(input);
+
+    const event = await getEventById(validated.eventId);
+
+    if (event.rsvpDeadline && event.rsvpDeadline.getTime() < Date.now()) {
+      return { success: false, error: "RSVP deadline has passed" };
+    }
+
+    const inviteeIds = await getEventInviteeMemberIds(validated.eventId);
+    if (!inviteeIds.includes(session.ownerid) && event.ownerid !== session.ownerid) {
+      return { success: false, error: "You are not invited to this event" };
+    }
+
     await rsvpToEvent(validated.eventId, session.ownerid, validated.status);
 
     revalidatePath("/events");
@@ -155,9 +167,10 @@ export async function fetchEventsForWeek(
   filters?: { inviteeMemberId?: number },
 ): Promise<ActionResult<EventSummary[]>> {
   try {
-    await verifySession();
+    const session = await verifySession();
     const validatedWeekStart = WeekStartSchema.parse(weekStart);
-    const events = await getEventsForWeek(validatedWeekStart, filters);
+    const scopedFilters = session.isAdmin ? filters : { ...filters, inviteeMemberId: session.ownerid };
+    const events = await getEventsForWeek(validatedWeekStart, scopedFilters);
     return { success: true, data: events };
   } catch (error) {
     const appError = transformError(error);
@@ -171,9 +184,12 @@ export async function fetchEventsForMonth(
   filters?: { eventType?: EventType; groupId?: number; inviteeMemberId?: number },
 ): Promise<ActionResult<EventSummary[]>> {
   try {
-    await verifySession();
+    const session = await verifySession();
     const validated = FetchEventsForMonthSchema.parse({ year, month, filters });
-    const events = await getEventsForMonth(validated.year, validated.month, validated.filters);
+    const scopedFilters = session.isAdmin
+      ? validated.filters
+      : { ...validated.filters, inviteeMemberId: session.ownerid };
+    const events = await getEventsForMonth(validated.year, validated.month, scopedFilters);
     return { success: true, data: events };
   } catch (error) {
     const appError = transformError(error);

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { verifySession } from "@/lib/dal";
+import { env } from "@/env";
 import { UpdatePreferencesSchema } from "@/schema/settings";
 import { grantSmsConsent, revokeSmsConsent } from "@/services/sms-consent";
 import { getMemberProfile } from "@/services/profile";
@@ -19,11 +20,13 @@ export async function updateUserPreferencesAction(input: {
     const validated = UpdatePreferencesSchema.parse(input);
     const updated = await updateUserPreferences(session.ownerid, validated);
 
-    if (validated.notifySmsDefault === true) {
-      const profile = await getMemberProfile(session.ownerid, session.isAdmin);
-      await grantSmsConsent(session.ownerid, profile.phone);
-    } else if (validated.notifySmsDefault === false) {
-      await revokeSmsConsent(session.ownerid, "web_settings_toggle", null);
+    if (env.SMS_ENABLED) {
+      if (validated.notifySmsDefault === true) {
+        const profile = await getMemberProfile(session.ownerid, session.isAdmin);
+        await grantSmsConsent(session.ownerid, profile.phone);
+      } else if (validated.notifySmsDefault === false) {
+        await revokeSmsConsent(session.ownerid, "web_settings_toggle", null);
+      }
     }
 
     revalidatePath("/settings");

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -31,7 +31,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
     <SidebarProvider>
       <TopBarActionProvider>
         <TopBarSearchProvider>
-          <Sidebar />
+          <Sidebar isAdmin={session.isAdmin} />
           <TopBar
             userName={session.ownername}
             userRole={userRole}

--- a/src/app/(protected)/messages/compose/compose-content.tsx
+++ b/src/app/(protected)/messages/compose/compose-content.tsx
@@ -95,6 +95,7 @@ export function ComposeContent({ groups, currentUser, isAdmin, smsFeatureEnabled
       groups={groups}
       currentUser={currentUser}
       onSend={handleSend}
+      isAdmin={isAdmin}
       isSending={isPending}
       smsFeatureEnabled={smsFeatureEnabled}
     />

--- a/src/components/events/create-event-popover.tsx
+++ b/src/components/events/create-event-popover.tsx
@@ -103,6 +103,9 @@ export function CreateEventPopover({
   const [manualRsvpDeadline, setManualRsvpDeadline] = useState<Date | null>(editingEvent?.rsvpDeadline ?? null);
   const [rsvpDeadlineTouched, setRsvpDeadlineTouched] = useState<boolean>(() => editingEvent !== undefined);
   const rsvpDeadline = rsvpDeadlineTouched ? manualRsvpDeadline : computeDefaultRsvpDeadline(range.start);
+  const [rsvpDeadlinePassed] = useState(
+    () => !!editingEvent?.rsvpDeadline && new Date(editingEvent.rsvpDeadline).getTime() < Date.now(),
+  );
   const [selectedMemberIds, setSelectedMemberIds] = useState<Set<number>>(() => new Set(initialMemberIds ?? []));
 
   const selectedGroupIds = useMemo(() => {
@@ -429,36 +432,42 @@ export function CreateEventPopover({
         {readOnly && editingEvent && currentUserOwnerid && inviteeMemberIds.includes(currentUserOwnerid) && (
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-muted-foreground">RSVP</span>
-            <Button
-              type="button"
-              variant={rsvpStatus === "going" ? "default" : "outline"}
-              size="sm"
-              onClick={() => handleRsvp("going")}
-              disabled={isPending}
-              className={rsvpStatus === "going" ? "bg-green-700 text-white hover:bg-green-800" : ""}
-            >
-              Going
-            </Button>
-            <Button
-              type="button"
-              variant={rsvpStatus === "maybe" ? "default" : "outline"}
-              size="sm"
-              onClick={() => handleRsvp("maybe")}
-              disabled={isPending}
-              className={rsvpStatus === "maybe" ? "bg-amber-600 text-white hover:bg-amber-700" : ""}
-            >
-              Maybe
-            </Button>
-            <Button
-              type="button"
-              variant={rsvpStatus === "declined" ? "default" : "outline"}
-              size="sm"
-              onClick={() => handleRsvp("declined")}
-              disabled={isPending}
-              className={rsvpStatus === "declined" ? "bg-red-700 text-white hover:bg-red-800" : ""}
-            >
-              No
-            </Button>
+            {rsvpDeadlinePassed ? (
+              <span className="text-sm text-muted-foreground">Deadline passed</span>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  variant={rsvpStatus === "going" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => handleRsvp("going")}
+                  disabled={isPending}
+                  className={rsvpStatus === "going" ? "bg-green-700 text-white hover:bg-green-800" : ""}
+                >
+                  Going
+                </Button>
+                <Button
+                  type="button"
+                  variant={rsvpStatus === "maybe" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => handleRsvp("maybe")}
+                  disabled={isPending}
+                  className={rsvpStatus === "maybe" ? "bg-amber-600 text-white hover:bg-amber-700" : ""}
+                >
+                  Maybe
+                </Button>
+                <Button
+                  type="button"
+                  variant={rsvpStatus === "declined" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => handleRsvp("declined")}
+                  disabled={isPending}
+                  className={rsvpStatus === "declined" ? "bg-red-700 text-white hover:bg-red-800" : ""}
+                >
+                  No
+                </Button>
+              </>
+            )}
           </div>
         )}
         {!readOnly && (

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   LayoutGrid,
   MessageSquareMore,
   Settings,
+  Table2,
   UserRound,
   UsersRound,
 } from "lucide-react";
@@ -63,7 +64,11 @@ function NavItem({ item, active, collapsed }: { item: SidebarNavItem; active: bo
   );
 }
 
-export function Sidebar() {
+interface SidebarProps {
+  isAdmin?: boolean;
+}
+
+export function Sidebar({ isAdmin = false }: SidebarProps) {
   const pathname = usePathname();
   const { collapsed, width } = useSidebar();
   const [isPending, startTransition] = useTransition();
@@ -78,6 +83,13 @@ export function Sidebar() {
           {SIDEBAR_ITEMS.map((item) => (
             <NavItem key={item.href} item={item} active={isItemActive(pathname, item.href)} collapsed={collapsed} />
           ))}
+          {isAdmin && (
+            <NavItem
+              item={{ label: "Referral Database", href: "/referral-database", icon: Table2 }}
+              active={isItemActive(pathname, "/referral-database")}
+              collapsed={collapsed}
+            />
+          )}
         </ul>
       </nav>
 

--- a/src/components/messages/compose-message-form.tsx
+++ b/src/components/messages/compose-message-form.tsx
@@ -30,6 +30,7 @@ interface ComposeMessageFormProps {
   }) => void;
   isSending?: boolean;
   smsFeatureEnabled?: boolean;
+  isAdmin?: boolean;
 }
 
 export function ComposeMessageForm({
@@ -39,6 +40,7 @@ export function ComposeMessageForm({
   onSend,
   isSending = false,
   smsFeatureEnabled = false,
+  isAdmin = false,
 }: ComposeMessageFormProps) {
   const [isBlast, setIsBlast] = useState(false);
   const [selectedGroupIds, setSelectedGroupIds] = useState<Set<number>>(new Set());
@@ -164,14 +166,16 @@ export function ComposeMessageForm({
               <CommandList>
                 <CommandEmpty>No groups found.</CommandEmpty>
                 <CommandGroup>
-                  <CommandItem
-                    value="all-members-blast"
-                    onSelect={handleBlastToggle}
-                    className="flex items-center gap-2"
-                  >
-                    <Check className={cn("h-4 w-4", isBlast ? "opacity-100" : "opacity-0")} />
-                    All Members
-                  </CommandItem>
+                  {isAdmin && (
+                    <CommandItem
+                      value="all-members-blast"
+                      onSelect={handleBlastToggle}
+                      className="flex items-center gap-2"
+                    >
+                      <Check className={cn("h-4 w-4", isBlast ? "opacity-100" : "opacity-0")} />
+                      All Members
+                    </CommandItem>
+                  )}
                   {groups.map((g) => (
                     <CommandItem
                       key={g.id}

--- a/test/actions/event.test.ts
+++ b/test/actions/event.test.ts
@@ -189,6 +189,8 @@ describe("rsvpAction", () => {
   });
 
   it("submits RSVP and revalidates", async () => {
+    mockGetEventById.mockResolvedValue({ ...sampleEvent, rsvpDeadline: null, ownerid: 100002 } as never);
+    mockGetEventInviteeMemberIds.mockResolvedValue([100001]);
     mockRsvpToEvent.mockResolvedValue(undefined);
 
     const result = await rsvpAction({ eventId: 1, status: "going" });
@@ -239,7 +241,7 @@ describe("fetchEventsForWeek", () => {
     const result = await fetchEventsForWeek(weekStart);
 
     expect(result).toEqual({ success: true, data: events });
-    expect(mockGetEventsForWeek).toHaveBeenCalledWith(weekStart, undefined);
+    expect(mockGetEventsForWeek).toHaveBeenCalledWith(weekStart, { inviteeMemberId: 100001 });
   });
 
   it("returns error when service throws", async () => {
@@ -282,7 +284,7 @@ describe("fetchEventsForMonth", () => {
     const result = await fetchEventsForMonth(2026, 4);
 
     expect(result).toEqual({ success: true, data: events });
-    expect(mockGetEventsForMonth).toHaveBeenCalledWith(2026, 4, undefined);
+    expect(mockGetEventsForMonth).toHaveBeenCalledWith(2026, 4, { inviteeMemberId: 100001 });
   });
 
   it("forwards filters to the service", async () => {
@@ -293,6 +295,7 @@ describe("fetchEventsForMonth", () => {
     expect(mockGetEventsForMonth).toHaveBeenCalledWith(2026, 4, {
       eventType: "meeting",
       groupId: 7,
+      inviteeMemberId: 100001,
     });
   });
 


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Six gaps found during integration test plan audit, each verified against the codebase before fixing.

- `src/actions/event.ts` - rsvpAction now verifies the user is an invitee and checks rsvpDeadline before accepting. fetchEventsForWeek and fetchEventsForMonth force inviteeMemberId to session.ownerid for non-admins, ignoring client-sent filter values.
- `src/components/events/create-event-popover.tsx` - RSVP buttons replaced with "Deadline passed" text when rsvpDeadline is in the past
- `src/components/messages/compose-message-form.tsx` - "All Members" blast option hidden for non-admins in the group picker
- `src/app/(protected)/messages/compose/compose-content.tsx` - passes isAdmin to ComposeMessageForm
- `src/actions/settings.ts` - SMS consent grant/revoke gated by env.SMS_ENABLED to prevent PII storage when SMS is disabled
- `src/components/layout/sidebar.tsx` - Referral Database appears as admin-only sidebar item
- `src/app/(protected)/layout.tsx` - passes isAdmin to Sidebar
- `test/actions/event.test.ts` - updated RSVP and fetch tests for new server-side checks

## How to test

1. Log in as member, open compose - "All Members" option not in group picker
2. Log in as admin, open compose - "All Members" visible
3. Create event with RSVP deadline in the past, click event as invitee - shows "Deadline passed" instead of RSVP buttons
4. Log in as member, verify sidebar shows 6 items (no Referral Database)
5. Log in as admin, verify sidebar shows Referral Database
6. Run `npx vitest run` - 555 tests pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers