### PR TITLE
feat: integrate real member portal auth and member api

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -36,6 +36,11 @@ SMS_ENABLED=false
 # Set to false for production with real Member Portal API
 USE_MOCK_MEMBER_API=true
 
+# Required when USE_MOCK_MEMBER_API=false: the PHP actions endpoint and the
+# getmembercontacts service secret
+# PRFC_PORTAL_API_URL=https://www.pasofoodcooperative.coop/accounts/actions/
+# MEMBER_API_SECRET=your-getmembercontacts-service-secret
+
 # Email Unsubscribe Token Secret (32 characters minimum)
 UNSUBSCRIBE_SECRET=your-32-character-secret-here-change-in-production
 

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { AUTH_COOKIE, validateToken, getSecret } from "@/lib/dal";
+import { AUTH_COOKIE, generateToken, getSecret } from "@/lib/dal";
+import { PORTAL_TOKEN_COOKIE, validatePortalToken } from "@/lib/api/portal-api";
 import { authRateLimiter } from "@/lib/rate-limit";
 import { AuthCallbackSchema } from "@/schema/auth";
 
@@ -15,9 +16,8 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  let secret: string;
   try {
-    secret = getSecret();
+    getSecret();
   } catch {
     return NextResponse.redirect(new URL("/home", req.url));
   }
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
 
   const { token } = parsed.data;
 
-  const session = validateToken(token, secret);
+  const session = await validatePortalToken(token);
   if (!session) {
     console.warn("[AUTH_CALLBACK] invalid or expired token", ip);
     return NextResponse.redirect(new URL("/home", req.url));
@@ -41,14 +41,16 @@ export async function POST(req: NextRequest) {
   console.info("[AUTH_CALLBACK] login success", session.ownerid, ip);
 
   const response = NextResponse.redirect(new URL("/home", req.url));
-
-  response.cookies.set(AUTH_COOKIE, token, {
+  const cookieOptions = {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    sameSite: "lax" as const,
     maxAge: 3600,
     path: "/",
-  });
+  };
+
+  response.cookies.set(AUTH_COOKIE, generateToken(session.ownerid, session.isAdmin), cookieOptions);
+  response.cookies.set(PORTAL_TOKEN_COOKIE, token, cookieOptions);
 
   return response;
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { AUTH_COOKIE } from "@/lib/dal";
+import { PORTAL_TOKEN_COOKIE } from "@/lib/api/portal-api";
 import { validateOrigin } from "@/lib/csrf";
 
 export async function POST(req: NextRequest) {
@@ -9,5 +10,6 @@ export async function POST(req: NextRequest) {
 
   const response = NextResponse.redirect(new URL("/", req.url));
   response.cookies.delete(AUTH_COOKIE);
+  response.cookies.delete(PORTAL_TOKEN_COOKIE);
   return response;
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -16,6 +16,10 @@ export const envSchema = z
 
     PRFC_PORTAL_LOGIN_URL: z.url().optional(),
 
+    // Member Portal API: the PHP actions endpoint and the service secret for getmembercontacts
+    PRFC_PORTAL_API_URL: z.url().optional(),
+    MEMBER_API_SECRET: z.string().min(1).optional(),
+
     // SMS feature flag (disabled by default)
     EMAIL_ENABLED: z
       .string()
@@ -65,6 +69,14 @@ export const envSchema = z
           message: "UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are required in production",
         });
       }
+    }
+
+    if (!parsed.USE_MOCK_MEMBER_API && (!parsed.PRFC_PORTAL_API_URL || !parsed.MEMBER_API_SECRET)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["PRFC_PORTAL_API_URL"],
+        message: "PRFC_PORTAL_API_URL and MEMBER_API_SECRET are required when USE_MOCK_MEMBER_API is false",
+      });
     }
 
     if (parsed.EMAIL_ENABLED && (!parsed.BREVO_API_KEY || !parsed.FROM_EMAIL)) {

--- a/src/lib/api/member-api.ts
+++ b/src/lib/api/member-api.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { env } from "@/env";
 import { AppError } from "@/utils/errors";
+import { fetchListMembers, fetchMemberContacts, getPortalToken } from "@/lib/api/portal-api";
 import type { MockMember } from "@/lib/mock-members";
 import type { MemberSummary } from "@/types/member";
 export type { MemberSummary } from "@/types/member";
@@ -10,8 +11,8 @@ async function getMockMemberDetails(memberIds: number[]): Promise<MockMember[]> 
   return memberIds.map((id) => findMemberById(id)).filter((m): m is MockMember => m !== undefined);
 }
 
