### PR TITLE
refactor: rename prfc-connect to prfc-outreach across the app

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions
-    url: https://github.com/hack4impact-calpoly/prfc-connect/discussions
+    url: https://github.com/hack4impact-calpoly/prfc-outreach/discussions
     about: Have a question? Start a discussion.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# PRFC Connect
+# PRFC Outreach
 
 <div align="center">
 
 <br />
 
-<img src="public/assets/logo-white.png" alt="PRFC Connect" />
+<img src="public/assets/logo-white.png" alt="PRFC Outreach" />
 
 <br />
 <br />
 
-[![CI](https://github.com/hack4impact-calpoly/prfc-connect/actions/workflows/ci.yml/badge.svg)](https://github.com/hack4impact-calpoly/prfc-connect/actions/workflows/ci.yml) [![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs&logoColor=white)](https://nextjs.org/) [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/) [![Prisma](https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white)](https://www.prisma.io/) [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![CI](https://github.com/hack4impact-calpoly/prfc-outreach/actions/workflows/ci.yml/badge.svg)](https://github.com/hack4impact-calpoly/prfc-outreach/actions/workflows/ci.yml) [![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs&logoColor=white)](https://nextjs.org/) [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/) [![Prisma](https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white)](https://www.prisma.io/) [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
 
 </div>
 
@@ -28,11 +28,11 @@ A member referral and outreach platform for Paso Robles Food Co-op.
 
 Paso Robles Food Co-op is a community-owned grocery cooperative in Paso Robles, California, with around 400 members. It focuses on local and sustainable food, and supports regional farmers and producers.
 
-PRFC Connect started as the co-op's referral tool. A member opens a personalized link, adds a friend's name and email, and the app saves the referral. Staff see every submission in an admin database. It does more than referrals now. The app sorts members into contact groups, emails those groups, schedules events and records RSVPs, and marks new activity for each member. SMS is built and TCPA-compliant, but it stays off until the co-op finishes carrier registration.
+PRFC Outreach started as the co-op's referral tool. A member opens a personalized link, adds a friend's name and email, and the app saves the referral. Staff see every submission in an admin database. It does more than referrals now. The app sorts members into contact groups, emails those groups, schedules events and records RSVPs, and marks new activity for each member. SMS is built and TCPA-compliant, but it stays off until the co-op finishes carrier registration.
 
 ### Team
 
-The PRFC Connect team is 12 Cal Poly students. We built and deployed this app together over about nine months.
+The PRFC Outreach team is 12 Cal Poly students. We built and deployed this app together over about nine months.
 
 - [Austin Lee](https://www.linkedin.com/in/austinlee17/) - Project Manager
 - [Kevin Rutledge](https://www.linkedin.com/in/rutledge-kevin/) - Tech Lead

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-PRFC Connect is a Next.js application for the Paso Robles Food Co-op. It handles member referrals, contact groups, group and blast messaging, calendar events, and member notifications.
+PRFC Outreach is a Next.js application for the Paso Robles Food Co-op. It handles member referrals, contact groups, group and blast messaging, calendar events, and member notifications.
 
 ## System Diagram
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This guide covers everything you need to contribute to PRFC Connect.
+This guide covers everything you need to contribute to PRFC Outreach.
 
 ## Prerequisites
 

--- a/docs/decisions/auth-patterns.md
+++ b/docs/decisions/auth-patterns.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-PRFC Connect needs to authenticate two types of users:
+PRFC Outreach needs to authenticate two types of users:
 
 1. **Admins** accessing the referral database
 2. **Members** accessing Contact Groups

--- a/docs/figures/architecture.mmd
+++ b/docs/figures/architecture.mmd
@@ -3,7 +3,7 @@ flowchart TB
 
     Portal["<b>PRFC Member Portal</b><br/>[External Site]<br/><br/>Member authentication"]
 
-    App["<b>PRFC Connect</b><br/>[Next.js App]<br/><br/>Referrals, contact groups,<br/>messaging, events, notifications"]
+    App["<b>PRFC Outreach</b><br/>[Next.js App]<br/><br/>Referrals, contact groups,<br/>messaging, events, notifications"]
 
     MySQL[("<b>MySQL</b><br/>[Database]<br/><br/>App tables: referrals, groups,<br/>messages, events")]
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide walks you through setting up PRFC Connect for local development.
+This guide walks you through setting up PRFC Outreach for local development.
 
 ## Prerequisites
 
@@ -37,8 +37,8 @@ eval "$(fnm env --use-on-cd)"
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/hack4impact-calpoly/prfc-connect.git
-cd prfc-connect
+git clone https://github.com/hack4impact-calpoly/prfc-outreach.git
+cd prfc-outreach
 ```
 
 ### 2. Install Node.js
@@ -138,7 +138,7 @@ Enable format on save:
 ## Project Structure
 
 ```
-prfc-connect/
+prfc-outreach/
 ├── .github/           # GitHub Actions and templates
 ├── docs/              # Documentation
 ├── prisma/            # Database schema and migrations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "prfc-connect",
+  "name": "prfc-outreach",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prfc-connect",
+      "name": "prfc-outreach",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prfc-connect",
+  "name": "prfc-outreach",
   "version": "0.1.0",
   "private": true,
   "engines": {

--- a/src/app/(protected)/events/page.tsx
+++ b/src/app/(protected)/events/page.tsx
@@ -7,7 +7,7 @@ import { coopStartOfWeek } from "@/utils/time";
 import { EventsContent } from "./events-content";
 
 export const metadata: Metadata = {
-  title: "Events | PRFC Connect",
+  title: "Events | PRFC Outreach",
 };
 
 export default async function EventsPage() {

--- a/src/app/(protected)/messages/compose/page.tsx
+++ b/src/app/(protected)/messages/compose/page.tsx
@@ -6,7 +6,7 @@ import { env } from "@/env";
 import { ComposeContent } from "./compose-content";
 
 export const metadata: Metadata = {
-  title: "Compose Message | PRFC Connect",
+  title: "Compose Message | PRFC Outreach",
 };
 
 export default async function ComposeMessagePage() {

--- a/src/app/(protected)/messages/page.tsx
+++ b/src/app/(protected)/messages/page.tsx
@@ -5,7 +5,7 @@ import { env } from "@/env";
 import { MessagesContent } from "./messages-content";
 
 export const metadata: Metadata = {
-  title: "Messages | PRFC Connect",
+  title: "Messages | PRFC Outreach",
 };
 
 export default async function MessagesPage() {

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -5,7 +5,7 @@ import { getProfilePhotoUrl } from "@/services/user-preference";
 import { ProfileContent } from "./profile-content";
 
 export const metadata: Metadata = {
-  title: "Profile | PRFC Connect",
+  title: "Profile | PRFC Outreach",
 };
 
 export default async function ProfilePage() {

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -7,7 +7,7 @@ import { env } from "@/env";
 import { SettingsContent } from "./settings-content";
 
 export const metadata: Metadata = {
-  title: "Settings | PRFC Connect",
+  title: "Settings | PRFC Outreach",
 };
 
 export default async function SettingsPage() {

--- a/src/app/(public)/forbidden/page.tsx
+++ b/src/app/(public)/forbidden/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "No Permission | PRFC Connect",
+  title: "No Permission | PRFC Outreach",
 };
 
 export default function ForbiddenPage() {

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy | PRFC Connect",
+  title: "Privacy Policy | PRFC Outreach",
 };
 
 export default function PrivacyPolicyPage() {
@@ -12,14 +12,14 @@ export default function PrivacyPolicyPage() {
 
       <div className="mt-8 space-y-6 text-base leading-relaxed text-foreground">
         <p>
-          Paso Robles Food Cooperative, Inc. ("the Co-op") operates PRFC Connect, an internal communication tool for
+          Paso Robles Food Cooperative, Inc. ("the Co-op") operates PRFC Outreach, an internal communication tool for
           co-op members and staff. This policy describes what data the tool collects, how it is used, and how it is
           protected.
         </p>
 
         <h2 className="font-semibold text-lg text-prfc-brown">Data collected</h2>
         <p>
-          PRFC Connect stores member names, email addresses, and phone numbers provided through the co-op's member
+          PRFC Outreach stores member names, email addresses, and phone numbers provided through the co-op's member
           portal. When a member opts in to SMS notifications, the phone number and the date of consent are recorded. The
           tool also stores message history, event data, and group membership.
         </p>

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms and Conditions | PRFC Connect",
+  title: "Terms and Conditions | PRFC Outreach",
 };
 
 export default function TermsPage() {
@@ -13,7 +13,7 @@ export default function TermsPage() {
       <div className="mt-8 space-y-6 text-base leading-relaxed text-foreground">
         <h2 className="font-semibold text-lg text-prfc-brown">Program</h2>
         <p>
-          Paso Robles Food Cooperative, Inc. ("the Co-op") sends SMS notifications to members through PRFC Connect, an
+          Paso Robles Food Cooperative, Inc. ("the Co-op") sends SMS notifications to members through PRFC Outreach, an
           internal communication tool. Messages include event reminders, group messages, and operational notifications.
         </p>
 
@@ -28,9 +28,9 @@ export default function TermsPage() {
 
         <h2 className="font-semibold text-lg text-prfc-brown">Opt-in</h2>
         <p>
-          Members opt in to SMS notifications by toggling the SMS preference in their PRFC Connect account settings. The
-          opt-in screen displays the following disclosure before consent is recorded: "Up to 8 msgs/month. Msg & data
-          rates may apply. Reply STOP to cancel."
+          Members opt in to SMS notifications by toggling the SMS preference in their PRFC Outreach account settings.
+          The opt-in screen displays the following disclosure before consent is recorded: "Up to 8 msgs/month. Msg &
+          data rates may apply. Reply STOP to cancel."
         </p>
 
         <h2 className="font-semibold text-lg text-prfc-brown">Opt-out</h2>

--- a/src/app/(public)/unauthorized/page.tsx
+++ b/src/app/(public)/unauthorized/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { getPortalLoginUrl } from "@/lib/portal";
 
 export const metadata: Metadata = {
-  title: "Sign In Required | PRFC Connect",
+  title: "Sign In Required | PRFC Outreach",
 };
 
 export default function UnauthorizedPage() {
@@ -12,7 +12,7 @@ export default function UnauthorizedPage() {
     <div className="fixed inset-0 flex flex-col items-center justify-center px-4 text-center">
       <h1 className="font-angkor text-3xl text-prfc-brown sm:text-4xl">Sign in required</h1>
       <p className="mt-4 max-w-md text-lg text-muted-foreground">
-        Paso Robles Food Co-op Connect requires authentication. Sign in through the member portal to continue.
+        Paso Robles Food Co-op Outreach requires authentication. Sign in through the member portal to continue.
       </p>
       <Link
         href={portalUrl}

--- a/src/app/(public)/unsubscribe/page.tsx
+++ b/src/app/(public)/unsubscribe/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { UnsubscribeForm } from "./unsubscribe-form";
 
 export const metadata: Metadata = {
-  title: "Unsubscribe | PRFC Connect",
+  title: "Unsubscribe | PRFC Outreach",
 };
 
 export default async function UnsubscribePage({ searchParams }: { searchParams: Promise<{ token?: string }> }) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "PRFC Connect",
-  description: "Paso Robles Food Co-op Connect",
+  title: "PRFC Outreach",
+  description: "Paso Robles Food Co-op Outreach",
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -7,7 +7,7 @@ import { getMemberById } from "@/lib/api/member-api";
 
 export const AUTH_COOKIE = "prfc_auth";
 const TOKEN_EXPIRY_MS = 3600000;
-const DEV_SECRET = "dev-only-prfc-connect-hmac-secret-32ch";
+const DEV_SECRET = "dev-only-prfc-outreach-hmac-secret-32ch";
 
 export function getSecret(): string {
   const secret = process.env.PRFC_PORTAL_SECRET;

--- a/test/mocks/sms-consent.ts
+++ b/test/mocks/sms-consent.ts
@@ -5,7 +5,7 @@ export const activeConsentKermit: SmsConsentRecord = {
   memberId: 100001,
   consentedAt: new Date("2026-01-15T10:00:00Z"),
   consentMethod: "web_form",
-  consentText: "I agree to receive SMS messages from PRFC Connect",
+  consentText: "I agree to receive SMS messages from PRFC Outreach",
   consentPurpose: "group_notifications",
   revokedAt: null,
   revokeMethod: null,


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

Renamed the app from PRFC Connect to PRFC Outreach across the codebase. Every display string (`PRFC Connect` -> `PRFC Outreach`, `Paso Robles Food Co-op Connect` -> `Paso Robles Food Co-op Outreach`) and every `prfc-connect` slug (repo URLs, package name, the dev-only fallback secret) now reads `outreach`. 22 files, all string-level, no behavior change.

- page titles and metadata in `src/app/**`, the privacy/terms prose, `layout.tsx`
- `README.md`, `docs/**` including the `architecture.mmd` source
- `package.json` / `package-lock.json` name, `src/lib/dal.ts` DEV_SECRET, the `test/mocks/sms-consent.ts` fixture
- the GitHub URLs in `README.md`, `docs/getting-started.md`, and `.github/ISSUE_TEMPLATE/config.yml`

## How to test

1. `npm run build`, `npm test` (707), tsc, and eslint all pass
2. `git grep -i "prfc connect\|prfc-connect"` returns nothing in tracked files

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers
