### PR TITLE
fix: reject events where endDate is before startDate at schema level

### DIFF
--- a/src/schema/event.ts
+++ b/src/schema/event.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const CreateEventSchema = z.object({
+const EventFieldsSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(5000).nullish(),
   location: z.string().max(200).nullish(),
@@ -14,7 +14,18 @@ export const CreateEventSchema = z.object({
   groupIds: z.array(z.number().int().positive()).optional(),
 });
 
-export const UpdateEventSchema = CreateEventSchema.partial();
+export const CreateEventSchema = EventFieldsSchema.refine((data) => data.endDate >= data.startDate, {
+  message: "End date must be after start date",
+  path: ["endDate"],
+});
+
+export const UpdateEventSchema = EventFieldsSchema.partial().refine(
+  (data) => {
+    if (data.startDate && data.endDate) return data.endDate >= data.startDate;
+    return true;
+  },
+  { message: "End date must be after start date", path: ["endDate"] },
+);
 
 export const RsvpSchema = z.object({
   eventId: z.number().int().positive(),

--- a/test/schema/event.test.ts
+++ b/test/schema/event.test.ts
@@ -1,4 +1,4 @@
-import { CreateEventSchema, RsvpSchema } from "@/schema/event";
+import { CreateEventSchema, UpdateEventSchema, RsvpSchema } from "@/schema/event";
 
 describe("CreateEventSchema", () => {
   it("accepts valid event data", () => {
@@ -59,6 +59,61 @@ describe("CreateEventSchema", () => {
       expect(result.data.startDate).toBeInstanceOf(Date);
       expect(result.data.endDate).toBeInstanceOf(Date);
     }
+  });
+
+  it("rejects endDate before startDate", () => {
+    const result = CreateEventSchema.safeParse({
+      title: "Test",
+      startDate: "2026-04-08T19:00:00Z",
+      endDate: "2026-04-08T18:00:00Z",
+      eventType: "meeting",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain("endDate");
+    }
+  });
+
+  it("accepts endDate equal to startDate", () => {
+    const result = CreateEventSchema.safeParse({
+      title: "Test",
+      startDate: "2026-04-08T18:00:00Z",
+      endDate: "2026-04-08T18:00:00Z",
+      eventType: "meeting",
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("UpdateEventSchema", () => {
+  it("rejects endDate before startDate when both provided", () => {
+    const result = UpdateEventSchema.safeParse({
+      startDate: "2026-04-08T19:00:00Z",
+      endDate: "2026-04-08T18:00:00Z",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain("endDate");
+    }
+  });
+
+  it("accepts update with only startDate", () => {
+    const result = UpdateEventSchema.safeParse({
+      startDate: "2026-04-08T19:00:00Z",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts update with only endDate", () => {
+    const result = UpdateEventSchema.safeParse({
+      endDate: "2026-04-08T19:00:00Z",
+    });
+
+    expect(result.success).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Developer

Kevin Rutledge

Closes #209

## What changed?

The event schemas validated dates individually but had no cross-field check. A direct server action call could create events where endDate came before startDate.

- `src/schema/event.ts` - extracted `EventFieldsSchema` as a private base object. `CreateEventSchema` adds `.refine()` requiring `endDate >= startDate`. `UpdateEventSchema` uses `.partial().refine()` that checks only when both dates are present.
- `test/schema/event.test.ts` - 5 new tests covering create rejection, equal dates, update with both dates, update with only startDate, update with only endDate

## How to test

1. `npm test` - 601 tests pass
2. Try creating an event with endDate before startDate via the UI (client already catches it) and verify the server also rejects it

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers