### PR TITLE
feat: add accessible pending state to referral submit button

### DIFF
--- a/src/components/referral/referral-form.tsx
+++ b/src/components/referral/referral-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useTransition } from "react";
 import { useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { Plus } from "lucide-react";
@@ -36,8 +36,11 @@ export function ReferralForm() {
   // Idempotency key persists across retries, regenerated only on success
   const idempotencyKeyRef = useRef<string>(crypto.randomUUID());
 
-  const handleSubmit = async (event: React.SyntheticEvent) => {
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: React.SyntheticEvent) => {
     event.preventDefault();
+    if (isPending) return;
     setErrorMessage("");
 
     for (let i = 0; i < prospects.length; i++) {
@@ -50,39 +53,41 @@ export function ReferralForm() {
 
     const memberFullName = `${referrerFirstName} ${referrerLastName}`;
 
-    try {
-      const referralData = {
-        memberName: memberFullName.trim(),
-        memberEmail: referrerEmail,
-        referralCode,
-        signature,
-        prospects: prospects.map((prospect) => ({
-          prospectName: prospect.fullName.trim(),
-          prospectEmail: prospect.email,
-        })),
-      };
+    startTransition(async () => {
+      try {
+        const referralData = {
+          memberName: memberFullName.trim(),
+          memberEmail: referrerEmail,
+          referralCode,
+          signature,
+          prospects: prospects.map((prospect) => ({
+            prospectName: prospect.fullName.trim(),
+            prospectEmail: prospect.email,
+          })),
+        };
 
-      const response = await fetch("/api/referrals", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Idempotency-Key": idempotencyKeyRef.current,
-        },
-        body: JSON.stringify(referralData),
-      });
+        const response = await fetch("/api/referrals", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotencyKeyRef.current,
+          },
+          body: JSON.stringify(referralData),
+        });
 
-      if (response.ok) {
-        setProspects([{ email: "", fullName: "" }]);
-        setYourEmail("");
-        setShowConfirmation(true);
-        idempotencyKeyRef.current = crypto.randomUUID();
-      } else {
-        const errorBody = await response.json();
-        setErrorMessage(errorBody.error?.message || "Failed to submit the form. Please try again!");
+        if (response.ok) {
+          setProspects([{ email: "", fullName: "" }]);
+          setYourEmail("");
+          setShowConfirmation(true);
+          idempotencyKeyRef.current = crypto.randomUUID();
+        } else {
+          const errorBody = await response.json();
+          setErrorMessage(errorBody.error?.message || "Failed to submit the form. Please try again!");
+        }
+      } catch {
+        setErrorMessage("An error occurred while submitting the form.");
       }
-    } catch {
-      setErrorMessage("An error occurred while submitting the form.");
-    }
+    });
   };
 
   const handleProspectChange = (index: number, field: "email" | "fullName", value: string) => {
@@ -185,9 +190,17 @@ export function ReferralForm() {
           ))}
         </div>
 
-        <Button type="submit" className="self-end px-6 py-2 bg-prfc-red text-white rounded-lg hover:bg-prfc-red/90">
-          Invite
+        <Button
+          type="submit"
+          aria-disabled={isPending}
+          className="self-end px-6 py-2 bg-prfc-red text-white rounded-lg hover:bg-prfc-red/90 aria-disabled:opacity-60 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-prfc-red"
+        >
+          {isPending ? "Sending..." : "Invite"}
         </Button>
+
+        <p aria-live="polite" className="sr-only">
+          {isPending ? "Sending your referral, please wait." : ""}
+        </p>
 
         {errorMessage && <p className="text-red-500 font-bold self-end -mt-6">{errorMessage}</p>}
 


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

The referral submit button now shows a pending state while the request is in flight: it greys out (`aria-disabled`), the label swaps to "Sending...", and an `aria-live` region announces it to screen readers. Built on React 19 `useTransition`. Duplicate submits were already blocked by the idempotency key; this adds the missing visual and screen-reader feedback for the slow send.

- `src/components/referral/referral-form.tsx`

## How to test

1. Open a signed referral link, fill it in, and submit - the button greys and reads "Sending..." until it resolves.
2. `npm run build`, `npm test` (707), tsc, and eslint all pass.

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers
