### PR TITLE
docs: add future-work doc for the next team

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Contributing](contributing.md) - Development workflow and PR process
 - [Architecture](architecture.md) - System overview and patterns
 - [Style Guide](style-guide.md) - Naming conventions and code patterns
+- [Future Work](future-work.md) - Deferred items and known issues for the next team
 
 ## Decisions
 

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -1,12 +1,12 @@
 # Future work
 
-This file lists the work we deferred at launch, with what triggers each item and where to start. Nothing here blocks production. We left each one for a reason, and that reason is written next to it.
+This file lists the work we deferred at launch. Each entry names what triggers it and where to start. Nothing here blocks production. We left each one for a reason, and that reason is written next to it.
 
 ## End-to-end test coverage
 
-The e2e suite once drove the mock member portal, so when #222 removed the mock portal it took the feature-flow specs with it. The auth suite is back, because it now mints the session cookie programmatically instead of clicking through a fake login. The rest still needs rebuilding against the real flow.
+The e2e suite once drove the mock member portal, so when #222 removed that portal it took the feature-flow specs with it. The auth suite is back, because it now mints the session cookie programmatically instead of clicking through a fake login. The rest still needs rebuilding against the real flow.
 
-Worth restoring, roughly in priority order: messaging, referral submission, email preferences, events, notifications, the SMS gate, and role-based sidebar visibility with collapse persistence. Each should land with a green browser run behind it, not just a compiled spec. Start from `e2e/` and the auth setup in `playwright/.auth/`, which already shows the cookie-mint pattern to copy.
+Worth restoring, roughly in priority order: messaging, referral submission, email preferences, events, notifications, the SMS gate, and role-based sidebar visibility with collapse persistence. Each needs a green browser run behind it. A spec that only compiles does not exercise the flow. Start from `e2e/` and the auth setup in `playwright/.auth/`, which already shows the cookie-mint pattern to copy.
 
 ## Responsive and mobile
 
@@ -28,7 +28,7 @@ The fix arrives with TanStack Table v9, which reworks the table around that patt
 
 ## Tailwind v4
 
-We run Tailwind v3. Its internals call Node's `url.parse`, which Node now marks deprecated (DEP0169), so the build prints a pending-deprecation warning. Tailwind v4 drops that call. The migration is real work, though, because v4 changes the config format and the directive syntax, so we left it for a focused pass rather than a launch-week scramble. Note that `@tailwindcss/vite` already sits in `package.json` unused, and the v4 migration is when it either gets wired up or removed.
+We run Tailwind v3. Its internals call Node's `url.parse`, which Node now marks deprecated (DEP0169), so the build prints a pending-deprecation warning. Tailwind v4 drops that call. The migration is real work, though, because v4 changes the config format and the directive syntax, so we left it for a focused pass rather than rushing it before launch. Note that `@tailwindcss/vite` already sits in `package.json` unused, and the v4 migration either wires it up or removes it.
 
 ## Dependency deprecation warnings
 
@@ -42,10 +42,10 @@ We see them, and they are safe to ignore until the owning package moves.
 
 ## Dependabot alerts
 
-The repo shows a large pile of Dependabot alerts, and almost all of them are stale. They target Next.js below 15 and a `mongoose` dependency, but we run Next 16 and carry no mongoose, so they do not apply. The one real finding was vitest below 4.1.0 (GHSA-5xrq-8626-4rwp, dev-only), which we already bumped past. So do not let the count alarm you. Read each alert against the version we actually ship before acting.
+The repo shows a long list of Dependabot alerts, and almost all of them are stale. They target Next.js below 15 and a `mongoose` dependency, but we run Next 16 and carry no mongoose, so they do not apply. The one real finding was vitest below 4.1.0 (GHSA-5xrq-8626-4rwp, dev-only), which we already bumped past. So the count overstates the real exposure. Read each alert against the version we actually ship before acting.
 
 ## Production database constraints
 
-The co-op runs the app against MariaDB 5.5.62, which sits below the version Prisma documents support for. We tested it and it works, but three constraints follow from that version and the next team should keep them in mind.
+The co-op runs the app against MariaDB 5.5.62, which sits below the version Prisma documents as supported. We tested it and it works. But three constraints follow from that version, and the next team should keep them in mind.
 
-First, the schema is hand-created from our DDL with every `DATETIME(3)` changed to plain `TIMESTAMP`, so the production build drops `prisma migrate deploy` and there is no migration ledger on that server. Second, `TIMESTAMP` truncates sub-second precision and rejects dates past 2038-01-19, which is the column's ceiling. Third, the server has SSL disabled, so `DATABASE_URL` must not include `?ssl=true`. Add it and every connection fails with `ER_SERVER_SSL_DISABLED` and every database page returns 500. The connection therefore runs unencrypted, which we accept because the PII columns are AES-encrypted at the app layer before they ever reach the wire.
+First, the schema is hand-created from our DDL with every `DATETIME(3)` changed to plain `TIMESTAMP`, so the production build drops `prisma migrate deploy` and there is no migration ledger on that server. Second, `TIMESTAMP` truncates sub-second precision and rejects dates past 2038-01-19, which is the column's ceiling. Third, the server has SSL disabled, so `DATABASE_URL` must not include `?ssl=true`. Add it and every connection fails with `ER_SERVER_SSL_DISABLED` and every database page returns 500.

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -1,0 +1,51 @@
+# Future work
+
+This file lists the work we deferred at launch, with what triggers each item and where to start. Nothing here blocks production. We left each one for a reason, and that reason is written next to it.
+
+## End-to-end test coverage
+
+The e2e suite once drove the mock member portal, so when #222 removed the mock portal it took the feature-flow specs with it. The auth suite is back, because it now mints the session cookie programmatically instead of clicking through a fake login. The rest still needs rebuilding against the real flow.
+
+Worth restoring, roughly in priority order: messaging, referral submission, email preferences, events, notifications, the SMS gate, and role-based sidebar visibility with collapse persistence. Each should land with a green browser run behind it, not just a compiled spec. Start from `e2e/` and the auth setup in `playwright/.auth/`, which already shows the cookie-mint pattern to copy.
+
+## Responsive and mobile
+
+Every protected page renders at desktop width today. None has had its own responsive pass, and none ships a dedicated mobile viewport. So a phone user sees a desktop layout scaled down.
+
+Take one page at a time. Audit it at a phone width, fix the layout, then add a mobile viewport to its e2e project so the breakpoint stays covered. The home, groups, messages, events, settings, and referral-database pages each need this.
+
+## SMS
+
+The SMS path is built and TCPA-compliant, but it is off at launch because `SMS_ENABLED` is unset. Turning it on is not a code change. It needs an A2P 10DLC campaign registered with the carriers, and that campaign ties to the co-op's legal entity, so it requires the legal name and EIN and takes a week or two to clear.
+
+Once the campaign is approved, set `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`, and `SMS_ENABLED=true`. The consent records, the STOP handling, and the rate limits are already in place.
+
+## TanStack Table and the React Compiler lint rule
+
+`eslint.config.mjs` turns off `react-hooks/incompatible-library`. The rule ships in the react-hooks recommended config and flags libraries that use interior mutability, and TanStack Table v8 is one of them. So we suppress it to keep `npm run lint` green over the data-table code.
+
+The fix arrives with TanStack Table v9, which reworks the table around that pattern. But v9 is still alpha (`9.0.0-alpha.54` at last check) and the tracking issue, TanStack/table#5567, is still open. We stay on v8 (`8.21.3`) until v9 ships stable. When it does, upgrade the dependency, delete the three comment lines and the `"react-hooks/incompatible-library": "off"` line together, then confirm lint stays green.
+
+## Tailwind v4
+
+We run Tailwind v3. Its internals call Node's `url.parse`, which Node now marks deprecated (DEP0169), so the build prints a pending-deprecation warning. Tailwind v4 drops that call. The migration is real work, though, because v4 changes the config format and the directive syntax, so we left it for a focused pass rather than a launch-week scramble. Note that `@tailwindcss/vite` already sits in `package.json` unused, and the v4 migration is when it either gets wired up or removed.
+
+## Dependency deprecation warnings
+
+Three Node deprecation warnings print during build and test. None is ours, and each clears when the upstream package upgrades:
+
+- DEP0169 (`url.parse`) from Tailwind v3, covered above.
+- DEP0144 (`module.parent`) from Next's `next.config.ts` loader.
+- The deprecated `scmp` package, pulled in transitively by twilio. It only loads when SMS runs, which is off at launch.
+
+We see them, and they are safe to ignore until the owning package moves.
+
+## Dependabot alerts
+
+The repo shows a large pile of Dependabot alerts, and almost all of them are stale. They target Next.js below 15 and a `mongoose` dependency, but we run Next 16 and carry no mongoose, so they do not apply. The one real finding was vitest below 4.1.0 (GHSA-5xrq-8626-4rwp, dev-only), which we already bumped past. So do not let the count alarm you. Read each alert against the version we actually ship before acting.
+
+## Production database constraints
+
+The co-op runs the app against MariaDB 5.5.62, which sits below the version Prisma documents support for. We tested it and it works, but three constraints follow from that version and the next team should keep them in mind.
+
+First, the schema is hand-created from our DDL with every `DATETIME(3)` changed to plain `TIMESTAMP`, so the production build drops `prisma migrate deploy` and there is no migration ledger on that server. Second, `TIMESTAMP` truncates sub-second precision and rejects dates past 2038-01-19, which is the column's ceiling. Third, the server has SSL disabled, so `DATABASE_URL` must not include `?ssl=true`. Add it and every connection fails with `ER_SERVER_SSL_DISABLED` and every database page returns 500. The connection therefore runs unencrypted, which we accept because the PII columns are AES-encrypted at the app layer before they ever reach the wire.


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

The deferred items from the launch were scattered across code comments, env-var notes, and nowhere at all, so a next-year student had no single place to find them. This adds `docs/future-work.md`, one doc that lists each deferred item with what triggers it and where to start, and links it from the docs index.

- `docs/future-work.md` - new doc covering e2e coverage, responsive/mobile, SMS enablement, the TanStack Table v9 lint suppression, Tailwind v4, the dependency deprecation warnings, the stale Dependabot alerts, and the MariaDB 5.5 production constraints
- `docs/README.md` - adds the Future Work link to the index

## How to test

1. Open `docs/README.md` and confirm the Future Work link resolves.
2. Read `docs/future-work.md` and confirm each item names its trigger and a starting file or version.

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers