### PR TITLE
fix: OWASP audit gaps - idempotency race condition, audit logging, auth hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10595,9 +10595,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/actions/contact-group.ts
+++ b/src/actions/contact-group.ts
@@ -55,6 +55,7 @@ export async function fetchEnrichedGroup(groupId: number): Promise<ActionResult<
     const validGroupId = PositiveIntSchema.parse(groupId);
 
     if (!session.isAdmin && !(await isGroupOwner(validGroupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] fetchEnrichedGroup", session.ownerid, validGroupId);
       return { success: false, error: "You do not have permission to view this group" };
     }
 
@@ -102,6 +103,7 @@ export async function createContactGroup(input: {
       );
     }
 
+    console.error("[AUDIT] createContactGroup", session.ownerid, group.id);
     revalidatePath("/groups");
     return { success: true, data: { id: group.id } };
   } catch (error) {
@@ -115,6 +117,7 @@ export async function updateContactGroup(groupId: number, formData: FormData): P
     const session = await verifySession();
 
     if (!session.isAdmin && !(await isGroupOwner(groupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] updateContactGroup", session.ownerid, groupId);
       return { success: false, error: "You do not have permission to edit this group" };
     }
 
@@ -140,11 +143,13 @@ export async function deleteContactGroup(groupId: number): Promise<ActionResult>
     const validGroupId = PositiveIntSchema.parse(groupId);
 
     if (!session.isAdmin && !(await isGroupOwner(validGroupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] deleteContactGroup", session.ownerid, validGroupId);
       return { success: false, error: "You do not have permission to delete this group" };
     }
 
     await deleteGroup(validGroupId);
 
+    console.error("[AUDIT] deleteContactGroup", session.ownerid, validGroupId);
     revalidatePath("/groups");
     return { success: true };
   } catch (error) {
@@ -162,6 +167,7 @@ export async function addMembers(input: {
     const validated = AddMembersSchema.parse(input);
 
     if (!session.isAdmin && !(await isGroupOwner(validated.groupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] addMembers", session.ownerid, validated.groupId);
       return { success: false, error: "You do not have permission to add members to this group" };
     }
 
@@ -182,6 +188,7 @@ export async function removeMember(groupId: number, memberId: number): Promise<A
     const validMemberId = PositiveIntSchema.parse(memberId);
 
     if (!session.isAdmin && !(await isGroupOwner(validGroupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] removeMember", session.ownerid, validGroupId);
       return { success: false, error: "You do not have permission to remove members from this group" };
     }
 
@@ -217,6 +224,7 @@ export async function removeMembers(groupId: number, memberIds: number[]): Promi
     const validMemberIds = z.array(PositiveIntSchema).min(1).parse(memberIds);
 
     if (!session.isAdmin && !(await isGroupOwner(validGroupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] removeMembers", session.ownerid, validGroupId);
       return { success: false, error: "You do not have permission to remove members from this group" };
     }
 
@@ -241,6 +249,7 @@ export async function updateNotifications(input: {
     const validated = UpdateNotificationSchema.parse(input);
 
     if (!session.isAdmin && !(await isGroupOwner(validated.groupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] updateNotifications", session.ownerid, validated.groupId);
       return { success: false, error: "You do not have permission to update notification preferences" };
     }
 
@@ -280,12 +289,14 @@ export async function sendMessage(input: {
     if (!session.isAdmin) {
       const ownerChecks = await Promise.all(validated.groupIds.map((gid) => isGroupOwner(gid, session.ownerid)));
       if (ownerChecks.some((isOwner) => !isOwner)) {
+        console.error("[ACCESS_DENIED] sendMessage", session.ownerid, validated.groupIds);
         return { success: false, error: "You do not have permission to send messages to one or more selected groups" };
       }
     }
 
     const result = await sendGroupMessage(validated, session.ownerid);
 
+    console.error("[AUDIT] sendMessage", session.ownerid, result.messageId, validated.groupIds);
     return { success: true, data: result };
   } catch (error) {
     const appError = transformError(error);
@@ -314,11 +325,13 @@ export async function sendBlast(input: {
     const validated = BlastMessageSchema.parse(input);
 
     if (!session.isAdmin) {
+      console.error("[ACCESS_DENIED] sendBlast", session.ownerid);
       return { success: false, error: "You do not have permission to send blast messages" };
     }
 
     const result = await sendBlastMessage(validated, session.ownerid);
 
+    console.error("[AUDIT] sendBlast", session.ownerid, result.messageId);
     return { success: true, data: result };
   } catch (error) {
     const appError = transformError(error);
@@ -355,6 +368,7 @@ export async function fetchMessageDetail(messageId: number): Promise<
     const isSender = message.senderId === session.ownerid;
     const isRecipient = await isMessageRecipient(validMessageId, session.ownerid);
     if (!session.isAdmin && !isSender && !isRecipient) {
+      console.error("[ACCESS_DENIED] fetchMessageDetail", session.ownerid, validMessageId);
       return { success: false, error: "You do not have permission to view this message" };
     }
 
@@ -372,6 +386,7 @@ export async function fetchRecipientPreview(groupId: number): Promise<ActionResu
     const validGroupId = PositiveIntSchema.parse(groupId);
 
     if (!session.isAdmin && !(await isGroupOwner(validGroupId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] fetchRecipientPreview", session.ownerid, validGroupId);
       return { success: false, error: "You do not have permission to preview recipients for this group" };
     }
 

--- a/src/actions/event.ts
+++ b/src/actions/event.ts
@@ -57,6 +57,7 @@ export async function createEventAction(input: {
       await inviteMembers(event.id, memberIds);
     }
 
+    console.error("[AUDIT] createEvent", session.ownerid, event.id);
     revalidatePath("/events");
     revalidatePath("/home");
     return { success: true, data: { id: event.id } };
@@ -72,6 +73,7 @@ export async function updateEventAction(eventId: number, input: Record<string, u
     const validatedId = EventIdSchema.parse(eventId);
 
     if (!session.isAdmin && !(await isEventOwner(validatedId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] updateEvent", session.ownerid, validatedId);
       return { success: false, error: "You do not have permission to edit this event" };
     }
 
@@ -102,11 +104,13 @@ export async function deleteEventAction(eventId: number): Promise<ActionResult> 
     const validatedId = EventIdSchema.parse(eventId);
 
     if (!session.isAdmin && !(await isEventOwner(validatedId, session.ownerid))) {
+      console.error("[ACCESS_DENIED] deleteEvent", session.ownerid, validatedId);
       return { success: false, error: "You do not have permission to delete this event" };
     }
 
     await deleteEvent(validatedId);
 
+    console.error("[AUDIT] deleteEvent", session.ownerid, validatedId);
     revalidatePath("/events");
     revalidatePath("/home");
     return { success: true };

--- a/src/actions/referral.ts
+++ b/src/actions/referral.ts
@@ -9,9 +9,10 @@ import type { ActionResult } from "@/types/action";
 
 export async function toggleRedeemed(id: number): Promise<ActionResult> {
   try {
-    await requireAdmin();
+    const session = await requireAdmin();
     const validId = PositiveIntSchema.parse(id);
     await toggleReferralRedeemed(validId);
+    console.error("[AUDIT] toggleRedeemed", session.ownerid, validId);
     revalidatePath("/referral-database");
     return { success: true };
   } catch (error) {

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -8,9 +8,10 @@ const AuthCallbackSchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
+  const rawIp = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "127.0.0.1";
+  const ip = /^[\d.:a-f]+$/i.test(rawIp) ? rawIp : "invalid";
+
   if (authRateLimiter) {
-    const forwarded = req.headers.get("x-forwarded-for");
-    const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
     const { success } = await authRateLimiter.limit(ip);
 
     if (!success) {
@@ -22,22 +23,26 @@ export async function POST(req: NextRequest) {
   try {
     secret = getSecret();
   } catch {
-    return NextResponse.redirect(new URL("/", req.url));
+    return NextResponse.redirect(new URL("/home", req.url));
   }
 
   const formData = await req.formData();
   const parsed = AuthCallbackSchema.safeParse({ token: formData.get("token") });
 
   if (!parsed.success) {
-    return NextResponse.redirect(new URL("/", req.url));
+    console.error("[AUTH_CALLBACK] missing or malformed token", ip);
+    return NextResponse.redirect(new URL("/home", req.url));
   }
 
   const { token } = parsed.data;
 
   const session = validateToken(token, secret);
   if (!session) {
-    return NextResponse.redirect(new URL("/", req.url));
+    console.error("[AUTH_CALLBACK] invalid or expired token", ip);
+    return NextResponse.redirect(new URL("/home", req.url));
   }
+
+  console.error("[AUTH_CALLBACK] login success", session.ownerid, ip);
 
   const response = NextResponse.redirect(new URL("/home", req.url));
 

--- a/src/app/api/referrals/[id]/route.ts
+++ b/src/app/api/referrals/[id]/route.ts
@@ -8,7 +8,7 @@ import { apiErrorHandler } from "@/utils/errors";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    await requireAdmin();
+    const session = await requireAdmin();
 
     if (!validateOrigin(req)) {
       return NextResponse.json({ error: { code: "FORBIDDEN", message: "Invalid origin" } }, { status: 403 });
@@ -20,6 +20,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     const { redeemed } = UpdateRedeemedSchema.parse(body);
 
     const updated = await updateReferralRedeemed(referralId, redeemed);
+    console.error("[AUDIT] updateReferralRedeemed", session.ownerid, referralId, redeemed);
     return NextResponse.json(updated, { status: 200 });
   } catch (error) {
     return apiErrorHandler(error);
@@ -28,7 +29,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    await requireAdmin();
+    const session = await requireAdmin();
 
     if (!validateOrigin(req)) {
       return NextResponse.json({ error: { code: "FORBIDDEN", message: "Invalid origin" } }, { status: 403 });
@@ -37,6 +38,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
     const { id } = await params;
     const referralId = StringIntSchema.parse(id);
     await deleteReferral(referralId);
+    console.error("[AUDIT] deleteReferral", session.ownerid, referralId);
     return NextResponse.json({ message: "Referral deleted" }, { status: 200 });
   } catch (error) {
     return apiErrorHandler(error);

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -4,7 +4,7 @@ import { createManyReferrals, getAllReferrals } from "@/services/referral";
 import { sendReferralEmails } from "@/services/email";
 import { env } from "@/env";
 import { rateLimiter } from "@/lib/rate-limit";
-import { getIdempotentResponse, setIdempotentResponse } from "@/lib/idempotency";
+import { claimIdempotencyKey, setIdempotentResponse } from "@/lib/idempotency";
 import { validateOrigin } from "@/lib/csrf";
 import { verifySession, requireAdmin } from "@/lib/dal";
 import { apiErrorHandler, transformError, errorStatusMap } from "@/utils/errors";
@@ -20,9 +20,9 @@ export async function POST(req: NextRequest) {
     }
 
     if (idempotencyKey) {
-      const cached = await getIdempotentResponse(idempotencyKey);
-      if (cached) {
-        return NextResponse.json(cached.body, { status: cached.status });
+      const claim = await claimIdempotencyKey(idempotencyKey);
+      if (!claim.claimed) {
+        return NextResponse.json(claim.response.body, { status: claim.response.status });
       }
     }
 
@@ -62,6 +62,8 @@ export async function POST(req: NextRequest) {
     if (env.EMAIL_ENABLED) {
       await sendReferralEmails({ prospects, referralCode, memberName });
     }
+
+    console.error("[AUDIT] createReferrals", referralCode, newReferrals.length);
 
     const responseBody = { message: "Referrals created successfully!", referrals: newReferrals };
 

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,12 +1,15 @@
 import "server-only";
 import { Redis } from "@upstash/redis";
 
-const IDEMPOTENCY_TTL = 86400; // 24 hours in seconds
+const IDEMPOTENCY_TTL = 86400;
+const LOCK_TTL = 300;
 
 interface CachedResponse {
   status: number;
   body: unknown;
 }
+
+type ClaimResult = { claimed: true } | { claimed: false; response: CachedResponse };
 
 function createIdempotencyStore() {
   if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
@@ -21,11 +24,29 @@ function createIdempotencyStore() {
 
 const redis = createIdempotencyStore();
 
-export async function getIdempotentResponse(key: string): Promise<CachedResponse | null> {
-  if (!redis || !key) return null;
+export async function claimIdempotencyKey(key: string): Promise<ClaimResult> {
+  if (!redis || !key) return { claimed: true };
 
-  const cached = await redis.get<CachedResponse>(`idempotency:${key}`);
-  return cached;
+  const existing = await redis.get<CachedResponse | "processing">(`idempotency:${key}`);
+  if (existing === "processing") {
+    return {
+      claimed: false,
+      response: { status: 409, body: { error: { code: "CONFLICT", message: "Request is already being processed" } } },
+    };
+  }
+  if (existing && typeof existing === "object") {
+    return { claimed: false, response: existing };
+  }
+
+  const result = await redis.set(`idempotency:${key}`, "processing", { nx: true, ex: LOCK_TTL });
+  if (result !== "OK") {
+    return {
+      claimed: false,
+      response: { status: 409, body: { error: { code: "CONFLICT", message: "Request is already being processed" } } },
+    };
+  }
+
+  return { claimed: true };
 }
 
 export async function setIdempotentResponse(key: string, status: number, body: unknown): Promise<void> {

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,27 +1,31 @@
 import "server-only";
 import { getMemberById } from "@/lib/api/member-api";
 import { splitName } from "@/utils/name";
-import { AppError } from "@/utils/errors";
+import { AppError, transformError } from "@/utils/errors";
 
 import type { MemberProfile } from "@/types/settings";
 
 export type { MemberProfile } from "@/types/settings";
 
 export async function getMemberProfile(ownerid: number, isAdmin: boolean): Promise<MemberProfile> {
-  const member = await getMemberById(ownerid);
+  try {
+    const member = await getMemberById(ownerid);
 
-  if (!member) {
-    throw new AppError("NOT_FOUND", "Member not found");
+    if (!member) {
+      throw new AppError("NOT_FOUND", "Member not found");
+    }
+
+    const { firstName, lastName } = splitName(member.ownername);
+
+    return {
+      firstName,
+      lastName,
+      email: member.owneremail,
+      phone: member.ownerphone,
+      altPhone: member.owneraltphone,
+      role: isAdmin ? "Admin" : "Member",
+    };
+  } catch (error) {
+    throw transformError(error);
   }
-
-  const { firstName, lastName } = splitName(member.ownername);
-
-  return {
-    firstName,
-    lastName,
-    email: member.owneremail,
-    phone: member.ownerphone,
-    altPhone: member.owneraltphone,
-    role: isAdmin ? "Admin" : "Member",
-  };
 }

--- a/test/actions/contact-group.test.ts
+++ b/test/actions/contact-group.test.ts
@@ -20,6 +20,7 @@ import {
   mockMessageSendLimiter,
 } from "../mocks";
 import {
+  fetchEnrichedGroup,
   createContactGroup,
   updateContactGroup,
   deleteContactGroup,
@@ -35,6 +36,22 @@ function createFormData(data: Record<string, string>): FormData {
   Object.entries(data).forEach(([key, value]) => formData.append(key, value));
   return formData;
 }
+
+describe("fetchEnrichedGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects non-owner non-admin access", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await fetchEnrichedGroup(5);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
+  });
+});
 
 describe("createContactGroup", () => {
   beforeEach(() => {
@@ -120,6 +137,24 @@ describe("createContactGroup", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("Authentication required");
   });
+
+  it("logs audit event on successful group creation", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockCreateGroup.mockResolvedValue({
+      id: 55,
+      name: "Neighbors",
+      description: null,
+      ownerid: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await createContactGroup({ name: "Neighbors", description: null });
+
+    expect(spy).toHaveBeenCalledWith("[AUDIT] createContactGroup", 10, 55);
+    spy.mockRestore();
+  });
 });
 
 describe("updateContactGroup", () => {
@@ -204,6 +239,17 @@ describe("deleteContactGroup", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("do not have permission");
     expect(mockDeleteGroup).not.toHaveBeenCalled();
+  });
+
+  it("logs access denial with ownerid and resource", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    await deleteContactGroup(7);
+
+    expect(spy).toHaveBeenCalledWith("[ACCESS_DENIED] deleteContactGroup", 10, 7);
+    spy.mockRestore();
   });
 });
 
@@ -303,6 +349,21 @@ describe("updateNotifications", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("At least one notification preference");
+    expect(mockUpdateMemberNotifications).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-owner non-admin updates", async () => {
+    mockVerifySession.mockResolvedValue({ ownerid: 10, isAdmin: false });
+    mockIsGroupOwner.mockResolvedValue(false);
+
+    const result = await updateNotifications({
+      groupId: 3,
+      memberId: 101,
+      notifyEmail: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("do not have permission");
     expect(mockUpdateMemberNotifications).not.toHaveBeenCalled();
   });
 });

--- a/test/actions/settings.test.ts
+++ b/test/actions/settings.test.ts
@@ -97,4 +97,37 @@ describe("uploadPhotoAction", () => {
     expect(result).toEqual({ success: false, error: "No file provided" });
     expect(mockUploadProfilePhoto).not.toHaveBeenCalled();
   });
+
+  it("returns error when file MIME type is not JPEG or PNG", async () => {
+    const file = new File([new Uint8Array(1024)], "avatar.gif", { type: "image/gif" });
+    const formData = new FormData();
+    formData.set("file", file);
+
+    const result = await uploadPhotoAction(formData);
+
+    expect(result).toEqual({ success: false, error: "Only JPEG and PNG files are allowed" });
+    expect(mockUploadProfilePhoto).not.toHaveBeenCalled();
+  });
+
+  it("returns error when file exceeds 2MB", async () => {
+    const file = new File([new Uint8Array(2 * 1024 * 1024 + 1)], "large.jpg", { type: "image/jpeg" });
+    const formData = new FormData();
+    formData.set("file", file);
+
+    const result = await uploadPhotoAction(formData);
+
+    expect(result).toEqual({ success: false, error: "File must be under 2MB" });
+    expect(mockUploadProfilePhoto).not.toHaveBeenCalled();
+  });
+
+  it("returns error when file is zero bytes", async () => {
+    const file = new File([], "empty.png", { type: "image/png" });
+    const formData = new FormData();
+    formData.set("file", file);
+
+    const result = await uploadPhotoAction(formData);
+
+    expect(result).toEqual({ success: false, error: "No file provided" });
+    expect(mockUploadProfilePhoto).not.toHaveBeenCalled();
+  });
 });

--- a/test/api/dev-token.test.ts
+++ b/test/api/dev-token.test.ts
@@ -1,0 +1,66 @@
+import { vi } from "vitest";
+
+vi.mock("@/lib/dal", () => ({
+  generateToken: vi.fn().mockReturnValue("mock-token"),
+}));
+
+import { POST } from "@/app/api/dev/token/route";
+import { NextRequest } from "next/server";
+
+describe("POST /api/dev/token", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalMockApi = process.env.USE_MOCK_MEMBER_API;
+
+  afterEach(() => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+    process.env.USE_MOCK_MEMBER_API = originalMockApi;
+  });
+
+  it("returns 404 in production when USE_MOCK_MEMBER_API is not set", async () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    delete process.env.USE_MOCK_MEMBER_API;
+
+    const req = new NextRequest("http://localhost:3000/api/dev/token", {
+      method: "POST",
+      body: JSON.stringify({ ownerid: 100001, isAdmin: true }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Not available");
+  });
+
+  it("allows access in production when USE_MOCK_MEMBER_API is true (staging)", async () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    process.env.USE_MOCK_MEMBER_API = "true";
+
+    const req = new NextRequest("http://localhost:3000/api/dev/token", {
+      method: "POST",
+      body: JSON.stringify({ ownerid: 100001, isAdmin: false }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("mock-token");
+  });
+
+  it("allows access in non-production environments", async () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "test";
+
+    const req = new NextRequest("http://localhost:3000/api/dev/token", {
+      method: "POST",
+      body: JSON.stringify({ ownerid: 100001, isAdmin: false }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/api/referral-route.test.ts
+++ b/test/api/referral-route.test.ts
@@ -13,7 +13,7 @@ import { allReferrals, formWithTwoProspects, referralCharlie } from "../mocks/re
 import { mockBrevoSend } from "../mocks/email";
 import { mockReserveEmailQuota } from "../mocks/email-quota";
 import { mockRateLimiter } from "../mocks/rate-limit";
-import { mockGetIdempotentResponse } from "../mocks/idempotency";
+import { mockClaimIdempotencyKey } from "../mocks/idempotency";
 import { mockValidateOrigin } from "../mocks/csrf";
 import { mockVerifySession, mockRequireAdmin } from "../mocks/dal";
 import { GET, POST } from "@/app/api/referrals/route";
@@ -137,7 +137,7 @@ describe("POST /api/referrals", () => {
 
   it("returns cached response for duplicate idempotency key", async () => {
     const cachedBody = { message: "Referrals created successfully!", referrals: [referralCharlie] };
-    mockGetIdempotentResponse.mockResolvedValueOnce({ status: 201, body: cachedBody });
+    mockClaimIdempotencyKey.mockResolvedValueOnce({ claimed: false, response: { status: 201, body: cachedBody } });
 
     const req = createMockRequest({
       body: formWithTwoProspects,
@@ -150,6 +150,30 @@ describe("POST /api/referrals", () => {
     expect(data.referrals).toHaveLength(1);
     expect(mockBrevoSend).not.toHaveBeenCalled();
     expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects concurrent submission when idempotency key is already claimed", async () => {
+    mockClaimIdempotencyKey.mockResolvedValueOnce({ claimed: true }).mockResolvedValueOnce({
+      claimed: false,
+      response: { status: 409, body: { error: { code: "CONFLICT", message: "Request is already being processed" } } },
+    });
+    const createdReferrals = [{ ...referralCharlie, id: 11 }];
+    mockPrisma.$transaction.mockResolvedValue(createdReferrals);
+
+    const req1 = createMockRequest({
+      body: formWithTwoProspects,
+      headers: { "idempotency-key": "same-key" },
+    });
+    const req2 = createMockRequest({
+      body: formWithTwoProspects,
+      headers: { "idempotency-key": "same-key" },
+    });
+
+    const [res1, res2] = await Promise.all([POST(req1), POST(req2)]);
+
+    expect(res1.status).toBe(201);
+    expect(res2.status).toBe(409);
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
   });
 
   it("creates referrals even when email quota is exhausted", async () => {

--- a/test/auth/auth-flow.test.ts
+++ b/test/auth/auth-flow.test.ts
@@ -36,6 +36,7 @@ vi.mock("react", async () => {
 });
 
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { validateToken, generateToken, getSecret, verifySession, getSession, AUTH_COOKIE } from "@/lib/dal";
 import { POST as callbackPOST } from "@/app/api/auth/callback/route";
 import { POST as logoutPOST } from "@/app/api/auth/logout/route";
@@ -126,6 +127,32 @@ describe("validateToken", () => {
   });
 });
 
+describe("getSecret", () => {
+  it("throws in production when PRFC_PORTAL_SECRET is unset", () => {
+    const originalSecret = process.env.PRFC_PORTAL_SECRET;
+    const originalNodeEnv = process.env.NODE_ENV;
+    delete process.env.PRFC_PORTAL_SECRET;
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+
+    expect(() => getSecret()).toThrow("PRFC_PORTAL_SECRET required in production");
+
+    process.env.PRFC_PORTAL_SECRET = originalSecret;
+    (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+  });
+
+  it("returns dev secret in non-production when PRFC_PORTAL_SECRET is unset", () => {
+    const originalSecret = process.env.PRFC_PORTAL_SECRET;
+    delete process.env.PRFC_PORTAL_SECRET;
+
+    const secret = getSecret();
+
+    expect(secret).toBeDefined();
+    expect(secret.length).toBeGreaterThanOrEqual(32);
+
+    process.env.PRFC_PORTAL_SECRET = originalSecret;
+  });
+});
+
 describe("POST /api/auth/callback", () => {
   it("sets auth cookie for valid token", async () => {
     const token = generateToken(100001, true);
@@ -146,6 +173,8 @@ describe("POST /api/auth/callback", () => {
     expect(cookie!.httpOnly).toBe(true);
     expect(cookie!.sameSite).toBe("lax");
     expect(cookie!.path).toBe("/");
+    expect(cookie!.secure).toBe(process.env.NODE_ENV === "production");
+    expect(cookie!.maxAge).toBe(3600);
   });
 
   it("redirects without cookie for invalid token", async () => {
@@ -179,6 +208,30 @@ describe("POST /api/auth/callback", () => {
     expect(cookie).toBeUndefined();
   });
 
+  it("redirects valid and invalid tokens to the same URL to prevent enumeration", async () => {
+    const validToken = generateToken(100001, true);
+    const validForm = new FormData();
+    validForm.set("token", validToken);
+    const validReq = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: validForm,
+    });
+
+    const invalidForm = new FormData();
+    invalidForm.set("token", "invalid|token|data|badhash!");
+    const invalidReq = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: invalidForm,
+    });
+
+    const validResponse = await callbackPOST(validReq);
+    const invalidResponse = await callbackPOST(invalidReq);
+
+    const validUrl = new URL(validResponse.headers.get("location")!);
+    const invalidUrl = new URL(invalidResponse.headers.get("location")!);
+    expect(validUrl.pathname).toBe(invalidUrl.pathname);
+  });
+
   it("returns 429 when rate limited", async () => {
     mockAuthLimit.mockResolvedValueOnce({ success: false, remaining: 0, reset: Date.now() + 60000 });
 
@@ -197,6 +250,83 @@ describe("POST /api/auth/callback", () => {
     expect(response.status).toBe(429);
     expect(cookie).toBeUndefined();
     expect(mockAuthLimit).toHaveBeenCalledWith("127.0.0.1");
+  });
+
+  it("extracts client IP from x-forwarded-for header for rate limiting", async () => {
+    const token = generateToken(100001, true);
+    const formData = new FormData();
+    formData.set("token", token);
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+      headers: { "x-forwarded-for": "203.0.113.42, 10.0.0.1" },
+    });
+
+    await callbackPOST(request);
+
+    expect(mockAuthLimit).toHaveBeenCalledWith("203.0.113.42");
+  });
+
+  it("replaces malformed IP with 'invalid' to prevent log injection", () => {
+    const malicious = "1.2.3.4\n[AUTH_CALLBACK] login success 99999";
+    const result = /^[\d.:a-f]+$/i.test(malicious) ? malicious : "invalid";
+
+    expect(result).toBe("invalid");
+  });
+
+  it("accepts valid IPv4 and IPv6 addresses", () => {
+    expect(/^[\d.:a-f]+$/i.test("203.0.113.42")).toBe(true);
+    expect(/^[\d.:a-f]+$/i.test("::1")).toBe(true);
+    expect(/^[\d.:a-f]+$/i.test("2001:db8::1")).toBe(true);
+  });
+
+  it("logs successful login with ownerid", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const token = generateToken(100001, true);
+    const formData = new FormData();
+    formData.set("token", token);
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    await callbackPOST(request);
+
+    expect(spy).toHaveBeenCalledWith("[AUTH_CALLBACK] login success", 100001, "127.0.0.1");
+    spy.mockRestore();
+  });
+
+  it("logs failed login for invalid token", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const formData = new FormData();
+    formData.set("token", "invalid|token|data|badhash!");
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    await callbackPOST(request);
+
+    expect(spy).toHaveBeenCalledWith("[AUTH_CALLBACK] invalid or expired token", "127.0.0.1");
+    spy.mockRestore();
+  });
+
+  it("logs failed login for missing token", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const formData = new FormData();
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    await callbackPOST(request);
+
+    expect(spy).toHaveBeenCalledWith("[AUTH_CALLBACK] missing or malformed token", "127.0.0.1");
+    spy.mockRestore();
   });
 });
 
@@ -224,6 +354,12 @@ describe("logout server action", () => {
 
     expect(mockCookieStore.delete).toHaveBeenCalledWith(AUTH_COOKIE);
     expect(mockRedirect).toHaveBeenCalledWith("/dev/mock-portal");
+  });
+
+  it("does not call revalidatePath to avoid error boundary on expired session", async () => {
+    await logout().catch(() => {});
+
+    expect(revalidatePath).not.toHaveBeenCalled();
   });
 });
 

--- a/test/components/create-group-modal.test.tsx
+++ b/test/components/create-group-modal.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { CreateGroupModal } from "@/components/groups/create-group-modal";
+
+const MEMBERS = [
+  { memberId: 100001, ownername: "Member Alpha" },
+  { memberId: 100002, ownername: "Member Bravo" },
+  { memberId: 100003, ownername: "Member Charlie" },
+];
+
+describe("CreateGroupModal owner pre-selection", () => {
+  it("owner checkbox is checked and disabled on open", () => {
+    render(
+      <CreateGroupModal open={true} onOpenChange={vi.fn()} onSubmit={vi.fn()} members={MEMBERS} ownerId={100001} />,
+    );
+
+    const ownerCheckbox = screen.getByLabelText("Select Member Alpha");
+    expect(ownerCheckbox).toBeChecked();
+    expect(ownerCheckbox).toBeDisabled();
+  });
+
+  it("owner cannot be deselected by clicking", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateGroupModal open={true} onOpenChange={vi.fn()} onSubmit={vi.fn()} members={MEMBERS} ownerId={100001} />,
+    );
+
+    const ownerCheckbox = screen.getByLabelText("Select Member Alpha");
+    await user.click(ownerCheckbox);
+
+    expect(ownerCheckbox).toBeChecked();
+  });
+
+  it("includes owner in submitted memberIds", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <CreateGroupModal open={true} onOpenChange={vi.fn()} onSubmit={onSubmit} members={MEMBERS} ownerId={100001} />,
+    );
+
+    const nameInput = screen.getByPlaceholderText("Group Name");
+    await user.type(nameInput, "Test Group");
+
+    const form = nameInput.closest("form")!;
+    fireEvent.submit(form);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberIds: expect.arrayContaining([100001]),
+      }),
+    );
+  });
+});

--- a/test/lib/email-quota.test.ts
+++ b/test/lib/email-quota.test.ts
@@ -63,4 +63,15 @@ describe("reserveEmailQuota", () => {
 
     expect(mockExpire).toHaveBeenCalledWith(expect.stringContaining("prfc:email-sent:"), 172800);
   });
+
+  it("handles concurrent reservations via atomic INCRBY", async () => {
+    mockIncrby.mockResolvedValueOnce(200).mockResolvedValueOnce(350);
+
+    const [result1, result2] = await Promise.all([reserveEmailQuota(200), reserveEmailQuota(150)]);
+
+    expect(result1).toEqual({ allowed: 200, total: 200 });
+    expect(result2).toEqual({ allowed: 100, total: 300 });
+    expect(mockIncrby).toHaveBeenCalledTimes(2);
+    expect(mockDecrby).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/lib/idempotency.test.ts
+++ b/test/lib/idempotency.test.ts
@@ -1,0 +1,95 @@
+import { vi } from "vitest";
+
+const { mockGet, mockSet } = vi.hoisted(() => {
+  process.env.UPSTASH_REDIS_REST_URL = "https://fake.upstash.io";
+  process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";
+  return {
+    mockGet: vi.fn(),
+    mockSet: vi.fn(),
+  };
+});
+
+vi.mock("@upstash/redis", () => ({
+  Redis: class {
+    get = mockGet;
+    set = mockSet;
+  },
+}));
+
+import { claimIdempotencyKey, setIdempotentResponse } from "@/lib/idempotency";
+
+describe("claimIdempotencyKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns claimed when key does not exist and SET NX succeeds", async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue("OK");
+
+    const result = await claimIdempotencyKey("new-key");
+
+    expect(result).toEqual({ claimed: true });
+    expect(mockSet).toHaveBeenCalledWith("idempotency:new-key", "processing", { nx: true, ex: 300 });
+  });
+
+  it("returns cached response when key has a completed response", async () => {
+    const cached = { status: 201, body: { message: "done" } };
+    mockGet.mockResolvedValue(cached);
+
+    const result = await claimIdempotencyKey("existing-key");
+
+    expect(result).toEqual({ claimed: false, response: cached });
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 conflict when key is currently being processed", async () => {
+    mockGet.mockResolvedValue("processing");
+
+    const result = await claimIdempotencyKey("in-progress-key");
+
+    expect(result.claimed).toBe(false);
+    if (!result.claimed) {
+      expect(result.response.status).toBe(409);
+    }
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 conflict when SET NX fails (another request claimed first)", async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue(null);
+
+    const result = await claimIdempotencyKey("raced-key");
+
+    expect(result.claimed).toBe(false);
+    if (!result.claimed) {
+      expect(result.response.status).toBe(409);
+    }
+  });
+
+  it("returns claimed when key is empty string", async () => {
+    const result = await claimIdempotencyKey("");
+
+    expect(result).toEqual({ claimed: true });
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("setIdempotentResponse", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores response with 24-hour TTL", async () => {
+    mockSet.mockResolvedValue("OK");
+
+    await setIdempotentResponse("completed-key", 201, { message: "done" });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      "idempotency:completed-key",
+      { status: 201, body: { message: "done" } },
+      { ex: 86400 },
+    );
+  });
+});

--- a/test/mocks/idempotency.ts
+++ b/test/mocks/idempotency.ts
@@ -1,17 +1,17 @@
 import { vi } from "vitest";
 
-const mockGetIdempotentResponse = vi.fn().mockResolvedValue(null);
+const mockClaimIdempotencyKey = vi.fn().mockResolvedValue({ claimed: true });
 const mockSetIdempotentResponse = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@/lib/idempotency", () => ({
-  getIdempotentResponse: mockGetIdempotentResponse,
+  claimIdempotencyKey: mockClaimIdempotencyKey,
   setIdempotentResponse: mockSetIdempotentResponse,
 }));
 
 beforeEach(() => {
-  mockGetIdempotentResponse.mockClear();
+  mockClaimIdempotencyKey.mockClear();
   mockSetIdempotentResponse.mockClear();
-  mockGetIdempotentResponse.mockResolvedValue(null);
+  mockClaimIdempotencyKey.mockResolvedValue({ claimed: true });
 });
 
-export { mockGetIdempotentResponse, mockSetIdempotentResponse };
+export { mockClaimIdempotencyKey, mockSetIdempotentResponse };

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -3,7 +3,7 @@ export { mockPrisma } from "./prisma";
 export { createMockRequest } from "./request";
 export { mockBrevoSend } from "./email";
 export { mockRateLimiter, mockMembersRateLimiter, mockMessageSendLimiter } from "./rate-limit";
-export { mockGetIdempotentResponse, mockSetIdempotentResponse } from "./idempotency";
+export { mockClaimIdempotencyKey, mockSetIdempotentResponse } from "./idempotency";
 export { mockValidateOrigin } from "./csrf";
 export { mockVerifySession, mockRequireAdmin } from "./dal";
 export { mockRevalidatePath } from "./next-cache";

--- a/test/schema/contact-group.test.ts
+++ b/test/schema/contact-group.test.ts
@@ -1,0 +1,44 @@
+import { CreateContactGroupSchema, ComposeMessageSchema } from "@/schema/contact-group";
+
+describe("CreateContactGroupSchema", () => {
+  it("strips unknown fields from parsed output", () => {
+    const input = {
+      name: "Test Group",
+      description: null,
+      memberIds: [100001],
+      isAdmin: true,
+      ownerid: 999,
+      __proto_pollution: "malicious",
+    };
+
+    const result = CreateContactGroupSchema.parse(input);
+
+    expect(result).toEqual({
+      name: "Test Group",
+      description: null,
+      memberIds: [100001],
+    });
+    expect(result).not.toHaveProperty("isAdmin");
+    expect(result).not.toHaveProperty("ownerid");
+    expect(result).not.toHaveProperty("__proto_pollution");
+  });
+});
+
+describe("ComposeMessageSchema", () => {
+  it("strips unknown fields from parsed output", () => {
+    const input = {
+      groupIds: [1],
+      subject: "Hello",
+      body: "Body text",
+      sendEmail: true,
+      sendSms: false,
+      recipientOverride: [999],
+      isAdmin: true,
+    };
+
+    const result = ComposeMessageSchema.parse(input);
+
+    expect(result).not.toHaveProperty("recipientOverride");
+    expect(result).not.toHaveProperty("isAdmin");
+  });
+});

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -201,7 +201,7 @@ describe("sendGroupEmails", () => {
       valid: recipients.map((r) => r.email),
       suppressed: [],
     });
-    mockBrevoSend.mockRejectedValueOnce(new Error("API Error")).mockResolvedValue("ok");
+    mockBrevoSend.mockRejectedValueOnce(new Error("API Error")).mockResolvedValue({ messageId: "ok", remaining: null });
 
     const { sent, failed, suppressed } = await sendGroupEmails({ ...defaultParams, recipients });
 
@@ -209,6 +209,19 @@ describe("sendGroupEmails", () => {
     expect(sent).toBe(2);
     expect(failed).toBe(1);
     expect(suppressed).toBe(0);
+  });
+
+  it("logs email send errors with [EMAIL_SEND_ERROR] prefix", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const recipients = [recipientBobby];
+    mockFilterSuppressedEmails.mockResolvedValue({ valid: [recipientBobby.email], suppressed: [] });
+    const sendError = new Error("Connection timeout");
+    mockBrevoSend.mockRejectedValueOnce(sendError);
+
+    await sendGroupEmails({ ...defaultParams, recipients });
+
+    expect(spy).toHaveBeenCalledWith("[EMAIL_SEND_ERROR]", sendError);
+    spy.mockRestore();
   });
 
   it("returns zeros with empty recipient list", async () => {

--- a/test/services/profile.test.ts
+++ b/test/services/profile.test.ts
@@ -44,4 +44,13 @@ describe("getMemberProfile", () => {
 
     expect(result.altPhone).toBeUndefined();
   });
+
+  it("wraps unexpected errors with transformError", async () => {
+    mockGetMemberById.mockRejectedValue(new Error("Connection refused"));
+
+    await expect(getMemberProfile(100001, false)).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "Connection refused",
+    });
+  });
 });

--- a/test/utils/errors.test.ts
+++ b/test/utils/errors.test.ts
@@ -57,4 +57,37 @@ describe("apiErrorHandler", () => {
 
     expect(res.status).toBe(status);
   });
+
+  it("returns only code and message in response body, no stack trace", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("Something broke internally");
+    const res = apiErrorHandler(err);
+    const body = await res.json();
+
+    expect(body).toEqual({
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Something broke internally",
+      },
+    });
+    expect(body.error).not.toHaveProperty("stack");
+    expect(body).not.toHaveProperty("stack");
+    spy.mockRestore();
+  });
+
+  it("transforms Prisma errors to generic message in response body", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { Prisma } = await import("@/generated/prisma/client");
+    const prismaErr = new Prisma.PrismaClientKnownRequestError("Column 'email' not found", {
+      code: "P2022",
+      clientVersion: "7.0.0",
+    });
+    const res = apiErrorHandler(prismaErr);
+    const body = await res.json();
+
+    expect(body.error.message).toBe("Database operation failed");
+    expect(body.error.message).not.toContain("Column");
+    expect(body.error.message).not.toContain("email");
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

I audited the platform against all 10 OWASP Top 10:2025 categories (134 checks) and fixed the gaps found.

**Idempotency race condition (A08, CWE-362)**
- `src/lib/idempotency.ts` - replaced read-then-write with atomic Redis SET NX to prevent duplicate referral processing under concurrency. Claims key with 300s lock TTL, returns 409 on conflict.
- `src/app/api/referrals/route.ts` - uses new `claimIdempotencyKey` instead of `getIdempotentResponse`

**Auth hardening (A07, A09)**
- `src/app/api/auth/callback/route.ts` - all redirect paths now go to /home (prevents token enumeration via different redirects). IP validated with allowlist regex before logging (CWE-117). Added [AUTH_CALLBACK] logging for login success, invalid token, and missing token.

**Audit logging (A09, CWE-778)**
- `src/actions/contact-group.ts` - [ACCESS_DENIED] on all 11 rejection points, [AUDIT] on createContactGroup, deleteContactGroup, sendMessage, sendBlast
- `src/actions/event.ts` - [ACCESS_DENIED] on updateEvent and deleteEvent, [AUDIT] on createEvent and deleteEvent
- `src/actions/referral.ts` - [AUDIT] on toggleRedeemed
- `src/app/api/referrals/route.ts` - [AUDIT] on createReferrals
- `src/app/api/referrals/[id]/route.ts` - [AUDIT] on updateReferralRedeemed and deleteReferral

**Error handling (A10)**
- `src/services/profile.ts` - added try/catch with transformError (was the only service without it)

**Dependency fix (A03)**
- `package-lock.json` - npm audit fix for qs DoS vulnerability in twilio transitive dep

**Tests (663 pass, up from 626)**
- `test/lib/idempotency.test.ts` - 6 tests: SET NX claim, cached response, in-progress conflict, race loss, empty key, TTL
- `test/api/dev-token.test.ts` - 3 tests: production guard returns 404, staging bypass, non-production access
- `test/components/create-group-modal.test.tsx` - 3 tests: owner checked+disabled, cannot deselect, included in submit
- `test/schema/contact-group.test.ts` - 2 tests: Zod strips unknown fields (mass assignment protection)
- `test/actions/contact-group.test.ts` - 3 tests: fetchEnrichedGroup rejection, updateNotifications rejection, audit logging
- `test/actions/settings.test.ts` - 3 tests: rejected MIME type, oversized file, zero-byte file
- `test/auth/auth-flow.test.ts` - 6 tests: cookie secure/maxAge, anti-enumeration redirect, x-forwarded-for extraction, IP allowlist, getSecret production throw, logout revalidatePath regression
- `test/services/email-group.test.ts` - 1 test: [EMAIL_SEND_ERROR] logging
- `test/services/profile.test.ts` - 1 test: transformError wrapping
- `test/utils/errors.test.ts` - 2 tests: no stack traces in response, Prisma errors become generic messages
- `test/lib/email-quota.test.ts` - 1 test: concurrent INCRBY behavior
- `test/api/referral-route.test.ts` - updated for claimIdempotencyKey API, concurrent rejection returns 409

## How to test

1. `npm test` - 663 tests pass
2. `npx tsc --noEmit` - clean
3. `npm audit` - 0 vulnerabilities
4. Submit the referral form twice rapidly with the same idempotency key - second request returns 409

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers