### PR TITLE
fix: log swallowed portal validation and profile photo errors

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -24,7 +24,10 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   const [unseenCount, lastSeenAt, photoUrl] = await Promise.all([
     getUnseenNotificationCount(session.ownerid),
     getLastNotificationSeenAt(session.ownerid),
-    getProfilePhotoUrl(session.ownerid).catch(() => null),
+    getProfilePhotoUrl(session.ownerid).catch((error) => {
+      console.warn("[PROFILE_PHOTO] failed to load", error instanceof Error ? error.message : error);
+      return null;
+    }),
   ]);
 
   return (

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -12,7 +12,10 @@ export default async function ProfilePage() {
   const session = await getSessionWithName();
   const [profile, photoUrl] = await Promise.all([
     getMemberProfile(session.ownerid, session.isAdmin),
-    getProfilePhotoUrl(session.ownerid).catch(() => null),
+    getProfilePhotoUrl(session.ownerid).catch((error) => {
+      console.warn("[PROFILE_PHOTO] failed to load", error instanceof Error ? error.message : error);
+      return null;
+    }),
   ]);
 
   return (

--- a/src/lib/api/portal-api.ts
+++ b/src/lib/api/portal-api.ts
@@ -60,14 +60,19 @@ export async function validatePortalToken(token: string): Promise<Session | null
   let raw: string;
   try {
     raw = await postForm("validatetoken", { token });
-  } catch {
+  } catch (error) {
+    console.warn("[PORTAL] validatetoken request failed", error instanceof Error ? error.message : error);
     return null;
   }
 
   let parsed;
   try {
     parsed = ValidateTokenResponseSchema.safeParse(extractObject(raw));
-  } catch {
+  } catch (error) {
+    console.warn(
+      "[PORTAL] validatetoken returned an unparseable response",
+      error instanceof Error ? error.message : error,
+    );
     return null;
   }
   if (!parsed.success) return null;


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Four error paths returned silently, which the audit flagged. `validatePortalToken` swallowed a failed `validatetoken` request and an unparseable response, and the two profile-photo loads degraded to no-photo without a trace. The behavior is still correct (reject the login, drop the avatar), but a flaky or unreachable portal and a blob/DB problem now leave a `console.warn` to diagnose from. Each logs only the error message, never the token.

- `src/lib/api/portal-api.ts` - `validatePortalToken` warns on a failed request and on an unparseable response
- `src/app/(protected)/layout.tsx`, `src/app/(protected)/profile/page.tsx` - the avatar `.catch` warns before returning null

## How to test

1. `npm test` passes (707)
2. `npm run build` passes

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [ ] Assigned reviewers
