### PR TITLE
fix: harden real-portal integration after the mock-portal swap

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,14 @@ Every later request validates this cookie in the DAL, so most requests need no p
 
 Next.js 16 uses `src/proxy.ts`, not `middleware.ts`. The proxy checks for the auth cookie on protected paths and redirects when it is missing, which is a fast UX guard. The real security boundary is `verifySession()` in `src/lib/dal.ts`, which verifies the HMAC and expiry, and `requireAdmin()` gates admin-only features. See the [Auth Patterns ADR](decisions/auth-patterns.md).
 
+### Member data and the portal
+
+Member identity comes from the co-op's member portal over HTTP, not from our database. Contact reads (`getmembercontacts`) authenticate with the `MEMBER_API_SECRET`; the roster read (`listmembers`) sends the member's portal token. Both go through `src/lib/api/portal-api.ts`.
+
+The portal is a single dependency, so the integration is defensive. Each call carries an 8-second `AbortSignal.timeout`, so a hung portal fails fast instead of holding a serverless function open. The portal answers `200` even on failure (an `INVALID_KEY` sentinel for a bad secret, a PHP notice for a missing token), so the client treats those shapes as errors and logs a truncated raw snippet rather than failing opaquely.
+
+We memoize reads per request with React `cache()`, so one request makes at most one portal call per distinct member read. We do not cache member data across requests. It is PII (name, email, phone), a Redis copy would be a new exposure surface for little gain at this roster size, and a stale entry could show wrong contact info.
+
 ## Data Model
 
 The Prisma schema defines the app's tables. Referral PII and SMS/email PII are encrypted at the service layer with AES-256-GCM, alongside HMAC blind-index columns for lookup without decryption.

--- a/docs/decisions/auth-patterns.md
+++ b/docs/decisions/auth-patterns.md
@@ -17,6 +17,8 @@ Use a single token-based session for both user types, validated in two steps. Th
 
 On a valid response the callback mints the app's own session cookie, `prfc_auth`, and stores the raw portal token in a second cookie (`prfc_portal_token`) for the member-roster read.
 
+The callback answers with a **303 (See Other)** redirect to `/home`, not the framework default of 307. The login POST arrives cross-site from the portal, and `prfc_auth` is `SameSite=Lax`. A 307 preserves the method, so the browser re-POSTs to `/home`, and a Lax cookie is not sent on a cross-site POST navigation, so the just-set session is dropped and the proxy bounces the user to `/unauthorized`. A 303 makes the browser GET `/home` instead, and Lax cookies ride along on top-level GET navigations, so the session holds. Keep the explicit 303.
+
 **Session cookie format:**
 
 ```
@@ -56,3 +58,4 @@ ownerid|isAdmin|timestamp|hmac_signature
 
 - Login depends on the portal's `validatetoken` endpoint being reachable and reporting the admin flag
 - `PRFC_PORTAL_SECRET` must be coordinated with PRFC infrastructure, since the same secret signs the session cookie and the public referral `cs` parameter
+- Sessions last one hour with no refresh. The portal issues one-hour tokens and has no refresh endpoint, and `listmembers` needs that same token, so a usable session cannot outlive the portal token without portal changes. Both cookies expire together, so `verifySession()` redirects to sign-in at the hour, and `handleActionError` treats a missing portal token (`"Member portal session required"`) the same way. Extending sessions would require a refresh endpoint on the portal side.

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -19,12 +19,21 @@ export async function updateUserPreferencesAction(input: {
   try {
     const session = await verifySession();
     const validated = UpdatePreferencesSchema.parse(input);
+
+    let consentPhone: string | undefined;
+    if (env.SMS_ENABLED && validated.notifySmsDefault === true) {
+      const profile = await getMemberProfile(session.ownerid, session.isAdmin);
+      if (!profile.phone || profile.phone.trim() === "") {
+        return { success: false, error: "Add a phone number to your member account before enabling text messages." };
+      }
+      consentPhone = profile.phone;
+    }
+
     const updated = await updateUserPreferences(session.ownerid, validated);
 
     if (env.SMS_ENABLED) {
-      if (validated.notifySmsDefault === true) {
-        const profile = await getMemberProfile(session.ownerid, session.isAdmin);
-        await grantSmsConsent(session.ownerid, profile.phone);
+      if (validated.notifySmsDefault === true && consentPhone) {
+        await grantSmsConsent(session.ownerid, consentPhone);
       } else if (validated.notifySmsDefault === false) {
         await revokeSmsConsent(session.ownerid, "web_settings_toggle", null);
       }

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
   try {
     getSecret();
   } catch {
-    return NextResponse.redirect(new URL("/home", req.url));
+    return NextResponse.redirect(new URL("/home", req.url), 303);
   }
 
   const formData = await req.formData();
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
 
   if (!parsed.success) {
     console.warn("[AUTH_CALLBACK] missing or malformed token", ip);
-    return NextResponse.redirect(new URL("/home", req.url));
+    return NextResponse.redirect(new URL("/home", req.url), 303);
   }
 
   const { token } = parsed.data;
@@ -35,12 +35,12 @@ export async function POST(req: NextRequest) {
   const session = await validatePortalToken(token);
   if (!session) {
     console.warn("[AUTH_CALLBACK] invalid or expired token", ip);
-    return NextResponse.redirect(new URL("/home", req.url));
+    return NextResponse.redirect(new URL("/home", req.url), 303);
   }
 
   console.info("[AUTH_CALLBACK] login success", session.ownerid, ip);
 
-  const response = NextResponse.redirect(new URL("/home", req.url));
+  const response = NextResponse.redirect(new URL("/home", req.url), 303);
   const cookieOptions = {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: { code: "FORBIDDEN", message: "Invalid origin" } }, { status: 403 });
   }
 
-  const response = NextResponse.redirect(new URL("/", req.url));
+  const response = NextResponse.redirect(new URL("/", req.url), 303);
   response.cookies.delete(AUTH_COOKIE);
   response.cookies.delete(PORTAL_TOKEN_COOKIE);
   return response;

--- a/src/lib/api/member-api.ts
+++ b/src/lib/api/member-api.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { cache } from "react";
 import { env } from "@/env";
 import { AppError } from "@/utils/errors";
 import { fetchListMembers, fetchMemberContacts, getPortalToken } from "@/lib/api/portal-api";
@@ -54,23 +55,23 @@ export async function getMemberDetails(memberIds: number[]): Promise<Member[]> {
   return getRealMemberDetails(memberIds);
 }
 
-export async function getAllActiveMemberIds(): Promise<number[]> {
+export const getAllActiveMemberIds = cache(async (): Promise<number[]> => {
   if (env.USE_MOCK_MEMBER_API) {
     return getMockAllActiveMemberIds();
   }
   return getRealAllActiveMemberIds();
-}
+});
 
-export async function getAllMembers(): Promise<MemberSummary[]> {
+export const getAllMembers = cache(async (): Promise<MemberSummary[]> => {
   if (env.USE_MOCK_MEMBER_API) {
     return getMockAllMembers();
   }
   return getRealAllMembers();
-}
+});
 
-export async function getMemberById(id: number): Promise<Member | null> {
+export const getMemberById = cache(async (id: number): Promise<Member | null> => {
   if (env.USE_MOCK_MEMBER_API) {
     return getMockMemberById(id);
   }
   return getRealMemberById(id);
-}
+});

--- a/src/lib/api/portal-api.ts
+++ b/src/lib/api/portal-api.ts
@@ -17,18 +17,47 @@ export async function getPortalToken(): Promise<string | null> {
   return cookieStore.get(PORTAL_TOKEN_COOKIE)?.value ?? null;
 }
 
+const PORTAL_TIMEOUT_MS = 8000;
+
 async function postForm(task: string, body: Record<string, string>): Promise<string> {
-  const res = await fetch(`${env.PRFC_PORTAL_API_URL}?task=${task}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(body).toString(),
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${env.PRFC_PORTAL_API_URL}?task=${task}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(body).toString(),
+      signal: AbortSignal.timeout(PORTAL_TIMEOUT_MS),
+    });
+  } catch (error) {
+    const name = error instanceof Error ? error.name : "";
+    if (name === "TimeoutError" || name === "AbortError") {
+      throw new AppError("INTERNAL_ERROR", `Member portal ${task} timed out after ${PORTAL_TIMEOUT_MS}ms`);
+    }
+    throw new AppError("INTERNAL_ERROR", `Member portal ${task} request failed`);
+  }
 
   if (!res.ok) {
     throw new AppError("INTERNAL_ERROR", `Member portal ${task} responded ${res.status}`);
   }
 
-  return res.text();
+  const text = await res.text();
+  assertNoPortalError(text, task);
+  return text;
+}
+
+function rawSnippet(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+function assertNoPortalError(raw: string, task: string): void {
+  if (raw.includes("INVALID_KEY")) {
+    throw new AppError("INTERNAL_ERROR", `Member portal ${task} rejected the request (invalid secret or token)`, {
+      raw: rawSnippet(raw),
+    });
+  }
+  if (/Undefined index|<b>\s*(Notice|Warning|Fatal error)\s*<\/b>/i.test(raw)) {
+    throw new AppError("INTERNAL_ERROR", `Member portal ${task} returned a server error`, { raw: rawSnippet(raw) });
+  }
 }
 
 function extractObject(raw: string): unknown {
@@ -36,23 +65,31 @@ function extractObject(raw: string): unknown {
   const start = stripped.indexOf("{");
   const end = stripped.lastIndexOf("}");
   if (start === -1 || end === -1) {
-    throw new AppError("INTERNAL_ERROR", "Member portal returned no JSON object");
+    throw new AppError("INTERNAL_ERROR", "Member portal returned no JSON object", { raw: rawSnippet(raw) });
   }
-  return JSON.parse(stripped.slice(start, end + 1));
+  try {
+    return JSON.parse(stripped.slice(start, end + 1));
+  } catch {
+    throw new AppError("INTERNAL_ERROR", "Member portal returned an unparseable JSON object", { raw: rawSnippet(raw) });
+  }
 }
 
 function extractArray(raw: string): unknown {
   const start = raw.indexOf("[");
   const end = raw.lastIndexOf("]");
   if (start === -1 || end === -1) {
-    throw new AppError("INTERNAL_ERROR", "Member portal returned no JSON array");
+    throw new AppError("INTERNAL_ERROR", "Member portal returned no JSON array", { raw: rawSnippet(raw) });
   }
   const body = raw
     .slice(start, end + 1)
     .replace(/<[^>]+>/g, "")
     .replace(/}\s*{/g, "},{")
     .replace(/,\s*]/g, "]");
-  return JSON.parse(body);
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new AppError("INTERNAL_ERROR", "Member portal returned an unparseable JSON array", { raw: rawSnippet(raw) });
+  }
 }
 
 export async function validatePortalToken(token: string): Promise<Session | null> {

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -189,8 +189,7 @@ export function wrapInEmailTemplate(bodyHtml: string, footerHtml: string): strin
 </table>`;
 }
 
-const BATCH_SIZE = 10;
-const BATCH_DELAY_MS = 1000;
+const BATCH_SIZE = 25;
 
 export type { EmailRecipient as Recipient } from "@/types/message";
 
@@ -279,10 +278,6 @@ export async function sendGroupEmails(
         recipientResults.push({ memberId: r.memberId, status: "queued" });
       }
       break;
-    }
-
-    if (i + BATCH_SIZE < validRecipients.length) {
-      await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_MS));
     }
   }
 

--- a/src/services/sms-consent.ts
+++ b/src/services/sms-consent.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import prisma from "@/lib/db";
-import { transformError } from "@/utils/errors";
+import { AppError, transformError } from "@/utils/errors";
 import { encrypt, decrypt, blindIndex } from "@/lib/encryption";
 
 import type { SmsConsentRecord } from "@/types/settings";
@@ -31,6 +31,9 @@ export async function getMemberSmsConsent(memberId: number): Promise<SmsConsentR
 }
 
 export async function grantSmsConsent(memberId: number, phone: string): Promise<void> {
+  if (!phone || phone.trim() === "") {
+    throw new AppError("VALIDATION_ERROR", "A phone number is required to record SMS consent");
+  }
   try {
     const existing = await prisma.smsConsent.findFirst({
       where: { memberId, revokedAt: null },

--- a/src/utils/auth-redirect.ts
+++ b/src/utils/auth-redirect.ts
@@ -1,8 +1,14 @@
+const SESSION_EXPIRED_ERRORS = new Set([
+  "Authentication required",
+  "Invalid or expired token",
+  "Member portal session required",
+]);
+
 export function handleActionError(
   error: string | undefined,
   fallback: string = "An unexpected error occurred",
 ): string {
-  if (error === "Authentication required" || error === "Invalid or expired token") {
+  if (error !== undefined && SESSION_EXPIRED_ERRORS.has(error)) {
     window.location.href = "/unauthorized";
     return "";
   }

--- a/test/auth/auth-flow.test.ts
+++ b/test/auth/auth-flow.test.ts
@@ -195,7 +195,7 @@ describe("POST /api/auth/callback", () => {
     const cookie = response.cookies.get(AUTH_COOKIE);
     const portalCookie = response.cookies.get("prfc_portal_token");
 
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(303);
     expect(cookie).toBeDefined();
     expect(validateToken(cookie!.value, getSecret())).toEqual({ ownerid: 100001, isAdmin: true });
     expect(cookie!.httpOnly).toBe(true);
@@ -204,6 +204,22 @@ describe("POST /api/auth/callback", () => {
     expect(cookie!.secure).toBe(process.env.NODE_ENV === "production");
     expect(cookie!.maxAge).toBe(3600);
     expect(portalCookie?.value).toBe(portalToken);
+  });
+
+  it("uses 303 See Other on success so the cross-site portal POST lands on a GET and the SameSite=lax cookie is sent", async () => {
+    mockValidatePortalToken.mockResolvedValueOnce({ ownerid: 100001, isAdmin: true });
+    const formData = new FormData();
+    formData.set("token", "portal-base64-token");
+
+    const request = new NextRequest("http://localhost:3000/api/auth/callback", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await callbackPOST(request);
+
+    expect(response.status).toBe(303);
+    expect(new URL(response.headers.get("location")!).pathname).toBe("/home");
   });
 
   it("redirects without cookie for invalid token", async () => {
@@ -218,7 +234,7 @@ describe("POST /api/auth/callback", () => {
     const response = await callbackPOST(request);
     const cookie = response.cookies.get(AUTH_COOKIE);
 
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(303);
     expect(cookie).toBeUndefined();
   });
 
@@ -233,7 +249,7 @@ describe("POST /api/auth/callback", () => {
     const response = await callbackPOST(request);
     const cookie = response.cookies.get(AUTH_COOKIE);
 
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(303);
     expect(cookie).toBeUndefined();
   });
 
@@ -369,7 +385,7 @@ describe("POST /api/auth/logout", () => {
     const response = await logoutPOST(request);
     const setCookies = response.headers.getSetCookie();
 
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(303);
     expect(setCookies.some((c) => c.includes(AUTH_COOKIE) && c.includes("Expires=Thu, 01 Jan 1970"))).toBe(true);
   });
 

--- a/test/lib/api/portal-resilience.test.ts
+++ b/test/lib/api/portal-resilience.test.ts
@@ -1,0 +1,88 @@
+import { vi, describe, it, expect, afterEach } from "vitest";
+import "../../mocks/encryption";
+import { validatePortalToken, fetchListMembers, fetchMemberContacts } from "@/lib/api/portal-api";
+import { blindIndex } from "@/lib/encryption";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("portal fetch resilience", () => {
+  it("aborts a hung portal request via an AbortSignal timeout", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        async () => new Response('{"ownerid":"100230","secondsleft":"3000","isadmin":"0"}', { status: 200 }),
+      );
+
+    await validatePortalToken("any-token");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0][1] as RequestInit | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("degrades to null when the portal request times out, instead of hanging", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new DOMException("timed out", "TimeoutError");
+    });
+
+    const result = await validatePortalToken("any-token");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("portal data shapes", () => {
+  it("passes an empty primary phone through as an empty string, which cannot key an SMS consent", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(
+          '[{"ownerid":"100230","ownername":"Ann Spencer","email":"a@example.com","phone":"","altphone":""}]',
+          { status: 200 },
+        ),
+    );
+
+    const members = await fetchMemberContacts([100230]);
+
+    expect(members[0].ownerphone).toBe("");
+    expect(members[0].owneraltphone).toBeUndefined();
+    expect(blindIndex("")).not.toBe(blindIndex("805-438-3543"));
+  });
+});
+
+describe("portal error detection (portal answers 200 even on failure)", () => {
+  it("surfaces a clear error, not an opaque parse failure, when the secret is rejected", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(
+          '{"ownerid" : "INVALID_KEY","ownername" : "INVALID_KEY","email" : "NONE", "phone" : "NONE", "altphone" : "NONE"}',
+          { status: 200 },
+        ),
+    );
+
+    await expect(fetchMemberContacts([100230])).rejects.toThrow(/invalid secret or token/i);
+  });
+
+  it("surfaces a clear error when the portal returns a PHP notice instead of data", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(
+          "<br /><b>Notice</b>:  Undefined index: token in <b>/home/httpd/html/accounts/actions/index.htm</b> on line <b>383</b>",
+          { status: 200 },
+        ),
+    );
+
+    await expect(fetchListMembers("")).rejects.toThrow(/server error/i);
+  });
+
+  it("login degrades to null when the portal returns its rejection sentinel", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response('{"ownerid" : "INVALID_KEY","secondsleft" : "0","isadmin" : "0"}', { status: 200 }),
+    );
+
+    const result = await validatePortalToken("any-token");
+
+    expect(result).toBeNull();
+  });
+});

--- a/test/lib/referral-signature.test.ts
+++ b/test/lib/referral-signature.test.ts
@@ -81,4 +81,23 @@ describe("verifyReferralSignature", () => {
 
     expect(result).toBe(false);
   });
+
+  it("rejects a legacy calculateChecksum signature that carries no secret", () => {
+    const legacyChecksum = (value: string): string => {
+      let checksum = 0x12345678;
+      for (let i = 0; i < value.length; i++) checksum += value.charCodeAt(i) * (i + 1);
+      return (checksum >>> 0).toString(16);
+    };
+    const signature = legacyChecksum("charlie@example.comCharlieBrownREF001");
+
+    const result = verifyReferralSignature({
+      memberName: "Charlie Brown",
+      memberEmail: "charlie@example.com",
+      referralCode: "REF001",
+      signature,
+    });
+
+    expect(signature).toHaveLength(8);
+    expect(result).toBe(false);
+  });
 });

--- a/test/services/email-group.test.ts
+++ b/test/services/email-group.test.ts
@@ -140,36 +140,38 @@ describe("sendGroupEmails", () => {
   });
 
   describe("batching", () => {
+    let sleepMs: number[];
+    let realSetTimeout: typeof globalThis.setTimeout;
+
     beforeEach(() => {
-      vi.useFakeTimers();
+      sleepMs = [];
+      realSetTimeout = globalThis.setTimeout;
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(((cb: () => void, ms?: number) => {
+        if (ms === 1000) sleepMs.push(ms);
+        return realSetTimeout(cb, 0);
+      }) as typeof globalThis.setTimeout);
     });
 
     afterEach(() => {
-      vi.useRealTimers();
+      vi.restoreAllMocks();
     });
 
-    it("sends in batches of 10 with delay between batches", async () => {
-      const batchDelayMs = 1000;
+    it("sends every recipient with no artificial per-batch delay, so it stays within the function budget", async () => {
+      const recipients = Array.from({ length: 50 }, (_, i) => ({
+        email: `m${i}@example.com`,
+        memberId: i,
+        name: `M${i}`,
+      }));
       mockFilterSuppressedEmails.mockResolvedValue({
-        valid: allRecipients.map((r) => r.email),
+        valid: recipients.map((r) => r.email),
         suppressed: [],
       });
 
-      const promise = sendGroupEmails({ ...defaultParams, recipients: allRecipients });
+      const { sent, failed, suppressed } = await sendGroupEmails({ ...defaultParams, recipients });
 
-      await vi.advanceTimersByTimeAsync(0);
-      expect(mockBrevoSend).toHaveBeenCalledTimes(10);
-
-      await vi.advanceTimersByTimeAsync(batchDelayMs - 1);
-      await Promise.resolve();
-      expect(mockBrevoSend).toHaveBeenCalledTimes(10);
-
-      await vi.advanceTimersByTimeAsync(1);
-      await Promise.resolve();
-      expect(mockBrevoSend).toHaveBeenCalledTimes(12);
-
-      const { sent, failed, suppressed } = await promise;
-      expect(sent).toBe(12);
+      expect(sleepMs).toHaveLength(0);
+      expect(mockBrevoSend).toHaveBeenCalledTimes(50);
+      expect(sent).toBe(50);
       expect(failed).toBe(0);
       expect(suppressed).toBe(0);
     });

--- a/test/services/sms-consent.test.ts
+++ b/test/services/sms-consent.test.ts
@@ -192,6 +192,12 @@ describe("grantSmsConsent", () => {
 
     await expect(grantSmsConsent(100001, "+15551234567")).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
   });
+
+  it("rejects an empty phone without writing a consent record", async () => {
+    await expect(grantSmsConsent(100001, "")).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    await expect(grantSmsConsent(100001, "   ")).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(mockPrisma.smsConsent.create).not.toHaveBeenCalled();
+  });
 });
 
 describe("revokeConsentByPhone", () => {

--- a/test/utils/auth-redirect.test.ts
+++ b/test/utils/auth-redirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleActionError } from "@/utils/auth-redirect";
+
+describe("handleActionError", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "" },
+    });
+  });
+
+  it("redirects to /unauthorized on session-expired errors", () => {
+    for (const message of ["Authentication required", "Invalid or expired token", "Member portal session required"]) {
+      window.location.href = "";
+      const result = handleActionError(message);
+      expect(window.location.href).toBe("/unauthorized");
+      expect(result).toBe("");
+    }
+  });
+
+  it("returns the message for ordinary errors without redirecting", () => {
+    const result = handleActionError("Something went wrong");
+
+    expect(result).toBe("Something went wrong");
+    expect(window.location.href).toBe("");
+  });
+
+  it("returns the fallback when the error is undefined", () => {
+    const result = handleActionError(undefined, "fallback message");
+
+    expect(result).toBe("fallback message");
+    expect(window.location.href).toBe("");
+  });
+});


### PR DESCRIPTION
## Developer

Kevin Rutledge

## What changed?

The mock portal ran inside the app's own origin, so assumptions that held there broke once login and member data came from the real cross-origin portal. This PR hardens that integration. The login callback redirects with 303 so the SameSite=Lax cookie survives the cross-site POST from the portal. Every portal call gets an 8-second timeout and treats the portal's 200-on-failure responses (an INVALID_KEY sentinel, a PHP notice) as errors with a logged raw snippet. The email blast drops its 1-second per-batch sleep, which Brevo does not need, so it stays inside the function budget. Member reads are memoized per request, SMS consent refuses an empty phone, and the 1-hour session redirects to re-login and is documented as a portal constraint.

- `src/app/api/auth/callback/route.ts`, `src/app/api/auth/logout/route.ts` - redirect with 303 (See Other) instead of the default 307
- `src/lib/api/portal-api.ts` - add `AbortSignal.timeout(8000)` to every portal call and surface the portal's 200-on-failure shapes with a raw snippet
- `src/lib/api/member-api.ts` - wrap the roster and member reads in React `cache()` for per-request dedup
- `src/services/email.ts` - drop the inter-batch delay, raise `BATCH_SIZE` to 25
- `src/services/sms-consent.ts`, `src/actions/settings.ts` - reject SMS consent without a phone and check before persisting the toggle
- `src/utils/auth-redirect.ts` - send a missing portal token back to sign-in
- `docs/architecture.md`, `docs/decisions/auth-patterns.md` - document the portal read and cache strategy, the 303 reason, and the 1-hour cap
- tests in `test/auth`, `test/lib/api`, `test/services`, `test/utils`

## How to test

1. `npm test` passes (719 unit tests) and `npm run build` succeeds.
2. The auth callback returns `303` to `/home` with the `prfc_auth` cookie set, so a cross-site portal POST lands logged in (see `test/auth/auth-flow.test.ts`).

## Checklist

- [x] Code works and is readable
- [x] Tested locally
- [x] Commits follow conventional commits
- [x] Assigned reviewers