-async function getRealMemberDetails(_memberIds: number[]): Promise<MockMember[]> {
-  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
+async function getRealMemberDetails(memberIds: number[]): Promise<MockMember[]> {
+  return fetchMemberContacts(memberIds);
 }
 
 async function getMockAllActiveMemberIds(): Promise<number[]> {
@@ -20,7 +21,10 @@ async function getMockAllActiveMemberIds(): Promise<number[]> {
 }
 
 async function getRealAllActiveMemberIds(): Promise<number[]> {
-  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
+  const token = await getPortalToken();
+  if (!token) throw new AppError("UNAUTHORIZED", "Member portal session required");
+  const members = await fetchListMembers(token);
+  return members.map((m) => m.ownerid);
 }
 
 async function getMockAllMembers(): Promise<MemberSummary[]> {
@@ -29,7 +33,9 @@ async function getMockAllMembers(): Promise<MemberSummary[]> {
 }
 
 async function getRealAllMembers(): Promise<MemberSummary[]> {
-  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
+  const token = await getPortalToken();
+  if (!token) throw new AppError("UNAUTHORIZED", "Member portal session required");
+  return fetchListMembers(token);
 }
 
 async function getMockMemberById(id: number): Promise<MockMember | null> {
@@ -37,8 +43,9 @@ async function getMockMemberById(id: number): Promise<MockMember | null> {
   return findMemberById(id) ?? null;
 }
 
-async function getRealMemberById(_id: number): Promise<MockMember | null> {
-  throw new AppError("INTERNAL_ERROR", "Service temporarily unavailable");
+async function getRealMemberById(id: number): Promise<MockMember | null> {
+  const members = await fetchMemberContacts([id]);
+  return members[0] ?? null;
 }
 
 export async function getMemberDetails(memberIds: number[]): Promise<MockMember[]> {

--- a/src/lib/api/portal-api.ts
+++ b/src/lib/api/portal-api.ts
@@ -1,0 +1,103 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { env } from "@/env";
+import { AppError } from "@/utils/errors";
+import {
+  ListMembersResponseSchema,
+  MemberContactsResponseSchema,
+  ValidateTokenResponseSchema,
+} from "@/schema/member-portal";
+import type { Session } from "@/lib/dal";
+import type { MemberSummary } from "@/types/member";
+import type { MockMember } from "@/lib/mock-members";
+
+export const PORTAL_TOKEN_COOKIE = "prfc_portal_token";
+
+export async function getPortalToken(): Promise<string | null> {
+  const cookieStore = await cookies();
+  return cookieStore.get(PORTAL_TOKEN_COOKIE)?.value ?? null;
+}
+
+async function postForm(task: string, body: Record<string, string>): Promise<string> {
+  const res = await fetch(`${env.PRFC_PORTAL_API_URL}?task=${task}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+
+  if (!res.ok) {
+    throw new AppError("INTERNAL_ERROR", `Member portal ${task} responded ${res.status}`);
+  }
+
+  return res.text();
+}
+
+function extractObject(raw: string): unknown {
+  const stripped = raw.replace(/<[^>]+>/g, "");
+  const start = stripped.indexOf("{");
+  const end = stripped.lastIndexOf("}");
+  if (start === -1 || end === -1) {
+    throw new AppError("INTERNAL_ERROR", "Member portal returned no JSON object");
+  }
+  return JSON.parse(stripped.slice(start, end + 1));
+}
+
+function extractArray(raw: string): unknown {
+  const start = raw.indexOf("[");
+  const end = raw.lastIndexOf("]");
+  if (start === -1 || end === -1) {
+    throw new AppError("INTERNAL_ERROR", "Member portal returned no JSON array");
+  }
+  const body = raw
+    .slice(start, end + 1)
+    .replace(/<[^>]+>/g, "")
+    .replace(/}\s*{/g, "},{")
+    .replace(/,\s*]/g, "]");
+  return JSON.parse(body);
+}
+
+export async function validatePortalToken(token: string): Promise<Session | null> {
+  let raw: string;
+  try {
+    raw = await postForm("validatetoken", { token });
+  } catch {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = ValidateTokenResponseSchema.safeParse(extractObject(raw));
+  } catch {
+    return null;
+  }
+  if (!parsed.success) return null;
+
+  const ownerid = Number(parsed.data.ownerid);
+  if (!Number.isInteger(ownerid) || ownerid <= 0) return null;
+  if (Number(parsed.data.secondsleft) <= 0) return null;
+
+  return { ownerid, isAdmin: parsed.data.isadmin === "1" };
+}
+
+export async function fetchListMembers(token: string): Promise<MemberSummary[]> {
+  const raw = await postForm("listmembers", { token });
+  const data = ListMembersResponseSchema.parse(extractArray(raw));
+  return data.map((m) => ({ ownerid: Number(m.ownerid), ownername: m.ownername }));
+}
+
+export async function fetchMemberContacts(ownerids: number[]): Promise<MockMember[]> {
+  if (ownerids.length === 0) return [];
+
+  const raw = await postForm("getmembercontacts", {
+    secret: env.MEMBER_API_SECRET ?? "",
+    ownerids: ownerids.join(","),
+  });
+  const data = MemberContactsResponseSchema.parse(extractArray(raw));
+  return data.map((m) => ({
+    ownerid: Number(m.ownerid),
+    ownername: m.ownername,
+    owneremail: m.email,
+    ownerphone: m.phone,
+    owneraltphone: m.altphone === "" ? undefined : m.altphone,
+  }));
+}

--- a/src/schema/member-portal.ts
+++ b/src/schema/member-portal.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const ValidateTokenResponseSchema = z.object({
+  ownerid: z.string(),
+  secondsleft: z.string(),
+  isadmin: z.string(),
+});
+
+export const ListMembersResponseSchema = z.array(
+  z.object({
+    ownerid: z.string(),
+    ownername: z.string(),
+  }),
+);
+
+export const MemberContactsResponseSchema = z.array(
+  z.object({
+    ownerid: z.string(),
+    ownername: z.string(),
+    email: z.string(),
+    phone: z.string(),
+    altphone: z.string(),
+  }),
+);
+
+export type ValidateTokenResponse = z.infer<typeof ValidateTokenResponseSchema>;
+export type ListMembersResponse = z.infer<typeof ListMembersResponseSchema>;
+export type MemberContactsResponse = z.infer<typeof MemberContactsResponseSchema>;

--- a/test/auth/auth-flow.test.ts
+++ b/test/auth/auth-flow.test.ts
@@ -29,6 +29,18 @@ vi.mock("@/lib/rate-limit", () => ({
   authRateLimiter: { limit: mockAuthLimit },
 }));
 
+const { mockValidatePortalToken } = vi.hoisted(() => ({
+  mockValidatePortalToken: vi.fn(),
+}));
+
+vi.mock("@/lib/api/portal-api", () => ({
+  PORTAL_TOKEN_COOKIE: "prfc_portal_token",
+  validatePortalToken: mockValidatePortalToken,
+  getPortalToken: vi.fn(),
+  fetchListMembers: vi.fn(),
+  fetchMemberContacts: vi.fn(),
+}));
+
 // Make React cache() a passthrough so tests get fresh results
 vi.mock("react", async () => {
   const actual = await vi.importActual("react");
@@ -155,10 +167,16 @@ describe("getSecret", () => {
 });
 
 describe("POST /api/auth/callback", () => {
-  it("sets auth cookie for valid token", async () => {
-    const token = generateToken(100001, true);
+  beforeEach(() => {
+    mockValidatePortalToken.mockReset();
+    mockValidatePortalToken.mockResolvedValue(null);
+  });
+
+  it("mints our session cookie and stores the portal token for a valid token", async () => {
+    mockValidatePortalToken.mockResolvedValueOnce({ ownerid: 100001, isAdmin: true });
+    const portalToken = "portal-base64-token";
     const formData = new FormData();
-    formData.set("token", token);
+    formData.set("token", portalToken);
 
     const request = new NextRequest("http://localhost:3000/api/auth/callback", {
       method: "POST",
@@ -167,15 +185,17 @@ describe("POST /api/auth/callback", () => {
 
     const response = await callbackPOST(request);
     const cookie = response.cookies.get(AUTH_COOKIE);
+    const portalCookie = response.cookies.get("prfc_portal_token");
 
     expect(response.status).toBe(307);
     expect(cookie).toBeDefined();
-    expect(cookie!.value).toBe(token);
+    expect(validateToken(cookie!.value, getSecret())).toEqual({ ownerid: 100001, isAdmin: true });
     expect(cookie!.httpOnly).toBe(true);
     expect(cookie!.sameSite).toBe("lax");
     expect(cookie!.path).toBe("/");
     expect(cookie!.secure).toBe(process.env.NODE_ENV === "production");
     expect(cookie!.maxAge).toBe(3600);
+    expect(portalCookie?.value).toBe(portalToken);
   });
 
   it("redirects without cookie for invalid token", async () => {
@@ -283,10 +303,10 @@ describe("POST /api/auth/callback", () => {
   });
 
   it("logs successful login with ownerid", async () => {
+    mockValidatePortalToken.mockResolvedValueOnce({ ownerid: 100001, isAdmin: true });
     const spy = vi.spyOn(console, "info").mockImplementation(() => {});
-    const token = generateToken(100001, true);
     const formData = new FormData();
-    formData.set("token", token);
+    formData.set("token", "portal-base64-token");
 
     const request = new NextRequest("http://localhost:3000/api/auth/callback", {
       method: "POST",

--- a/test/lib/api/portal-api.test.ts
+++ b/test/lib/api/portal-api.test.ts
@@ -1,0 +1,95 @@
+import { vi } from "vitest";
+
+vi.mock("@/env", () => ({
+  env: { PRFC_PORTAL_API_URL: "https://portal.test/actions/", MEMBER_API_SECRET: "test-secret" },
+}));
+
+const { mockCookieStore } = vi.hoisted(() => ({
+  mockCookieStore: { get: vi.fn() },
+}));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue(mockCookieStore),
+}));
+
+import { validatePortalToken, fetchMemberContacts, fetchListMembers, getPortalToken } from "@/lib/api/portal-api";
+
+function mockFetch(text: string, ok = true, status = 200) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok, status, text: () => Promise.resolve(text) }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("validatePortalToken", () => {
+  it("returns the session for a valid token", async () => {
+    mockFetch(`{"ownerid" : "100184","secondsleft" : "3599","isadmin" : "1"}`);
+    expect(await validatePortalToken("tok")).toEqual({ ownerid: 100184, isAdmin: true });
+  });
+
+  it("returns isAdmin false for a non-admin", async () => {
+    mockFetch(`{"ownerid" : "100003","secondsleft" : "3599","isadmin" : "0"}`);
+    expect(await validatePortalToken("tok")).toEqual({ ownerid: 100003, isAdmin: false });
+  });
+
+  it("rejects BAD_CHECKSUM even with leading PHP notices", async () => {
+    mockFetch(
+      `<br />\n<b>Notice</b>:  Undefined offset: 2 in <b>/home/httpd/html/accounts/actions/index.htm</b> on line <b>358</b><br />\n{"ownerid" : "BAD_CHECKSUM","secondsleft" : "0","isadmin" : "0"}`,
+    );
+    expect(await validatePortalToken("tok")).toBeNull();
+  });
+
+  it("rejects an expired token (secondsleft 0)", async () => {
+    mockFetch(`{"ownerid" : "100184","secondsleft" : "0","isadmin" : "1"}`);
+    expect(await validatePortalToken("tok")).toBeNull();
+  });
+
+  it("returns null when the portal call throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    expect(await validatePortalToken("tok")).toBeNull();
+  });
+});
+
+describe("fetchMemberContacts", () => {
+  it("parses the trailing-comma array and maps API fields to tblowner fields", async () => {
+    mockFetch(
+      `[{"ownerid" : "100001","ownername" : "Sue","email" : "sue@x.com","phone" : "805-1","altphone" : ""}, {"ownerid" : "100003","ownername" : "Lyd","email" : "l@x.com","phone" : "805-2","altphone" : "805-3"}, ]`,
+    );
+    expect(await fetchMemberContacts([100001, 100003])).toEqual([
+      { ownerid: 100001, ownername: "Sue", owneremail: "sue@x.com", ownerphone: "805-1", owneraltphone: undefined },
+      { ownerid: 100003, ownername: "Lyd", owneremail: "l@x.com", ownerphone: "805-2", owneraltphone: "805-3" },
+    ]);
+  });
+
+  it("returns empty without calling fetch when given no ids", async () => {
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+    expect(await fetchMemberContacts([])).toEqual([]);
+    expect(f).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchListMembers", () => {
+  it("parses the <br>-separated roster into typed summaries", async () => {
+    mockFetch(
+      `[{"ownerid" : "100001","ownername" : "Sue Aiken"}<br>\n{"ownerid" : "100002","ownername" : "Bob"}<br>\n]`,
+    );
+    expect(await fetchListMembers("tok")).toEqual([
+      { ownerid: 100001, ownername: "Sue Aiken" },
+      { ownerid: 100002, ownername: "Bob" },
+    ]);
+  });
+});
+
+describe("getPortalToken", () => {
+  it("reads the portal token cookie", async () => {
+    mockCookieStore.get.mockReturnValue({ value: "the-token" });
+    expect(await getPortalToken()).toBe("the-token");
+  });
+
+  it("returns null when the cookie is missing", async () => {
+    mockCookieStore.get.mockReturnValue(undefined);
+    expect(await getPortalToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

This wires the app to the co-op's real member portal, replacing the mock member API and fixing login, which did not work against his portal at all. His login token is base64 of comma-delimited fields with an Eastern-time timestamp, while our callback expected our own pipe-delimited format, so a real click-through never logged anyone in. Rather than re-implement his signing locally (which would depend on the shared secret, his exact algorithm, and his server timezone), the callback now validates the token through his `validatetoken` endpoint and mints our own session cookie from the result. Member data flows through his endpoints too: contacts and self-lookup use `getmembercontacts` with the service secret (so they work in the cron and the public unsubscribe route), and the roster uses `listmembers` with the portal token stored at login. I verified all of it against his live portal.

- `src/lib/api/portal-api.ts` - new client for `validatetoken`, `listmembers`, `getmembercontacts`, with cleaning for his `<br>`, PHP-notice, and trailing-comma response quirks
- `src/app/api/auth/callback/route.ts` - validates via `validatePortalToken`, mints our cookie, stores the portal token cookie
- `src/lib/api/member-api.ts` - the four `getReal*` functions implemented against the portal client
- `src/schema/member-portal.ts` - Zod schemas for the three responses
- `src/env.ts` - `PRFC_PORTAL_API_URL` and `MEMBER_API_SECRET`, required when `USE_MOCK_MEMBER_API=false`
- `src/app/api/auth/logout/route.ts` - clears the portal token cookie
- `test/lib/api/portal-api.test.ts` - cleaning and mapping covered with his exact response shapes; `test/auth/auth-flow.test.ts` updated for the new callback

## How to test

1. `npm test` passes (707)
2. `npm run build` passes

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers
