### PR TITLE
fix: migrate database adapter from tidb to mysql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,6 @@
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.13",
-        "@tidbcloud/prisma-adapter": "^6.17.0",
-        "@tidbcloud/serverless": "^0.2.0",
         "@upstash/ratelimit": "^2.0.7",
         "@upstash/redis": "^1.35.8",
         "@vercel/blob": "^2.3.3",
@@ -4137,42 +4135,6 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
-      }
-    },
-    "node_modules/@tidbcloud/prisma-adapter": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@tidbcloud/prisma-adapter/-/prisma-adapter-6.17.0.tgz",
-      "integrity": "sha512-ULKaE2e4+j5ijgkvRMN2rz7Ub35Ufh5Z4qkBhGk6BhLb3A1NnnN/+RPITDwYS0Te4bHYYhGwdRSek00jK9g1WQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/driver-adapter-utils": "6.17.0"
-      },
-      "peerDependencies": {
-        "@tidbcloud/serverless": ">= 0.1.0"
-      }
-    },
-    "node_modules/@tidbcloud/prisma-adapter/node_modules/@prisma/debug": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.17.0.tgz",
-      "integrity": "sha512-eE2CB32nr1hRqyLVnOAVY6c//iSJ/PN+Yfoa/2sEzLGpORaCg61d+nvdAkYSh+6Y2B8L4BVyzkRMANLD6nnC2g==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@tidbcloud/prisma-adapter/node_modules/@prisma/driver-adapter-utils": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.17.0.tgz",
-      "integrity": "sha512-JqK4STDoZVQnj7ac6+daN5w6l0Vns82tHdj8FVzMdCLMdWd2JgDzDS688gTMZt7rEDNJSb/z9U5XtIP0C08sWg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.17.0"
-      }
-    },
-    "node_modules/@tidbcloud/serverless": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@tidbcloud/serverless/-/serverless-0.2.0.tgz",
-      "integrity": "sha512-UGmMa9hYeRVcmDjsUE/vNYbsiS4PGHU2M9Y+DFyMUu6gRMxXOfda6rTTnuHQ5OzUsbk6AfV4gtJoEUWvmpBpJw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.13",
-    "@tidbcloud/prisma-adapter": "^6.17.0",
-    "@tidbcloud/serverless": "^0.2.0",
     "@upstash/ratelimit": "^2.0.7",
     "@upstash/redis": "^1.35.8",
     "@vercel/blob": "^2.3.3",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,29 +1,8 @@
 import "server-only";
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaMariaDb } from "@prisma/adapter-mariadb";
-import { PrismaTiDBCloud } from "@tidbcloud/prisma-adapter";
+import { buildDbPoolConfig } from "@/utils/db-config";
 import { env } from "@/env";
-
-function createAdapter() {
-  // TiDB serverless uses HTTPS, avoiding connection pool exhaustion in Vercel
-  if (process.env.VERCEL) {
-    return new PrismaTiDBCloud({ url: env.DATABASE_URL });
-  }
-
-  // Local/CI uses TCP connection to Docker MySQL
-  const url = new URL(env.DATABASE_URL);
-  return new PrismaMariaDb({
-    host: url.hostname,
-    port: url.port ? parseInt(url.port, 10) : 3306,
-    user: url.username,
-    password: url.password,
-    database: url.pathname.slice(1),
-    connectionLimit: 5,
-    keepAliveDelay: 30000,
-    socketTimeout: 60000,
-    timezone: "Z",
-  });
-}
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
@@ -32,7 +11,7 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    adapter: createAdapter(),
+    adapter: new PrismaMariaDb(buildDbPoolConfig(env.DATABASE_URL)),
     log: env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
   });
 

--- a/src/utils/db-config.ts
+++ b/src/utils/db-config.ts
@@ -1,0 +1,33 @@
+export type DbPoolConfig = {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+  connectionLimit: number;
+  idleTimeout: number;
+  socketTimeout: number;
+  timezone: string;
+  ssl?: { rejectUnauthorized: boolean };
+};
+
+export function buildDbPoolConfig(databaseUrl: string): DbPoolConfig {
+  const url = new URL(databaseUrl);
+  const config: DbPoolConfig = {
+    host: url.hostname,
+    port: url.port ? parseInt(url.port, 10) : 3306,
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    database: url.pathname.slice(1),
+    connectionLimit: 3,
+    idleTimeout: 5,
+    socketTimeout: 60000,
+    timezone: "Z",
+  };
+
+  if (url.searchParams.get("ssl") === "true") {
+    config.ssl = { rejectUnauthorized: false };
+  }
+
+  return config;
+}

--- a/test/utils/db-config.test.ts
+++ b/test/utils/db-config.test.ts
@@ -1,0 +1,38 @@
+import { buildDbPoolConfig } from "@/utils/db-config";
+
+describe("buildDbPoolConfig", () => {
+  it("parses host, port, user, password, and database from a basic url", () => {
+    const config = buildDbPoolConfig("mysql://app:secret@db.example.com:3306/coop");
+    expect(config.host).toBe("db.example.com");
+    expect(config.port).toBe(3306);
+    expect(config.user).toBe("app");
+    expect(config.password).toBe("secret");
+    expect(config.database).toBe("coop");
+  });
+
+  it("decodes percent-encoded credentials", () => {
+    const config = buildDbPoolConfig("mysql://co%40op:p%40ss%2Fw0%3Ard%231@host/db");
+    expect(config.user).toBe("co@op");
+    expect(config.password).toBe("p@ss/w0:rd#1");
+  });
+
+  it("defaults the port to 3306 when the url omits it", () => {
+    expect(buildDbPoolConfig("mysql://u:p@host/db").port).toBe(3306);
+  });
+
+  it("uses a small pool and the UTC timezone", () => {
+    const config = buildDbPoolConfig("mysql://u:p@host/db");
+    expect(config.connectionLimit).toBe(3);
+    expect(config.idleTimeout).toBe(5);
+    expect(config.timezone).toBe("Z");
+  });
+
+  it("enables encrypted TLS without certificate verification when ?ssl=true", () => {
+    expect(buildDbPoolConfig("mysql://u:p@host/db?ssl=true").ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it("leaves ssl unset when absent or not true", () => {
+    expect(buildDbPoolConfig("mysql://u:p@host/db").ssl).toBeUndefined();
+    expect(buildDbPoolConfig("mysql://u:p@host/db?ssl=false").ssl).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

`src/lib/db.ts` routed every Vercel deploy to the TiDB adapter, which only ever backed staging. Production runs on the co-op's MySQL, so this always uses the MySQL adapter (`PrismaMariaDb`), built from the connection string by a new `src/utils/db-config.ts` that decodes credentials and turns on TLS when the url carries `?ssl=true`. I validated the schema and CRUD against MySQL 8.0, 5.7, and MariaDB 10.11.

- `src/lib/db.ts` - always uses `PrismaMariaDb` with a small pool, drops the `process.env.VERCEL` branch
- `src/utils/db-config.ts` - parses the connection string into the pool config (credential decode, `?ssl=true` TLS)
- `test/utils/db-config.test.ts` - 6 tests for the parser
- `package.json` - removed `@tidbcloud/prisma-adapter` and `@tidbcloud/serverless`

## How to test

1. `npm test` passes (697)
2. `npx next build` compiles

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers
