### PR TITLE
fix: scope events group dropdown to owned groups for members

### DIFF
--- a/src/app/(protected)/events/page.tsx
+++ b/src/app/(protected)/events/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { verifySession } from "@/lib/dal";
 import { getEventsForWeek } from "@/services/event";
-import { getAllGroupsWithMemberIds } from "@/services/contact-group";
+import { getAllGroupsWithMemberIds, getGroupsWithMemberIdsByOwner } from "@/services/contact-group";
 import { getAllMembers } from "@/lib/api/member-api";
 import { coopStartOfWeek } from "@/utils/time";
 import { EventsContent } from "./events-content";
@@ -14,9 +14,10 @@ export default async function EventsPage() {
   const session = await verifySession();
   const now = new Date();
   const weekStart = coopStartOfWeek(now);
+  const groupsFn = session.isAdmin ? getAllGroupsWithMemberIds() : getGroupsWithMemberIdsByOwner(session.ownerid);
   const [initialWeekEvents, groups, members] = await Promise.all([
     getEventsForWeek(weekStart),
-    getAllGroupsWithMemberIds(),
+    groupsFn,
     getAllMembers(),
   ]);
 

--- a/src/services/contact-group.ts
+++ b/src/services/contact-group.ts
@@ -78,6 +78,27 @@ export async function getAllGroupsWithMemberIds(): Promise<GroupWithMemberIds[]>
   }
 }
 
+export async function getGroupsWithMemberIdsByOwner(ownerid: number): Promise<GroupWithMemberIds[]> {
+  try {
+    const groups = await prisma.contactGroup.findMany({
+      where: { ownerid },
+      include: {
+        members: { select: { memberId: true } },
+        _count: { select: { members: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return groups.map((g) => ({
+      ...g,
+      memberCount: g._count.members,
+      memberIds: g.members.map((m) => m.memberId),
+    }));
+  } catch (error) {
+    throw transformError(error);
+  }
+}
+
 export async function getGroupById(id: number): Promise<GroupWithMembers> {
   try {
     const group = await prisma.contactGroup.findUnique({

--- a/test/mocks/contact-group-service.ts
+++ b/test/mocks/contact-group-service.ts
@@ -4,6 +4,7 @@ vi.mock("@/services/contact-group", () => ({
   getGroupsByOwner: vi.fn(),
   getAllGroups: vi.fn(),
   getAllGroupsWithMemberIds: vi.fn(),
+  getGroupsWithMemberIdsByOwner: vi.fn(),
   getGroupById: vi.fn(),
   isGroupOwner: vi.fn(),
   createGroup: vi.fn(),
@@ -23,6 +24,7 @@ import {
   getGroupsByOwner,
   getAllGroups,
   getAllGroupsWithMemberIds,
+  getGroupsWithMemberIdsByOwner,
   getGroupById,
   isGroupOwner,
   createGroup,
@@ -41,6 +43,7 @@ import {
 export const mockGetGroupsByOwner = vi.mocked(getGroupsByOwner);
 export const mockGetAllGroups = vi.mocked(getAllGroups);
 export const mockGetAllGroupsWithMemberIds = vi.mocked(getAllGroupsWithMemberIds);
+export const mockGetGroupsWithMemberIdsByOwner = vi.mocked(getGroupsWithMemberIdsByOwner);
 export const mockGetGroupById = vi.mocked(getGroupById);
 export const mockIsGroupOwner = vi.mocked(isGroupOwner);
 export const mockCreateGroup = vi.mocked(createGroup);

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -24,6 +24,7 @@ export {
   mockGetGroupsByOwner,
   mockGetAllGroups,
   mockGetAllGroupsWithMemberIds,
+  mockGetGroupsWithMemberIdsByOwner,
   mockGetGroupById,
   mockIsGroupOwner,
   mockCreateGroup,


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

The events page showed all groups in the month view filter dropdown and create event popover for all users. Members now see only groups they own. Admins still see all groups.

- `src/services/contact-group.ts` - added `getGroupsWithMemberIdsByOwner(ownerid)` matching the existing `getAllGroupsWithMemberIds` pattern
- `src/app/(protected)/events/page.tsx` - admins call `getAllGroupsWithMemberIds()`, members call `getGroupsWithMemberIdsByOwner(session.ownerid)`
- `test/mocks/contact-group-service.ts` and `test/mocks/index.ts` - added centralized mock

Event visibility is unchanged. All members still see all events regardless of group ownership.

## How to test

1. Log in as a member (ownerid 100003)
2. Go to Events, switch to month view
3. Open the group filter dropdown - only owned groups appear
4. Click a time slot to create an event - only owned groups in the group dropdown
5. Log in as admin - all groups appear in both places

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers