### PR TITLE
fix: scope dashboard recent messages to recipient for non-admins

### DIFF
--- a/src/app/(protected)/home/page.tsx
+++ b/src/app/(protected)/home/page.tsx
@@ -10,12 +10,13 @@ export default async function HomePage() {
   const session = await verifySession();
   const now = coopNow();
 
+  const messageFilter = session.isAdmin ? { limit: 3 } : { limit: 3, recipientId: session.ownerid };
   const [memberList, monthEvents, upcomingEvents, recentActivity, recentMessages] = await Promise.all([
     getAllMembers(),
     getEventsForMonth(now.year, now.month0 + 1),
     getUpcomingEvents(4),
     getRecentActivity(session.ownerid, 3),
-    getAllMessageHistory({ limit: 3 }),
+    getAllMessageHistory(messageFilter),
   ]);
 
   return (

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -453,18 +453,22 @@ export async function processEmailQueue(): Promise<{ sent: number; failed: numbe
 
 export async function getAllMessageHistory(options: {
   senderId?: number;
+  recipientId?: number;
   limit?: number;
   offset?: number;
   channel?: "email" | "sms";
 }): Promise<MessageHistoryItem[]> {
   try {
-    const { senderId, limit = 50, offset = 0, channel } = options;
+    const { senderId, recipientId, limit = 50, offset = 0, channel } = options;
     const effectiveLimit = Math.min(Math.max(1, limit), MAX_MESSAGE_HISTORY_LIMIT);
 
     const where: Record<string, unknown> = {};
     if (senderId) where.senderId = senderId;
-    if (channel) {
-      where.recipients = { some: { channel } };
+    const recipientFilter: Record<string, unknown> = {};
+    if (recipientId) recipientFilter.memberId = recipientId;
+    if (channel) recipientFilter.channel = channel;
+    if (Object.keys(recipientFilter).length > 0) {
+      where.recipients = { some: recipientFilter };
     }
 
     const messages = await prisma.message.findMany({

--- a/test/services/message-query.test.ts
+++ b/test/services/message-query.test.ts
@@ -81,6 +81,32 @@ describe("getAllMessageHistory", () => {
     );
   });
 
+  it("filters by recipientId when provided", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+
+    await getAllMessageHistory({ recipientId: 100003 });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ recipients: { some: { memberId: 100003 } } }),
+      }),
+    );
+  });
+
+  it("combines recipientId and channel filter", async () => {
+    mockPrisma.message.findMany.mockResolvedValue([] as never);
+
+    await getAllMessageHistory({ recipientId: 100003, channel: "email" });
+
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recipients: { some: { memberId: 100003, channel: "email" } },
+        }),
+      }),
+    );
+  });
+
   it("filters by channel when provided", async () => {
     mockPrisma.message.findMany.mockResolvedValue([] as never);
 


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #208

## What changed?

The home dashboard showed all messages system-wide to non-admin members. Members now only see messages they were a recipient of.

- `src/services/message.ts` - added `recipientId` parameter to `getAllMessageHistory`, filters via `recipients: { some: { memberId } }`
- `src/app/(protected)/home/page.tsx` - passes `recipientId: session.ownerid` for non-admins
- `test/services/message-query.test.ts` - two new tests for recipientId filtering and combined recipientId+channel filter

## How to test

1. Log in as member (ownerid 100003), go to Home, verify Recent Messages shows only received messages
2. Log in as admin, verify Recent Messages shows all messages
3. `npm test` - 598 tests pass

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers