### PR TITLE
fix: remove group avatar from invitee stack, count unique members only

### DIFF
--- a/src/components/events/invitee-combobox.tsx
+++ b/src/components/events/invitee-combobox.tsx
@@ -41,16 +41,12 @@ export function InviteeCombobox({
   const filteredMembers = useFuzzySearch(members, { keys: ["ownername"] }, query);
 
   const selectedInvitees = useMemo<InviteeAvatar[]>(() => {
-    const groupInvitees: InviteeAvatar[] = groups
-      .filter((g) => selectedGroupIds.has(g.id))
-      .map((g) => ({ id: `g-${g.id}`, name: g.name }));
-    const memberInvitees: InviteeAvatar[] = members
+    return members
       .filter((m) => selectedMemberIds.has(m.ownerid))
       .map((m) => ({ id: `m-${m.ownerid}`, name: m.ownername, photoUrl: m.photoUrl }));
-    return [...groupInvitees, ...memberInvitees];
-  }, [groups, members, selectedGroupIds, selectedMemberIds]);
+  }, [members, selectedMemberIds]);
 
-  const selectedCount = selectedInvitees.length;
+  const selectedCount = selectedMemberIds.size;
   const noOptions = groups.length === 0 && members.length === 0;
 
   return (

--- a/test/components/invitee-combobox.test.tsx
+++ b/test/components/invitee-combobox.test.tsx
@@ -8,13 +8,14 @@ function wrap(ui: React.ReactElement) {
 }
 
 const GROUPS = [
-  { id: 1, name: "Board of Directors", memberCount: 7, memberIds: [] },
-  { id: 2, name: "Volunteers", memberCount: 23, memberIds: [] },
+  { id: 1, name: "Board of Directors", memberCount: 2, memberIds: [100001, 100002] },
+  { id: 2, name: "Volunteers", memberCount: 1, memberIds: [100003] },
 ];
 
 const MEMBERS = [
   { ownerid: 100001, ownername: "Kevin Rutledge" },
   { ownerid: 100002, ownername: "Mary Jones" },
+  { ownerid: 100003, ownername: "Alice Smith" },
 ];
 
 describe("InviteeCombobox", () => {
@@ -35,20 +36,36 @@ describe("InviteeCombobox", () => {
     expect(screen.getByText("Nothing to invite yet.")).toBeInTheDocument();
   });
 
-  it("shows selected count in the header when groups are selected", () => {
+  it("counts unique members only, not groups", () => {
     render(
       wrap(
         <InviteeCombobox
           groups={GROUPS}
           members={MEMBERS}
           selectedGroupIds={new Set([1])}
-          selectedMemberIds={new Set([100001])}
+          selectedMemberIds={new Set([100001, 100002])}
           onToggleGroup={vi.fn()}
           onToggleMember={vi.fn()}
         />,
       ),
     );
     expect(screen.getByText("2 invitees selected")).toBeInTheDocument();
+  });
+
+  it("shows singular invitee for one member", () => {
+    render(
+      wrap(
+        <InviteeCombobox
+          groups={GROUPS}
+          members={MEMBERS}
+          selectedGroupIds={new Set()}
+          selectedMemberIds={new Set([100001])}
+          onToggleGroup={vi.fn()}
+          onToggleMember={vi.fn()}
+        />,
+      ),
+    );
+    expect(screen.getByText("1 invitee selected")).toBeInTheDocument();
   });
 
   it("calls onToggleGroup when a group item is clicked", () => {


### PR DESCRIPTION
Closes #206

## Summary
- Selecting a group invitee was adding both a group-initials avatar **and** each member avatar to the stack, inflating the count by 1 extra (the group itself)
- Root cause: `selectedInvitees` in `InviteeCombobox` included group entries alongside member entries, even though `selectedMemberIds` already holds all expanded member IDs
- Fix: derive the avatar list and count from `selectedMemberIds` only — groups are visual-only in the dropdown (checkmarks still work via `selectedGroupIds`)

## Test plan
- [x] Select a group with N members → count shows N, N member avatars visible, no group-initials avatar
- [x] Select individual members alongside a group → count reflects total unique members, no duplicates
- [x] Deselect a group → count decreases correctly
- [x] Select members individually until a full group is checked → group row shows checkmark, count is correct