### PR TITLE
fix: drop prisma migrate deploy from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && prisma migrate deploy && next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

The build ran `prisma migrate deploy`, which fails in production against the co-op's MySQL. Kermit creates the production tables by hand (no `_prisma_migrations` ledger), and the server is MariaDB 5.5 where the migrations cannot run, so `migrate deploy` tries to `CREATE TABLE` on tables that already exist and the deploy fails. Prisma recommends running `migrate deploy` as a separate CI/CD step, not in the build, and `ci.yml` already does that, so the build step is redundant there and breaking in production.

- `package.json` - build script is now `prisma generate && next build`; the `prisma migrate deploy` step is dropped

CI is unaffected (it migrates at its own step), local dev uses `npm run db:migrate`, and the build no longer needs a database connection.

## How to test

1. `npm run build` succeeds with no migrate step

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers
