### PR TITLE
fix: referral emails count against daily quota via reserveEmailQuota

### DIFF
--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -7,6 +7,7 @@ import type { EmailRecipient, RecipientSendResult } from "@/types/message";
 import { env } from "@/env";
 import { sendBrevoEmail } from "@/lib/brevo";
 import { generateEmailUnsubscribeToken } from "@/lib/unsubscribe-tokens";
+import { reserveEmailQuota } from "@/lib/email-quota";
 import { filterSuppressedEmails, isEmailSuppressed } from "./email-suppression";
 
 export function validateEmailAllowed(): void {
@@ -46,11 +47,23 @@ export async function sendReferralEmails({
   prospects,
   referralCode,
   memberName,
-}: SendReferralEmailParams): Promise<void> {
+}: SendReferralEmailParams): Promise<{ sent: number; skipped: number }> {
+  let sent = 0;
+  let skipped = 0;
+
   try {
     for (const prospect of prospects) {
       const suppressed = await isEmailSuppressed(prospect.prospectEmail);
-      if (suppressed) continue;
+      if (suppressed) {
+        skipped++;
+        continue;
+      }
+
+      const { allowed } = await reserveEmailQuota(1);
+      if (allowed === 0) {
+        skipped++;
+        continue;
+      }
 
       const originalSubject = "You've Been Invited!";
       const { to, subject } = applyRedirect(prospect.prospectEmail, originalSubject);
@@ -71,7 +84,10 @@ export async function sendReferralEmails({
           "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
         },
       });
+      sent++;
     }
+
+    return { sent, skipped };
   } catch (error) {
     throw new AppError("EMAIL_ERROR", "Failed to send referral emails", {
       originalError: error instanceof Error ? error.message : String(error),

--- a/test/services/email.test.ts
+++ b/test/services/email.test.ts
@@ -1,24 +1,31 @@
 import "../mocks/email";
 import "../mocks/email-suppression";
 import "../mocks/unsubscribe-tokens";
+import "../mocks/email-quota";
 import { mockBrevoSend } from "../mocks/email";
 import { mockIsEmailSuppressed } from "../mocks/email-suppression";
+import { mockReserveEmailQuota } from "../mocks/email-quota";
 import { sendReferralEmails } from "@/services/email";
 
 describe("sendReferralEmails", () => {
+  beforeEach(() => {
+    mockReserveEmailQuota.mockResolvedValue({ allowed: 1, total: 0 });
+  });
+
   const prospects = [
     { prospectName: "Lucy Van Pelt", prospectEmail: "lucy.vanpelt@yahoo.com" },
     { prospectName: "Marcie Johnson", prospectEmail: "marcie.johnson@gmail.com" },
   ];
 
-  it("sends email to each prospect", async () => {
-    await sendReferralEmails({
+  it("sends email to each prospect and returns sent count", async () => {
+    const result = await sendReferralEmails({
       prospects,
       referralCode: "REF-7F3A9B",
       memberName: "Charlie Brown",
     });
 
     expect(mockBrevoSend).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ sent: 2, skipped: 0 });
   });
 
   it("includes referral code in email", async () => {
@@ -46,7 +53,61 @@ describe("sendReferralEmails", () => {
     });
   });
 
-  it("skips suppressed prospect emails", async () => {
+  it("skips suppressed prospect emails and counts them", async () => {
+    mockIsEmailSuppressed.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const result = await sendReferralEmails({
+      prospects,
+      referralCode: "REF-7F3A9B",
+      memberName: "Charlie Brown",
+    });
+
+    expect(mockBrevoSend).toHaveBeenCalledTimes(1);
+    expect(mockBrevoSend.mock.calls[0][0].to[0].email).toBe("marcie.johnson@gmail.com");
+    expect(result).toEqual({ sent: 1, skipped: 1 });
+  });
+
+  it("skips all prospects when quota is exhausted", async () => {
+    mockReserveEmailQuota.mockResolvedValue({ allowed: 0, total: 300 });
+
+    const result = await sendReferralEmails({
+      prospects,
+      referralCode: "REF-7F3A9B",
+      memberName: "Charlie Brown",
+    });
+
+    expect(mockBrevoSend).not.toHaveBeenCalled();
+    expect(result).toEqual({ sent: 0, skipped: 2 });
+  });
+
+  it("sends some and skips rest when quota runs out mid-batch", async () => {
+    mockReserveEmailQuota
+      .mockResolvedValueOnce({ allowed: 1, total: 299 })
+      .mockResolvedValueOnce({ allowed: 0, total: 300 });
+
+    const result = await sendReferralEmails({
+      prospects,
+      referralCode: "REF-7F3A9B",
+      memberName: "Charlie Brown",
+    });
+
+    expect(mockBrevoSend).toHaveBeenCalledTimes(1);
+    expect(mockBrevoSend.mock.calls[0][0].to[0].email).toBe("lucy.vanpelt@yahoo.com");
+    expect(result).toEqual({ sent: 1, skipped: 1 });
+  });
+
+  it("reserves quota per prospect not in bulk", async () => {
+    await sendReferralEmails({
+      prospects,
+      referralCode: "REF-7F3A9B",
+      memberName: "Charlie Brown",
+    });
+
+    expect(mockReserveEmailQuota).toHaveBeenCalledTimes(2);
+    expect(mockReserveEmailQuota).toHaveBeenCalledWith(1);
+  });
+
+  it("does not reserve quota for suppressed prospects", async () => {
     mockIsEmailSuppressed.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
     await sendReferralEmails({
@@ -55,8 +116,7 @@ describe("sendReferralEmails", () => {
       memberName: "Charlie Brown",
     });
 
-    expect(mockBrevoSend).toHaveBeenCalledTimes(1);
-    expect(mockBrevoSend.mock.calls[0][0].to[0].email).toBe("marcie.johnson@gmail.com");
+    expect(mockReserveEmailQuota).toHaveBeenCalledTimes(1);
   });
 
   it("escapes HTML in prospect name", async () => {
@@ -105,5 +165,30 @@ describe("sendReferralEmails", () => {
     const headers = mockBrevoSend.mock.calls[0][0].headers;
     expect(headers["List-Unsubscribe"]).toContain("/api/unsubscribe?token=");
     expect(headers["List-Unsubscribe-Post"]).toBe("List-Unsubscribe=One-Click");
+  });
+
+  it("returns zero sent and zero skipped for empty prospects", async () => {
+    const result = await sendReferralEmails({
+      prospects: [],
+      referralCode: "REF-7F3A9B",
+      memberName: "Charlie Brown",
+    });
+
+    expect(mockBrevoSend).not.toHaveBeenCalled();
+    expect(mockReserveEmailQuota).not.toHaveBeenCalled();
+    expect(result).toEqual({ sent: 0, skipped: 0 });
+  });
+
+  it("includes textContent plain text fallback", async () => {
+    await sendReferralEmails({
+      prospects: [prospects[0]],
+      referralCode: "REF-7F3A9B",
+      memberName: "Charlie Brown",
+    });
+
+    const textContent = mockBrevoSend.mock.calls[0][0].textContent;
+    expect(textContent).toContain("Hi Lucy Van Pelt");
+    expect(textContent).toContain("REF-7F3A9B");
+    expect(textContent).toContain("pasofoodcooperative.com");
   });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Referral emails bypassed the daily email quota entirely. They now call `reserveEmailQuota(1)` per prospect before sending, sharing the same atomic Redis counter as group and blast messages. Prospects are skipped when the quota is exhausted. Return type changed from `void` to `{ sent, skipped }`.

- `src/services/email.ts` - added `reserveEmailQuota` import, quota check per prospect, return counts
- `test/services/email.test.ts` - 14 tests covering quota exhaustion, mid-batch cutoff, suppression+quota interaction, empty prospects

## How to test

1. `npm test` - 595 tests pass
2. Verify referral sends decrement the same Redis counter as group messages

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers