### PR TITLE
refactor: move member type to types and rename MockMember to Member

### DIFF
--- a/src/lib/api/member-api.ts
+++ b/src/lib/api/member-api.ts
@@ -2,16 +2,15 @@ import "server-only";
 import { env } from "@/env";
 import { AppError } from "@/utils/errors";
 import { fetchListMembers, fetchMemberContacts, getPortalToken } from "@/lib/api/portal-api";
-import type { MockMember } from "@/lib/mock-members";
-import type { MemberSummary } from "@/types/member";
+import type { Member, MemberSummary } from "@/types/member";
 export type { MemberSummary } from "@/types/member";
 
-async function getMockMemberDetails(memberIds: number[]): Promise<MockMember[]> {
+async function getMockMemberDetails(memberIds: number[]): Promise<Member[]> {
   const { findMemberById } = await import("@/lib/mock-members");
-  return memberIds.map((id) => findMemberById(id)).filter((m): m is MockMember => m !== undefined);
+  return memberIds.map((id) => findMemberById(id)).filter((m): m is Member => m !== undefined);
 }
 
-async function getRealMemberDetails(memberIds: number[]): Promise<MockMember[]> {
+async function getRealMemberDetails(memberIds: number[]): Promise<Member[]> {
   return fetchMemberContacts(memberIds);
 }
 
@@ -38,17 +37,17 @@ async function getRealAllMembers(): Promise<MemberSummary[]> {
   return fetchListMembers(token);
 }
 
-async function getMockMemberById(id: number): Promise<MockMember | null> {
+async function getMockMemberById(id: number): Promise<Member | null> {
   const { findMemberById } = await import("@/lib/mock-members");
   return findMemberById(id) ?? null;
 }
 
-async function getRealMemberById(id: number): Promise<MockMember | null> {
+async function getRealMemberById(id: number): Promise<Member | null> {
   const members = await fetchMemberContacts([id]);
   return members[0] ?? null;
 }
 
-export async function getMemberDetails(memberIds: number[]): Promise<MockMember[]> {
+export async function getMemberDetails(memberIds: number[]): Promise<Member[]> {
   if (env.USE_MOCK_MEMBER_API) {
     return getMockMemberDetails(memberIds);
   }
@@ -69,7 +68,7 @@ export async function getAllMembers(): Promise<MemberSummary[]> {
   return getRealAllMembers();
 }
 
-export async function getMemberById(id: number): Promise<MockMember | null> {
+export async function getMemberById(id: number): Promise<Member | null> {
   if (env.USE_MOCK_MEMBER_API) {
     return getMockMemberById(id);
   }

--- a/src/lib/api/portal-api.ts
+++ b/src/lib/api/portal-api.ts
@@ -8,8 +8,7 @@ import {
   ValidateTokenResponseSchema,
 } from "@/schema/member-portal";
 import type { Session } from "@/lib/dal";
-import type { MemberSummary } from "@/types/member";
-import type { MockMember } from "@/lib/mock-members";
+import type { Member, MemberSummary } from "@/types/member";
 
 export const PORTAL_TOKEN_COOKIE = "prfc_portal_token";
 
@@ -85,7 +84,7 @@ export async function fetchListMembers(token: string): Promise<MemberSummary[]> 
   return data.map((m) => ({ ownerid: Number(m.ownerid), ownername: m.ownername }));
 }
 
-export async function fetchMemberContacts(ownerids: number[]): Promise<MockMember[]> {
+export async function fetchMemberContacts(ownerids: number[]): Promise<Member[]> {
   if (ownerids.length === 0) return [];
 
   const raw = await postForm("getmembercontacts", {

--- a/src/lib/mock-members.ts
+++ b/src/lib/mock-members.ts
@@ -1,13 +1,6 @@
 import "server-only";
 import { faker } from "@faker-js/faker";
-
-export interface MockMember {
-  ownerid: number;
-  ownername: string;
-  owneremail: string;
-  ownerphone: string;
-  owneraltphone?: string;
-}
+import type { Member } from "@/types/member";
 
 const SEED = 12345;
 const START_ID = 100001;
@@ -17,7 +10,7 @@ const EMAIL_PROVIDERS = ["gmail.com", "yahoo.com", "outlook.com", "icloud.com", 
 faker.seed(SEED);
 faker.setDefaultRefDate("2025-12-01T00:00:00.000Z");
 
-function generateMember(ownerid: number): MockMember {
+function generateMember(ownerid: number): Member {
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
   const fullName = `${firstName} ${lastName}`;
@@ -43,7 +36,7 @@ function generateMember(ownerid: number): MockMember {
   };
 }
 
-export const mockMembers: readonly MockMember[] = Array.from({ length: MEMBER_COUNT }, (_, i) =>
+export const mockMembers: readonly Member[] = Array.from({ length: MEMBER_COUNT }, (_, i) =>
   generateMember(START_ID + i),
 );
 
@@ -53,7 +46,7 @@ export const mockAdmin1 = mockMembers[0];
 
 export const mockAdmin2 = mockMembers[1];
 
-export function findMemberById(ownerid: number): MockMember | undefined {
+export function findMemberById(ownerid: number): Member | undefined {
   return mockMembers.find((m) => m.ownerid === ownerid);
 }
 

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -9,7 +9,7 @@ import { sendGroupSms, validateSmsAllowed } from "@/services/sms";
 import { getConsentedPhones } from "@/services/sms-consent";
 import { getMemberDetails, getAllActiveMemberIds } from "@/lib/api/member-api";
 import type { ComposeMessage, BlastMessage } from "@/schema/contact-group";
-import type { MockMember } from "@/lib/mock-members";
+import type { Member } from "@/types/member";
 import type {
   MessageResult,
   MessageSummary,
@@ -68,7 +68,7 @@ export { isQuietHours, validateSmsAllowed } from "@/services/sms";
 
 async function sendEmailsForMessage(
   messageId: number,
-  recipients: MockMember[],
+  recipients: Member[],
   subject: string,
   body: string,
 ): Promise<{ sent: number; failed: number }> {

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -1,3 +1,11 @@
+export interface Member {
+  ownerid: number;
+  ownername: string;
+  owneremail: string;
+  ownerphone: string;
+  owneraltphone?: string;
+}
+
 export interface MemberSummary {
   ownerid: number;
   ownername: string;

--- a/test/mocks/members.ts
+++ b/test/mocks/members.ts
@@ -1,6 +1,6 @@
-import type { MockMember } from "@/lib/mock-members";
+import type { Member } from "@/types/member";
 
-export const memberKermit: MockMember = {
+export const memberKermit: Member = {
   ownerid: 100001,
   ownername: "Kermit Komm",
   owneremail: "kermit@coop.org",
@@ -8,7 +8,7 @@ export const memberKermit: MockMember = {
   owneraltphone: "805-555-5678",
 };
 
-export const memberAngelica: MockMember = {
+export const memberAngelica: Member = {
   ownerid: 100003,
   ownername: "Angelica Allison",
   owneremail: "angelica@email.com",


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

The member shape was declared as `MockMember` in `src/lib/mock-members.ts`, a `server-only` file slated for deletion, even though it is a cross-layer type used by the member API, the portal client, and message sending. Now that the real portal API returns it, the name was actively misleading - `getRealMemberDetails(): Promise<MockMember[]>`. I moved the interface to `src/types/member.ts` (where `MemberSummary` already lives) and renamed it `Member`. `mock-members.ts` keeps the mock data and imports the type from `types/`. This is the relocation `production-cleanup.md` step 5 prescribes.

- `src/types/member.ts` - added the `Member` interface
- `src/lib/mock-members.ts` - dropped the local interface, imports `Member`
- `src/lib/api/member-api.ts`, `src/lib/api/portal-api.ts`, `src/services/message.ts` - import `Member` from `@/types/member`
- `test/mocks/members.ts` - same

## How to test

1. `npm test` passes (707)
2. `npm run build` passes

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers
